### PR TITLE
Fix keyboard audio tap isolation crash

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+ASC_KEY_ID=
+ASC_ISSUER_ID=
+ASC_PRIVATE_KEY_PATH=/absolute/path/to/AuthKey_XXXXXXXXXX.p8
+ASC_APP_ID=
+ASC_BUNDLE_ID=com.phequals7.muesli.ios

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,4 +22,11 @@ jobs:
             -destination 'generic/platform=iOS Simulator' \
             CODE_SIGNING_ALLOWED=NO \
             build
-
+      - name: Build test bundle
+        run: |
+          xcodebuild \
+            -project MuesliiOS.xcodeproj \
+            -scheme Muesli \
+            -destination 'generic/platform=iOS Simulator' \
+            CODE_SIGNING_ALLOWED=NO \
+            build-for-testing

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,10 @@
 .DS_Store
+.env
+.env.*
+!.env.example
+*.p8
+diagnostics/
+secrets/
 *.xcuserstate
 *.xcworkspace
 *.xcodeproj

--- a/Muesli/KeyboardSessionKeeper.swift
+++ b/Muesli/KeyboardSessionKeeper.swift
@@ -28,9 +28,7 @@ final class KeyboardSessionKeeper {
         let engine = AVAudioEngine()
         let inputNode = engine.inputNode
         let format = inputNode.inputFormat(forBus: 0)
-        inputNode.installTap(onBus: 0, bufferSize: 1_024, format: format) { _, _ in
-            // Keep the microphone session alive for keyboard commands; audio is intentionally discarded.
-        }
+        inputNode.installTap(onBus: 0, bufferSize: 1_024, format: format, block: Self.discardAudioTap)
         engine.prepare()
 
         do {
@@ -60,4 +58,6 @@ final class KeyboardSessionKeeper {
             try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
         }
     }
+
+    nonisolated static func discardAudioTap(_: AVAudioPCMBuffer, when _: AVAudioTime) {}
 }

--- a/Tests/MuesliTests/KeyboardSessionKeeperTests.swift
+++ b/Tests/MuesliTests/KeyboardSessionKeeperTests.swift
@@ -1,0 +1,19 @@
+import AVFoundation
+import XCTest
+
+@testable import Muesli
+
+final class KeyboardSessionKeeperTests: XCTestCase {
+    func testDiscardAudioTapIsCallableFromNonMainActorContext() throws {
+        let format = try XCTUnwrap(AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: 16_000,
+            channels: 1,
+            interleaved: false
+        ))
+        let buffer = try XCTUnwrap(AVAudioPCMBuffer(pcmFormat: format, frameCapacity: 1_024))
+        let time = AVAudioTime(sampleTime: 0, atRate: 16_000)
+
+        KeyboardSessionKeeper.discardAudioTap(buffer, when: time)
+    }
+}


### PR DESCRIPTION
## Summary
- Move the keyboard session AVAudio tap callback to a nonisolated static function so AVFAudio can invoke it on its realtime queue without Swift actor executor assertions
- Keep the callback intentionally discard-only for background keyboard session liveness
- Add local-only App Store Connect diagnostics and secret ignore rules plus a safe env template

## Evidence
TestFlight crash submissions from build 0.1.0 (1) all showed EXC_BREAKPOINT / _dispatch_assert_queue_fail in KeyboardSessionKeeper.start() via the AVAudioNode tap callback.

## Test Plan
- xcodebuild -project MuesliiOS.xcodeproj -scheme Muesli -destination 'generic/platform=iOS' build

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli-ios/pr/2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->