### PR TITLE
[codex] Add keyboard handoff state machine

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,8 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
 
     steps:
@@ -39,6 +39,8 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          use_sticky_comment: true
+          display_report: true
+          show_full_output: false
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,8 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: write
-      issues: write
+      pull-requests: read
+      issues: read
       id-token: write
 
     steps:
@@ -39,8 +39,6 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
-          use_sticky_comment: true
-          display_report: true
-          show_full_output: false
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
+

--- a/Muesli/DictationCoordinator.swift
+++ b/Muesli/DictationCoordinator.swift
@@ -157,6 +157,9 @@ final class DictationCoordinator {
         let request = pendingRequest?.id == requestID
             ? pendingRequest!
             : DictationRequest(id: requestID)
+        if refreshActiveKeyboardRequestIfNeeded(request) {
+            return
+        }
         if recoverKeyboardRequestIfNeeded(request) {
             return
         }
@@ -164,6 +167,64 @@ final class DictationCoordinator {
         activeRequest = request
         startKeyboardRuntimePolling()
         startRecording(for: request, source: "keyboard")
+    }
+
+    private func refreshActiveKeyboardRequestIfNeeded(_ request: DictationRequest) -> Bool {
+        guard activeRequest?.id == request.id else { return false }
+
+        isKeyboardHandoffActive = true
+        startKeyboardRuntimePolling()
+
+        if isRecording {
+            saveKeyboardHandoff(
+                requestID: request.id,
+                phase: .recordingStarted,
+                message: "Listening"
+            )
+            saveKeyboardRuntimeStatus(
+                isActive: true,
+                activeRequestID: request.id,
+                phase: .recording,
+                message: "Listening",
+                supportsBackgroundStart: isKeyboardSessionArmed
+            )
+            return true
+        }
+
+        if statusText == "Transcribing" || activeSession?.requestID == request.id {
+            try? store.saveStatus(.init(
+                requestID: request.id,
+                phase: .transcribing,
+                message: "Transcribing"
+            ))
+            saveKeyboardHandoff(
+                requestID: request.id,
+                phase: .transcribingStarted,
+                message: "Transcribing"
+            )
+            saveKeyboardRuntimeStatus(
+                isActive: true,
+                activeRequestID: request.id,
+                phase: .transcribing,
+                message: "Transcribing",
+                supportsBackgroundStart: isKeyboardSessionArmed
+            )
+            return true
+        }
+
+        saveKeyboardHandoff(
+            requestID: request.id,
+            phase: .startAcknowledged,
+            message: "Starting"
+        )
+        saveKeyboardRuntimeStatus(
+            isActive: true,
+            activeRequestID: request.id,
+            phase: .requested,
+            message: "Starting",
+            supportsBackgroundStart: isKeyboardSessionArmed
+        )
+        return true
     }
 
     private func recoverKeyboardRequestIfNeeded(_ request: DictationRequest) -> Bool {
@@ -752,6 +813,10 @@ final class DictationCoordinator {
     private func startRecording(for request: DictationRequest, source: String) {
         guard !isRecording, !isMeetingRecording, statusText != "Transcribing" else {
             if source == "keyboard" {
+                if refreshActiveKeyboardRequestIfNeeded(request) {
+                    return
+                }
+
                 let message = "Muesli is busy"
                 if activeRequest?.id == request.id {
                     activeRequest = nil
@@ -1726,6 +1791,16 @@ final class DictationCoordinator {
 
                 if let command = try? self.store.pendingCommand(), command.action == .start {
                     try? self.store.clearPendingCommand()
+                    let pendingRequest = try? self.store.pendingRequest()
+                    let request = pendingRequest?.id == command.requestID
+                        ? pendingRequest!
+                        : DictationRequest(id: command.requestID)
+
+                    if self.refreshActiveKeyboardRequestIfNeeded(request) {
+                        try? await Task.sleep(for: .milliseconds(500))
+                        continue
+                    }
+
                     guard !self.isRecording, !self.isMeetingRecording, self.statusText != "Transcribing" else {
                         self.saveKeyboardHandoff(
                             requestID: command.requestID,
@@ -1741,10 +1816,6 @@ final class DictationCoordinator {
                         continue
                     }
 
-                    let pendingRequest = try? self.store.pendingRequest()
-                    let request = pendingRequest?.id == command.requestID
-                        ? pendingRequest!
-                        : DictationRequest(id: command.requestID)
                     self.isKeyboardHandoffActive = true
                     self.activeRequest = request
                     self.startRecording(for: request, source: "keyboard")

--- a/Muesli/DictationCoordinator.swift
+++ b/Muesli/DictationCoordinator.swift
@@ -144,6 +144,11 @@ final class DictationCoordinator {
         let action = components.queryItems?.first(where: { $0.name == MuesliAppConstants.actionQueryItem })?.value
             ?? MuesliAppConstants.startAction
         if action == MuesliAppConstants.stopAction {
+            saveKeyboardHandoff(
+                requestID: requestID,
+                phase: .stopAcknowledged,
+                message: "Stopping"
+            )
             stopRecording(requestID: requestID)
             return
         }
@@ -152,10 +157,56 @@ final class DictationCoordinator {
         let request = pendingRequest?.id == requestID
             ? pendingRequest!
             : DictationRequest(id: requestID)
+        if recoverKeyboardRequestIfNeeded(request) {
+            return
+        }
         isKeyboardHandoffActive = true
         activeRequest = request
         startKeyboardRuntimePolling()
         startRecording(for: request, source: "keyboard")
+    }
+
+    private func recoverKeyboardRequestIfNeeded(_ request: DictationRequest) -> Bool {
+        guard let status = try? store.status(),
+              status.requestID == request.id,
+              [.recording, .transcribing].contains(status.phase),
+              activeRequest == nil,
+              !isRecording
+        else {
+            return false
+        }
+
+        guard let session = try? store.recordingSession(requestID: request.id),
+              let audioFileName = session.audioFileName,
+              let audioURL = try? store.audioFileURL(fileName: audioFileName),
+              FileManager.default.fileExists(atPath: audioURL.path)
+        else {
+            let message = "Recording was interrupted. Start a new dictation."
+            try? store.saveStatus(.init(requestID: request.id, phase: .failed, message: message))
+            saveKeyboardHandoff(requestID: request.id, phase: .failed, message: message)
+            statusText = message
+            return true
+        }
+
+        isKeyboardHandoffActive = true
+        activeRequest = request
+        activeSession = session
+        statusText = "Transcribing"
+        try? store.saveStatus(.init(requestID: request.id, phase: .transcribing, message: "Recovering transcription"))
+        saveKeyboardHandoff(
+            requestID: request.id,
+            phase: .transcribingStarted,
+            message: "Recovering transcription"
+        )
+        saveKeyboardRuntimeStatus(
+            isActive: true,
+            activeRequestID: request.id,
+            phase: .transcribing,
+            message: "Recovering transcription",
+            supportsBackgroundStart: isKeyboardSessionArmed
+        )
+        recoverKeyboardTranscription(request: request, session: session, audioURL: audioURL)
+        return true
     }
 
     #if DEBUG
@@ -699,12 +750,36 @@ final class DictationCoordinator {
     }
 
     private func startRecording(for request: DictationRequest, source: String) {
-        guard !isRecording, !isMeetingRecording, statusText != "Transcribing" else { return }
+        guard !isRecording, !isMeetingRecording, statusText != "Transcribing" else {
+            if source == "keyboard" {
+                let message = "Muesli is busy"
+                if activeRequest?.id == request.id {
+                    activeRequest = nil
+                }
+                try? store.saveStatus(.init(requestID: request.id, phase: .failed, message: message))
+                saveKeyboardHandoff(requestID: request.id, phase: .failed, message: message)
+                saveKeyboardRuntimeStatus(
+                    isActive: isKeyboardSessionArmed,
+                    activeRequestID: nil,
+                    phase: .failed,
+                    message: message,
+                    supportsBackgroundStart: isKeyboardSessionArmed
+                )
+            }
+            return
+        }
         activeRequest = request
         liveDictationTranscript = ""
         realtimeDictationCommittedText = ""
         let kind: RecordingSessionKind = source == "keyboard" ? .keyboardDictation : .quickDictation
         var session = RecordingSession(requestID: request.id, kind: kind)
+        if source == "keyboard" {
+            saveKeyboardHandoff(
+                requestID: request.id,
+                phase: .startAcknowledged,
+                message: "Starting"
+            )
+        }
 
         Task {
             do {
@@ -725,6 +800,11 @@ final class DictationCoordinator {
                 activeSession = session
                 isRecording = true
                 if source == "keyboard" {
+                    saveKeyboardHandoff(
+                        requestID: request.id,
+                        phase: .recordingStarted,
+                        message: "Listening"
+                    )
                     startKeyboardRuntimePolling()
                     saveKeyboardRuntimeStatus(
                         isActive: true,
@@ -763,6 +843,13 @@ final class DictationCoordinator {
                 resumeKeyboardSessionKeeperIfNeeded()
                 AppTelemetry.signal("dictation_failed", parameters: ["stage": "recording"])
                 try? store.saveStatus(.init(requestID: request.id, phase: .failed, message: error.localizedDescription))
+                if source == "keyboard" {
+                    saveKeyboardHandoff(
+                        requestID: request.id,
+                        phase: .failed,
+                        message: error.localizedDescription
+                    )
+                }
             }
         }
     }
@@ -770,6 +857,105 @@ final class DictationCoordinator {
     private func stopRecording() {
         guard let request = activeRequest else { return }
         stopRecording(requestID: request.id)
+    }
+
+    private func recoverKeyboardTranscription(
+        request: DictationRequest,
+        session: RecordingSession,
+        audioURL: URL
+    ) {
+        beginTranscriptionBackgroundTask()
+        Task {
+            defer { endTranscriptionBackgroundTask() }
+
+            do {
+                await engine.selectModel(selectedTranscriptionModel)
+                saveKeyboardHandoff(
+                    requestID: request.id,
+                    phase: .transcribingStarted,
+                    message: "Recovering transcription"
+                )
+                let text = postProcessTranscript(try await engine.transcribe(audioURL: audioURL))
+                let savedTranscript = Transcript(
+                    sessionID: session.id,
+                    text: text,
+                    engineIdentifier: engine.identifier
+                )
+                try store.saveTranscript(savedTranscript)
+
+                var completedSession = session
+                completedSession.phase = .completed
+                completedSession.endedAt = completedSession.endedAt ?? .now
+                completedSession.transcriptID = savedTranscript.id
+                completedSession.engineIdentifier = engine.identifier
+                completedSession.errorMessage = nil
+                try store.saveSession(completedSession)
+
+                let result = DictationResult(
+                    requestID: request.id,
+                    sessionID: savedTranscript.sessionID,
+                    text: text,
+                    engineIdentifier: engine.identifier
+                )
+                try store.saveResult(result)
+                saveKeyboardHandoff(requestID: request.id, phase: .resultReady, message: "Ready to insert")
+                try store.clearPendingRequest()
+                activeRequest = nil
+                activeSession = nil
+                isKeyboardHandoffActive = false
+                statusText = "Ready"
+                refreshHistory()
+                saveKeyboardRuntimeStatus(
+                    isActive: isKeyboardSessionArmed,
+                    activeRequestID: nil,
+                    phase: .idle,
+                    message: isKeyboardSessionArmed ? "Keyboard session ready" : "Ready",
+                    supportsBackgroundStart: isKeyboardSessionArmed
+                )
+                resumeKeyboardSessionKeeperIfNeeded()
+                AppTelemetry.signal(
+                    "keyboard_transcription_recovered",
+                    parameters: [
+                        "engine": engine.identifier,
+                        "empty": text.isEmpty ? "true" : "false"
+                    ]
+                )
+            } catch {
+                var failedSession = session
+                failedSession.phase = .failed
+                failedSession.errorMessage = error.localizedDescription
+                try? store.saveSession(failedSession)
+                try? store.saveStatus(.init(
+                    requestID: request.id,
+                    phase: .failed,
+                    message: error.localizedDescription
+                ))
+                saveKeyboardHandoff(
+                    requestID: request.id,
+                    phase: .failed,
+                    message: error.localizedDescription
+                )
+                activeRequest = nil
+                activeSession = nil
+                isKeyboardHandoffActive = false
+                statusText = error.localizedDescription
+                saveKeyboardRuntimeStatus(
+                    isActive: isKeyboardSessionArmed,
+                    activeRequestID: nil,
+                    phase: .failed,
+                    message: error.localizedDescription,
+                    supportsBackgroundStart: isKeyboardSessionArmed
+                )
+                resumeKeyboardSessionKeeperIfNeeded()
+                AppTelemetry.signal(
+                    "keyboard_transcription_recovery_failed",
+                    parameters: [
+                        "engine": engine.identifier,
+                        "error": String(describing: type(of: error))
+                    ]
+                )
+            }
+        }
     }
 
     private func stopRecording(requestID: UUID) {
@@ -785,6 +971,7 @@ final class DictationCoordinator {
             let message = "No active recording found. Start a new dictation."
             statusText = message
             try? store.saveStatus(.init(requestID: requestID, phase: .failed, message: message))
+            saveKeyboardHandoff(requestID: requestID, phase: .failed, message: message)
             return
         }
 
@@ -793,6 +980,13 @@ final class DictationCoordinator {
         stopCommandPolling()
         statusText = "Transcribing"
         try? store.saveStatus(.init(requestID: request.id, phase: .transcribing, message: "Transcribing"))
+        if isKeyboardHandoffActive {
+            saveKeyboardHandoff(
+                requestID: request.id,
+                phase: .stopAcknowledged,
+                message: "Finalizing audio"
+            )
+        }
         if isKeyboardHandoffActive {
             saveKeyboardRuntimeStatus(
                 isActive: true,
@@ -819,6 +1013,7 @@ final class DictationCoordinator {
         beginTranscriptionBackgroundTask()
         Task {
             defer { endTranscriptionBackgroundTask() }
+            let startedFromKeyboard = isKeyboardHandoffActive
 
             do {
                 let usesRealtimeStreaming = realtimeDictationRecorder != nil
@@ -840,6 +1035,16 @@ final class DictationCoordinator {
                         throw AudioRecorder.RecordingError.noRecording
                     }
                     audioURL = retainedAudioURL
+                    if startedFromKeyboard {
+                        saveKeyboardHandoff(requestID: request.id, phase: .audioSaved, message: "Audio saved")
+                    }
+                    if startedFromKeyboard {
+                        saveKeyboardHandoff(
+                            requestID: request.id,
+                            phase: .transcribingStarted,
+                            message: "Transcribing"
+                        )
+                    }
                     text = postProcessTranscript(try await engine.finishRealtimeSession())
                     if text.isEmpty {
                         text = postProcessTranscript(try await engine.transcribe(audioURL: audioURL))
@@ -847,6 +1052,16 @@ final class DictationCoordinator {
                     liveDictationTranscript = text
                 } else {
                     audioURL = try recorder.stop()
+                    if startedFromKeyboard {
+                        saveKeyboardHandoff(requestID: request.id, phase: .audioSaved, message: "Audio saved")
+                    }
+                    if startedFromKeyboard {
+                        saveKeyboardHandoff(
+                            requestID: request.id,
+                            phase: .transcribingStarted,
+                            message: "Transcribing"
+                        )
+                    }
                     text = postProcessTranscript(try await engine.transcribe(audioURL: audioURL))
                 }
                 if isKeyboardSessionArmed {
@@ -879,12 +1094,15 @@ final class DictationCoordinator {
                     engineIdentifier: engine.identifier
                 )
                 try store.saveResult(result)
+                if startedFromKeyboard {
+                    saveKeyboardHandoff(requestID: request.id, phase: .resultReady, message: "Ready to insert")
+                }
                 try store.clearPendingRequest()
                 refreshHistory()
                 lastTranscript = text
                 activeRequest = nil
                 activeSession = nil
-                if isKeyboardHandoffActive {
+                if startedFromKeyboard {
                     saveKeyboardRuntimeStatus(
                         isActive: true,
                         activeRequestID: nil,
@@ -955,6 +1173,13 @@ final class DictationCoordinator {
                     ]
                 )
                 try? store.saveStatus(.init(requestID: request.id, phase: .failed, message: error.localizedDescription))
+                if startedFromKeyboard {
+                    saveKeyboardHandoff(
+                        requestID: request.id,
+                        phase: .failed,
+                        message: error.localizedDescription
+                    )
+                }
             }
         }
     }
@@ -1472,8 +1697,18 @@ final class DictationCoordinator {
                     case .start:
                         break
                     case .stop:
+                        self.saveKeyboardHandoff(
+                            requestID: requestID,
+                            phase: .stopAcknowledged,
+                            message: "Stopping"
+                        )
                         self.stopRecording(requestID: requestID)
                     case .cancel:
+                        self.saveKeyboardHandoff(
+                            requestID: requestID,
+                            phase: .cancelled,
+                            message: "Cancelled"
+                        )
                         self.cancelRecording(requestID: requestID)
                     }
                     return
@@ -1500,6 +1735,11 @@ final class DictationCoordinator {
                 if let command = try? self.store.pendingCommand(), command.action == .start {
                     try? self.store.clearPendingCommand()
                     guard !self.isRecording, !self.isMeetingRecording, self.statusText != "Transcribing" else {
+                        self.saveKeyboardHandoff(
+                            requestID: command.requestID,
+                            phase: .failed,
+                            message: "Muesli is busy"
+                        )
                         try? self.store.saveStatus(.init(
                             requestID: command.requestID,
                             phase: .failed,
@@ -1515,6 +1755,11 @@ final class DictationCoordinator {
                         : DictationRequest(id: command.requestID)
                     self.isKeyboardHandoffActive = true
                     self.activeRequest = request
+                    self.saveKeyboardHandoff(
+                        requestID: request.id,
+                        phase: .startAcknowledged,
+                        message: "Starting"
+                    )
                     self.startRecording(for: request, source: "keyboard")
                 }
 
@@ -1564,6 +1809,21 @@ final class DictationCoordinator {
             message: message,
             supportsBackgroundStart: supportsBackgroundStart
         ))
+    }
+
+    private func saveKeyboardHandoff(
+        requestID: UUID,
+        phase: KeyboardHandoffPhase,
+        message: String? = nil
+    ) {
+        let previous = try? store.keyboardHandoffState()
+        let state: KeyboardHandoffState
+        if let previous, previous.requestID == requestID {
+            state = previous.advanced(to: phase, message: message)
+        } else {
+            state = KeyboardHandoffState(requestID: requestID, phase: phase, message: message)
+        }
+        try? store.saveKeyboardHandoffState(state)
     }
 
     private func scheduleKeyboardSessionTimeout() {
@@ -1662,6 +1922,7 @@ final class DictationCoordinator {
         try? store.clearPendingCommand()
         try? store.clearPendingRequest()
         try? store.saveStatus(.idle)
+        saveKeyboardHandoff(requestID: requestID, phase: .cancelled, message: "Cancelled")
     }
 
     private func cleanupRealtimeDictationRecorder() {

--- a/Muesli/DictationCoordinator.swift
+++ b/Muesli/DictationCoordinator.swift
@@ -986,8 +986,6 @@ final class DictationCoordinator {
                 phase: .stopAcknowledged,
                 message: "Finalizing audio"
             )
-        }
-        if isKeyboardHandoffActive {
             saveKeyboardRuntimeStatus(
                 isActive: true,
                 activeRequestID: request.id,
@@ -1036,9 +1034,6 @@ final class DictationCoordinator {
                     }
                     audioURL = retainedAudioURL
                     if startedFromKeyboard {
-                        saveKeyboardHandoff(requestID: request.id, phase: .audioSaved, message: "Audio saved")
-                    }
-                    if startedFromKeyboard {
                         saveKeyboardHandoff(
                             requestID: request.id,
                             phase: .transcribingStarted,
@@ -1052,9 +1047,6 @@ final class DictationCoordinator {
                     liveDictationTranscript = text
                 } else {
                     audioURL = try recorder.stop()
-                    if startedFromKeyboard {
-                        saveKeyboardHandoff(requestID: request.id, phase: .audioSaved, message: "Audio saved")
-                    }
                     if startedFromKeyboard {
                         saveKeyboardHandoff(
                             requestID: request.id,
@@ -1755,11 +1747,6 @@ final class DictationCoordinator {
                         : DictationRequest(id: command.requestID)
                     self.isKeyboardHandoffActive = true
                     self.activeRequest = request
-                    self.saveKeyboardHandoff(
-                        requestID: request.id,
-                        phase: .startAcknowledged,
-                        message: "Starting"
-                    )
                     self.startRecording(for: request, source: "keyboard")
                 }
 

--- a/MuesliKeyboard/KeyboardController.swift
+++ b/MuesliKeyboard/KeyboardController.swift
@@ -4,13 +4,12 @@ import Observation
 @MainActor
 @Observable
 final class KeyboardController {
-    private static let staleStartInterval: TimeInterval = 10
     private static let staleRecordingInterval: TimeInterval = 45
-    private static let staleStopRequestInterval: TimeInterval = 8
     private static let staleStoppingInterval: TimeInterval = 10
     private static let staleTranscribingInterval: TimeInterval = 120
 
     private let store = SharedStore()
+    private let handoffRecoveryPolicy = KeyboardHandoffRecoveryPolicy.keyboardDefaults
     private var pollingTask: Task<Void, Never>?
     private var latestResultID: UUID?
     private var preparedRequest: DictationRequest?
@@ -487,76 +486,34 @@ final class KeyboardController {
     private func markHandoffForRecoveryIfStale(_ state: KeyboardHandoffState) -> Bool {
         guard let requestID = state.requestID else { return false }
 
-        if let latestRuntimeStatus,
-           latestRuntimeStatus.activeRequestID == requestID,
-           Date().timeIntervalSince(latestRuntimeStatus.updatedAt) < 8,
-           [.recording, .transcribing].contains(latestRuntimeStatus.phase),
-           state.phase != .stopRequested
-        {
+        let action = handoffRecoveryPolicy.action(
+            for: state,
+            latestRuntimeStatus: latestRuntimeStatus,
+            canUseRuntimeStart: canUseRuntimeStart
+        )
+
+        switch action {
+        case .none:
             return false
-        }
 
-        let age = Date().timeIntervalSince(state.updatedAt)
-        let threshold: TimeInterval
-        let retryAction: DictationCommandAction?
-        let recoveryMessage: String
-
-        switch state.phase {
-        case .startRequested, .startAcknowledged:
-            threshold = Self.staleStartInterval
-            retryAction = .start
-            recoveryMessage = "Open Muesli to start"
-        case .recordingStarted:
-            threshold = Self.staleRecordingInterval
-            retryAction = nil
-            recoveryMessage = "Open Muesli to continue"
-        case .stopRequested:
-            threshold = Self.staleStopRequestInterval
-            retryAction = .stop
-            recoveryMessage = "Open Muesli to finish"
-        case .stopAcknowledged, .audioSaved, .transcribingStarted:
-            threshold = Self.staleTranscribingInterval
-            retryAction = nil
-            recoveryMessage = "Open Muesli to finish"
-        case .recoveryRequested:
-            recoveryRequestID = requestID
-            launchURL = makeLaunchURL(for: requestID, action: MuesliAppConstants.startAction)
-            dictationPhase = .failed
-            statusText = state.message ?? "Open Muesli to finish"
-            return true
-        default:
-            return false
-        }
-
-        guard age > threshold else { return false }
-
-        if let retryAction, state.recoveryAttemptCount == 0, canUseRuntimeStart {
-            let retrying = state.advanced(
-                to: state.phase,
-                message: retryAction == .start ? "Retrying start" : "Retrying stop",
-                recoveryAttemptCount: 1
-            )
+        case let .retry(retryAction, retrying):
             try? store.saveCommand(.init(requestID: requestID, action: retryAction))
             try? store.saveKeyboardHandoffState(retrying)
             latestHandoffState = retrying
             dictationPhase = retrying.phase.dictationPhase
             statusText = retrying.message ?? "Retrying"
             return true
-        }
 
-        let recovery = state.advanced(
-            to: .recoveryRequested,
-            message: recoveryMessage,
-            recoveryAttemptCount: max(state.recoveryAttemptCount, 1)
-        )
-        try? store.saveKeyboardHandoffState(recovery)
-        latestHandoffState = recovery
-        recoveryRequestID = requestID
-        launchURL = makeLaunchURL(for: requestID, action: MuesliAppConstants.startAction)
-        dictationPhase = .failed
-        activeRequestID = nil
-        statusText = recoveryMessage
-        return true
+        case let .recover(recovery):
+            try? store.saveKeyboardHandoffState(recovery)
+            latestHandoffState = recovery
+            recoveryRequestID = requestID
+            launchURL = makeLaunchURL(for: requestID, action: MuesliAppConstants.startAction)
+            dictationPhase = .failed
+            activeRequestID = nil
+            statusText = recovery.message ?? "Open Muesli to finish"
+            return true
+        }
     }
 
     private func insertCompletedResult(_ result: DictationResult) {

--- a/MuesliKeyboard/KeyboardController.swift
+++ b/MuesliKeyboard/KeyboardController.swift
@@ -4,11 +4,20 @@ import Observation
 @MainActor
 @Observable
 final class KeyboardController {
+    private static let staleStartInterval: TimeInterval = 10
+    private static let staleRecordingInterval: TimeInterval = 45
+    private static let staleStopRequestInterval: TimeInterval = 8
+    private static let staleStoppingInterval: TimeInterval = 10
+    private static let staleTranscribingInterval: TimeInterval = 120
+
     private let store = SharedStore()
     private var pollingTask: Task<Void, Never>?
     private var latestResultID: UUID?
     private var preparedRequest: DictationRequest?
     private var activeRequestID: UUID?
+    private var recoveryRequestID: UUID?
+    private var latestHandoffState: KeyboardHandoffState?
+    private var latestRuntimeStatus: KeyboardRuntimeStatus?
     private var insertedRequestIDs = Set<UUID>()
 
     var statusText = "Record in Muesli first"
@@ -21,7 +30,15 @@ final class KeyboardController {
     private var canUseRuntimeStart = false
 
     var primaryButtonTitle: String {
-        switch dictationPhase {
+        if recoveryRequestID != nil {
+            return "Open Muesli"
+        }
+
+        if latestHandoffState?.phase == .stopRequested {
+            return "Waiting for Muesli"
+        }
+
+        return switch dictationPhase {
         case .requested:
             activeRequestID == nil ? "Open Muesli" : "Stop Dictation"
         case .recording:
@@ -36,7 +53,15 @@ final class KeyboardController {
     }
 
     var primaryButtonIcon: String {
-        switch dictationPhase {
+        if recoveryRequestID != nil {
+            return "arrow.up.forward.app"
+        }
+
+        if latestHandoffState?.phase == .stopRequested {
+            return "hourglass"
+        }
+
+        return switch dictationPhase {
         case .requested, .recording:
             "stop.fill"
         case .transcribing:
@@ -60,7 +85,11 @@ final class KeyboardController {
     }
 
     var isPrimaryButtonDisabled: Bool {
-        dictationPhase == .transcribing || dictationPhase == .finished
+        recoveryRequestID == nil && (
+            dictationPhase == .transcribing
+            || dictationPhase == .finished
+            || latestHandoffState?.phase == .stopRequested
+        )
     }
 
     var canInsertLatest: Bool {
@@ -68,8 +97,18 @@ final class KeyboardController {
     }
 
     var opensMuesliFromPrimaryButton: Bool {
-        !canUseRuntimeStart
+        recoveryRequestID != nil
+            || !canUseRuntimeStart
             && (dictationPhase == .idle || dictationPhase == .failed || (dictationPhase == .requested && activeRequestID == nil))
+    }
+
+    func primaryLaunchAction() {
+        if recoveryRequestID != nil {
+            statusText = "Opening Muesli"
+            return
+        }
+
+        startDictation()
     }
 
     func primaryAction() {
@@ -119,6 +158,7 @@ final class KeyboardController {
         MuesliHaptics.dictationStart()
         let request = preparedRequest ?? DictationRequest()
         preparedRequest = nil
+        recoveryRequestID = nil
         launchURL = makeLaunchURL(for: request)
         activeRequestID = request.id
         insertedRequestIDs.remove(request.id)
@@ -128,6 +168,11 @@ final class KeyboardController {
         do {
             try store.clearPendingCommand()
             try store.saveRequest(request)
+            try store.saveKeyboardHandoffState(.init(
+                requestID: request.id,
+                phase: .startRequested,
+                message: canUseRuntimeStart ? "Starting" : "Opening Muesli"
+            ))
             if canUseRuntimeStart {
                 try store.saveCommand(.init(requestID: request.id, action: .start))
                 try store.saveStatus(.init(requestID: request.id, phase: .requested, message: "Starting"))
@@ -155,9 +200,14 @@ final class KeyboardController {
         MuesliHaptics.dictationStop()
         do {
             try store.saveCommand(.init(requestID: activeRequestID, action: .stop))
-            try store.saveStatus(.init(requestID: activeRequestID, phase: .transcribing, message: "Stopping"))
-            dictationPhase = .transcribing
-            statusText = "Transcribing"
+            try store.saveKeyboardHandoffState(.init(
+                requestID: activeRequestID,
+                phase: .stopRequested,
+                message: "Stopping"
+            ))
+            try store.saveStatus(.init(requestID: activeRequestID, phase: .recording, message: "Stopping"))
+            dictationPhase = .recording
+            statusText = "Stopping"
         } catch {
             statusText = "Enable Full Access"
         }
@@ -206,9 +256,13 @@ final class KeyboardController {
 
     private func refreshLatestDictation() {
         do {
-            apply(runtimeStatus: try store.keyboardRuntimeStatus())
-            let status = try store.status()
-            apply(status: status)
+            let runtimeStatus = try store.keyboardRuntimeStatus()
+            latestRuntimeStatus = runtimeStatus
+            apply(runtimeStatus: runtimeStatus)
+
+            let handoffState = try store.keyboardHandoffState()
+            latestHandoffState = handoffState
+            apply(handoffState: handoffState)
 
             guard let result = try store.resultsHistory().first else {
                 latestResultID = nil
@@ -225,6 +279,11 @@ final class KeyboardController {
                 return
             }
 
+            if handoffState.requestID == nil || handoffState.phase == .idle {
+                let status = try store.status()
+                apply(status: status)
+            }
+
             if latestResultID != result.id {
                 latestResultID = result.id
                 if activeRequestID == nil {
@@ -235,6 +294,83 @@ final class KeyboardController {
             }
         } catch {
             statusText = "Waiting for Full Access"
+        }
+    }
+
+    private func apply(handoffState: KeyboardHandoffState) {
+        guard let requestID = handoffState.requestID else { return }
+
+        let resumablePhases: [KeyboardHandoffPhase] = [
+            .startRequested,
+            .startAcknowledged,
+            .recordingStarted,
+            .stopRequested,
+            .stopAcknowledged,
+            .audioSaved,
+            .transcribingStarted,
+            .resultReady,
+            .recoveryRequested
+        ]
+        if activeRequestID == nil, resumablePhases.contains(handoffState.phase) {
+            activeRequestID = requestID
+        }
+
+        guard activeRequestID == requestID else { return }
+
+        if markHandoffForRecoveryIfStale(handoffState) {
+            return
+        }
+
+        recoveryRequestID = handoffState.phase == .recoveryRequested ? requestID : nil
+
+        switch handoffState.phase {
+        case .idle:
+            dictationPhase = .idle
+            activeRequestID = nil
+            statusText = hasLatestDictation ? "Latest ready" : "Ready"
+        case .startRequested:
+            dictationPhase = .requested
+            statusText = handoffState.message ?? "Starting"
+        case .startAcknowledged:
+            dictationPhase = .requested
+            statusText = handoffState.message ?? "Starting"
+        case .recordingStarted:
+            dictationPhase = .recording
+            statusText = handoffState.message ?? "Listening"
+        case .stopRequested:
+            dictationPhase = .recording
+            statusText = handoffState.message ?? "Stopping"
+        case .stopAcknowledged:
+            dictationPhase = .transcribing
+            statusText = handoffState.message ?? "Finalizing audio"
+        case .audioSaved:
+            dictationPhase = .transcribing
+            statusText = handoffState.message ?? "Audio saved"
+        case .transcribingStarted:
+            dictationPhase = .transcribing
+            statusText = handoffState.message ?? "Transcribing"
+        case .resultReady:
+            dictationPhase = .transcribing
+            statusText = handoffState.message ?? "Inserting"
+        case .inserted:
+            dictationPhase = .finished
+            activeRequestID = nil
+            statusText = "Inserted"
+        case .recoveryRequested:
+            dictationPhase = .failed
+            recoveryRequestID = requestID
+            launchURL = makeLaunchURL(for: requestID, action: MuesliAppConstants.startAction)
+            statusText = handoffState.message ?? "Open Muesli to finish"
+        case .failed:
+            dictationPhase = .failed
+            activeRequestID = nil
+            recoveryRequestID = nil
+            statusText = handoffState.message ?? "Dictation failed"
+        case .cancelled:
+            dictationPhase = .idle
+            activeRequestID = nil
+            recoveryRequestID = nil
+            statusText = hasLatestDictation ? "Latest ready" : "Ready"
         }
     }
 
@@ -272,8 +408,13 @@ final class KeyboardController {
 
         guard activeRequestID == requestID else { return }
 
+        if markForRecoveryIfStale(status, requestID: requestID) {
+            return
+        }
+
         switch status.phase {
         case .requested:
+            recoveryRequestID = nil
             if activeRequestID == nil {
                 dictationPhase = .requested
                 statusText = "Open Muesli to record"
@@ -282,23 +423,140 @@ final class KeyboardController {
                 statusText = "Recording in Muesli"
             }
         case .recording:
+            recoveryRequestID = nil
             dictationPhase = .recording
             statusText = "Recording in Muesli"
         case .transcribing:
+            recoveryRequestID = nil
             dictationPhase = .transcribing
             statusText = status.message ?? "Transcribing"
         case .failed:
+            recoveryRequestID = nil
             dictationPhase = .failed
             activeRequestID = nil
             statusText = status.message ?? "Dictation failed"
         case .finished:
+            recoveryRequestID = nil
             dictationPhase = .finished
             break
         case .idle:
+            recoveryRequestID = nil
             dictationPhase = .idle
             activeRequestID = nil
             statusText = hasLatestDictation ? "Latest ready" : "Ready"
         }
+    }
+
+    private func markForRecoveryIfStale(_ status: DictationStatus, requestID: UUID) -> Bool {
+        if let latestRuntimeStatus,
+           latestRuntimeStatus.activeRequestID == requestID,
+           Date().timeIntervalSince(latestRuntimeStatus.updatedAt) < 8,
+           [.recording, .transcribing].contains(latestRuntimeStatus.phase)
+        {
+            recoveryRequestID = nil
+            dictationPhase = latestRuntimeStatus.phase
+            statusText = latestRuntimeStatus.message ?? status.message ?? latestRuntimeStatus.phase.rawValue.capitalized
+            return true
+        }
+
+        let age = Date().timeIntervalSince(status.updatedAt)
+        let threshold: TimeInterval
+        let message: String
+
+        switch status.phase {
+        case .requested, .recording:
+            threshold = Self.staleRecordingInterval
+            message = "Open Muesli to continue"
+        case .transcribing:
+            threshold = status.message == "Stopping" ? Self.staleStoppingInterval : Self.staleTranscribingInterval
+            message = "Open Muesli to finish"
+        default:
+            return false
+        }
+
+        guard age > threshold else { return false }
+
+        recoveryRequestID = requestID
+        launchURL = makeLaunchURL(for: requestID, action: MuesliAppConstants.startAction)
+        dictationPhase = .failed
+        activeRequestID = nil
+        statusText = message
+        return true
+    }
+
+    private func markHandoffForRecoveryIfStale(_ state: KeyboardHandoffState) -> Bool {
+        guard let requestID = state.requestID else { return false }
+
+        if let latestRuntimeStatus,
+           latestRuntimeStatus.activeRequestID == requestID,
+           Date().timeIntervalSince(latestRuntimeStatus.updatedAt) < 8,
+           [.recording, .transcribing].contains(latestRuntimeStatus.phase),
+           state.phase != .stopRequested
+        {
+            return false
+        }
+
+        let age = Date().timeIntervalSince(state.updatedAt)
+        let threshold: TimeInterval
+        let retryAction: DictationCommandAction?
+        let recoveryMessage: String
+
+        switch state.phase {
+        case .startRequested, .startAcknowledged:
+            threshold = Self.staleStartInterval
+            retryAction = .start
+            recoveryMessage = "Open Muesli to start"
+        case .recordingStarted:
+            threshold = Self.staleRecordingInterval
+            retryAction = nil
+            recoveryMessage = "Open Muesli to continue"
+        case .stopRequested:
+            threshold = Self.staleStopRequestInterval
+            retryAction = .stop
+            recoveryMessage = "Open Muesli to finish"
+        case .stopAcknowledged, .audioSaved, .transcribingStarted:
+            threshold = Self.staleTranscribingInterval
+            retryAction = nil
+            recoveryMessage = "Open Muesli to finish"
+        case .recoveryRequested:
+            recoveryRequestID = requestID
+            launchURL = makeLaunchURL(for: requestID, action: MuesliAppConstants.startAction)
+            dictationPhase = .failed
+            statusText = state.message ?? "Open Muesli to finish"
+            return true
+        default:
+            return false
+        }
+
+        guard age > threshold else { return false }
+
+        if let retryAction, state.recoveryAttemptCount == 0, canUseRuntimeStart {
+            let retrying = state.advanced(
+                to: state.phase,
+                message: retryAction == .start ? "Retrying start" : "Retrying stop",
+                recoveryAttemptCount: 1
+            )
+            try? store.saveCommand(.init(requestID: requestID, action: retryAction))
+            try? store.saveKeyboardHandoffState(retrying)
+            latestHandoffState = retrying
+            dictationPhase = retrying.phase.dictationPhase
+            statusText = retrying.message ?? "Retrying"
+            return true
+        }
+
+        let recovery = state.advanced(
+            to: .recoveryRequested,
+            message: recoveryMessage,
+            recoveryAttemptCount: max(state.recoveryAttemptCount, 1)
+        )
+        try? store.saveKeyboardHandoffState(recovery)
+        latestHandoffState = recovery
+        recoveryRequestID = requestID
+        launchURL = makeLaunchURL(for: requestID, action: MuesliAppConstants.startAction)
+        dictationPhase = .failed
+        activeRequestID = nil
+        statusText = recoveryMessage
+        return true
     }
 
     private func insertCompletedResult(_ result: DictationResult) {
@@ -309,11 +567,17 @@ final class KeyboardController {
         hasLatestDictation = true
         activeRequestID = nil
         preparedRequest = nil
+        recoveryRequestID = nil
         launchURL = nil
         dictationPhase = .finished
         statusText = "Inserted"
         try? store.clearPendingRequest()
         try? store.clearPendingCommand()
+        try? store.saveKeyboardHandoffState(.init(
+            requestID: result.requestID,
+            phase: .inserted,
+            message: "Inserted"
+        ))
         try? store.saveStatus(.idle)
         prepareLaunchRequestIfNeeded()
 
@@ -326,12 +590,16 @@ final class KeyboardController {
     }
 
     private func makeLaunchURL(for request: DictationRequest) -> URL? {
+        makeLaunchURL(for: request.id, action: MuesliAppConstants.startAction)
+    }
+
+    private func makeLaunchURL(for requestID: UUID, action: String) -> URL? {
         var components = URLComponents()
         components.scheme = MuesliAppConstants.urlScheme
         components.host = MuesliAppConstants.dictateHost
         components.queryItems = [
-            URLQueryItem(name: MuesliAppConstants.requestQueryItem, value: request.id.uuidString),
-            URLQueryItem(name: MuesliAppConstants.actionQueryItem, value: MuesliAppConstants.startAction)
+            URLQueryItem(name: MuesliAppConstants.requestQueryItem, value: requestID.uuidString),
+            URLQueryItem(name: MuesliAppConstants.actionQueryItem, value: action)
         ]
 
         return components.url

--- a/MuesliKeyboard/KeyboardRootView.swift
+++ b/MuesliKeyboard/KeyboardRootView.swift
@@ -36,7 +36,7 @@ struct KeyboardRootView: View {
                         primaryButtonLabel
                     }
                     .simultaneousGesture(TapGesture().onEnded {
-                        controller.startDictation()
+                        controller.primaryLaunchAction()
                     })
                     .buttonStyle(.plain)
                 } else {

--- a/Shared/DictationModels.swift
+++ b/Shared/DictationModels.swift
@@ -15,6 +15,37 @@ enum DictationCommandAction: String, Codable, Sendable, Equatable {
     case cancel
 }
 
+enum KeyboardHandoffPhase: String, Codable, Sendable, Equatable {
+    case idle
+    case startRequested
+    case startAcknowledged
+    case recordingStarted
+    case stopRequested
+    case stopAcknowledged
+    case audioSaved
+    case transcribingStarted
+    case resultReady
+    case inserted
+    case recoveryRequested
+    case failed
+    case cancelled
+
+    var dictationPhase: DictationPhase {
+        switch self {
+        case .idle, .inserted, .cancelled:
+            .idle
+        case .startRequested, .startAcknowledged:
+            .requested
+        case .recordingStarted, .stopRequested:
+            .recording
+        case .stopAcknowledged, .audioSaved, .transcribingStarted, .resultReady:
+            .transcribing
+        case .recoveryRequested, .failed:
+            .failed
+        }
+    }
+}
+
 enum RecordingSessionKind: String, Codable, Sendable, Equatable, CaseIterable {
     case quickDictation
     case keyboardDictation
@@ -79,6 +110,49 @@ struct DictationCommand: Codable, Sendable, Equatable {
         self.action = action
         self.createdAt = createdAt
     }
+}
+
+struct KeyboardHandoffState: Codable, Sendable, Equatable {
+    let requestID: UUID?
+    let phase: KeyboardHandoffPhase
+    let message: String?
+    let recoveryAttemptCount: Int
+    let createdAt: Date
+    let updatedAt: Date
+
+    init(
+        requestID: UUID?,
+        phase: KeyboardHandoffPhase,
+        message: String? = nil,
+        recoveryAttemptCount: Int = 0,
+        createdAt: Date = .now,
+        updatedAt: Date = .now
+    ) {
+        self.requestID = requestID
+        self.phase = phase
+        self.message = message
+        self.recoveryAttemptCount = recoveryAttemptCount
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+    }
+
+    func advanced(
+        to phase: KeyboardHandoffPhase,
+        message: String? = nil,
+        recoveryAttemptCount: Int? = nil,
+        updatedAt: Date = .now
+    ) -> KeyboardHandoffState {
+        KeyboardHandoffState(
+            requestID: requestID,
+            phase: phase,
+            message: message,
+            recoveryAttemptCount: recoveryAttemptCount ?? self.recoveryAttemptCount,
+            createdAt: createdAt,
+            updatedAt: updatedAt
+        )
+    }
+
+    static let idle = KeyboardHandoffState(requestID: nil, phase: .idle)
 }
 
 struct DictationResult: Codable, Sendable, Equatable, Identifiable {

--- a/Shared/DictationModels.swift
+++ b/Shared/DictationModels.swift
@@ -155,6 +155,95 @@ struct KeyboardHandoffState: Codable, Sendable, Equatable {
     static let idle = KeyboardHandoffState(requestID: nil, phase: .idle)
 }
 
+enum KeyboardHandoffRecoveryAction: Sendable, Equatable {
+    case none
+    case retry(DictationCommandAction, KeyboardHandoffState)
+    case recover(KeyboardHandoffState)
+}
+
+struct KeyboardHandoffRecoveryPolicy: Sendable, Equatable {
+    let staleStartInterval: TimeInterval
+    let staleRecordingInterval: TimeInterval
+    let staleStopRequestInterval: TimeInterval
+    let staleTranscribingInterval: TimeInterval
+    let runtimeFreshnessInterval: TimeInterval
+
+    static let keyboardDefaults = KeyboardHandoffRecoveryPolicy(
+        staleStartInterval: 10,
+        staleRecordingInterval: 45,
+        staleStopRequestInterval: 8,
+        staleTranscribingInterval: 120,
+        runtimeFreshnessInterval: 8
+    )
+
+    func action(
+        for state: KeyboardHandoffState,
+        latestRuntimeStatus: KeyboardRuntimeStatus?,
+        canUseRuntimeStart: Bool,
+        now: Date = .now
+    ) -> KeyboardHandoffRecoveryAction {
+        guard let requestID = state.requestID else { return .none }
+
+        if let latestRuntimeStatus,
+           latestRuntimeStatus.activeRequestID == requestID,
+           now.timeIntervalSince(latestRuntimeStatus.updatedAt) < runtimeFreshnessInterval,
+           [.recording, .transcribing].contains(latestRuntimeStatus.phase),
+           state.phase != .stopRequested
+        {
+            return .none
+        }
+
+        let threshold: TimeInterval
+        let retryAction: DictationCommandAction?
+        let recoveryMessage: String
+
+        switch state.phase {
+        case .startRequested, .startAcknowledged:
+            threshold = staleStartInterval
+            retryAction = .start
+            recoveryMessage = "Open Muesli to start"
+        case .recordingStarted:
+            threshold = staleRecordingInterval
+            retryAction = nil
+            recoveryMessage = "Open Muesli to continue"
+        case .stopRequested:
+            threshold = staleStopRequestInterval
+            retryAction = .stop
+            recoveryMessage = "Open Muesli to finish"
+        case .stopAcknowledged, .audioSaved, .transcribingStarted:
+            threshold = staleTranscribingInterval
+            retryAction = nil
+            recoveryMessage = "Open Muesli to finish"
+        case .recoveryRequested:
+            return .recover(state)
+        default:
+            return .none
+        }
+
+        guard now.timeIntervalSince(state.updatedAt) > threshold else {
+            return .none
+        }
+
+        if let retryAction, state.recoveryAttemptCount == 0, canUseRuntimeStart {
+            let retrying = state.advanced(
+                to: state.phase,
+                message: retryAction == .start ? "Retrying start" : "Retrying stop",
+                recoveryAttemptCount: 1,
+                updatedAt: now
+            )
+            return .retry(retryAction, retrying)
+        }
+
+        let recovery = state.advanced(
+            to: .recoveryRequested,
+            message: recoveryMessage,
+            recoveryAttemptCount: max(state.recoveryAttemptCount, 1),
+            updatedAt: now
+        )
+        return .recover(recovery)
+    }
+}
+
 struct DictationResult: Codable, Sendable, Equatable, Identifiable {
     let id: UUID
     let requestID: UUID

--- a/Shared/SharedStore.swift
+++ b/Shared/SharedStore.swift
@@ -52,6 +52,18 @@ struct SharedStore: Sendable {
         try database().clearValue(key: .pendingCommand)
     }
 
+    func saveKeyboardHandoffState(_ state: KeyboardHandoffState) throws {
+        try database().saveValue(state, key: .keyboardHandoffState)
+    }
+
+    func keyboardHandoffState() throws -> KeyboardHandoffState {
+        try database().value(KeyboardHandoffState.self, key: .keyboardHandoffState) ?? .idle
+    }
+
+    func clearKeyboardHandoffState() throws {
+        try database().clearValue(key: .keyboardHandoffState)
+    }
+
     func saveStatus(_ status: DictationStatus) throws {
         try database().saveValue(status, key: .dictationStatus)
     }
@@ -202,6 +214,7 @@ struct SharedStore: Sendable {
 private enum SharedStoreKey: String {
     case pendingRequest = "pending_request"
     case pendingCommand = "pending_command"
+    case keyboardHandoffState = "keyboard_handoff_state"
     case dictationStatus = "dictation_status"
     case keyboardExtensionStatus = "keyboard_extension_status"
     case keyboardRuntimeStatus = "keyboard_runtime_status"

--- a/Tests/MuesliTests/SharedStoreTests.swift
+++ b/Tests/MuesliTests/SharedStoreTests.swift
@@ -130,13 +130,124 @@ final class SharedStoreTests: XCTestCase {
         XCTAssertEqual(try store.keyboardHandoffState(), started)
 
         try store.saveKeyboardHandoffState(acknowledged)
-        XCTAssertEqual(try store.keyboardHandoffState().requestID, requestID)
-        XCTAssertEqual(try store.keyboardHandoffState().phase, .startAcknowledged)
-        XCTAssertEqual(try store.keyboardHandoffState().message, "Starting")
-        XCTAssertEqual(try store.keyboardHandoffState().recoveryAttemptCount, 1)
+        let retrieved = try store.keyboardHandoffState()
+        XCTAssertEqual(retrieved.requestID, requestID)
+        XCTAssertEqual(retrieved.phase, .startAcknowledged)
+        XCTAssertEqual(retrieved.message, "Starting")
+        XCTAssertEqual(retrieved.recoveryAttemptCount, 1)
 
         try store.clearKeyboardHandoffState()
         XCTAssertEqual(try store.keyboardHandoffState(), .idle)
+    }
+
+    func testKeyboardHandoffRecoveryPolicyRetriesStaleStartOnce() throws {
+        let requestID = UUID()
+        let now = Date(timeIntervalSince1970: 1_000)
+        let staleStart = KeyboardHandoffState(
+            requestID: requestID,
+            phase: .startRequested,
+            message: "Starting",
+            recoveryAttemptCount: 0,
+            createdAt: now.addingTimeInterval(-11),
+            updatedAt: now.addingTimeInterval(-11)
+        )
+
+        let action = KeyboardHandoffRecoveryPolicy.keyboardDefaults.action(
+            for: staleStart,
+            latestRuntimeStatus: nil,
+            canUseRuntimeStart: true,
+            now: now
+        )
+
+        guard case let .retry(retryAction, retryingState) = action else {
+            return XCTFail("Expected stale start to retry once")
+        }
+        XCTAssertEqual(retryAction, .start)
+        XCTAssertEqual(retryingState.phase, .startRequested)
+        XCTAssertEqual(retryingState.message, "Retrying start")
+        XCTAssertEqual(retryingState.recoveryAttemptCount, 1)
+    }
+
+    func testKeyboardHandoffRecoveryPolicyRecoversStaleStartAfterRetry() throws {
+        let requestID = UUID()
+        let now = Date(timeIntervalSince1970: 1_000)
+        let staleStart = KeyboardHandoffState(
+            requestID: requestID,
+            phase: .startRequested,
+            message: "Retrying start",
+            recoveryAttemptCount: 1,
+            createdAt: now.addingTimeInterval(-20),
+            updatedAt: now.addingTimeInterval(-20)
+        )
+
+        let action = KeyboardHandoffRecoveryPolicy.keyboardDefaults.action(
+            for: staleStart,
+            latestRuntimeStatus: nil,
+            canUseRuntimeStart: true,
+            now: now
+        )
+
+        guard case let .recover(recoveryState) = action else {
+            return XCTFail("Expected stale retried start to request recovery")
+        }
+        XCTAssertEqual(recoveryState.phase, .recoveryRequested)
+        XCTAssertEqual(recoveryState.message, "Open Muesli to start")
+        XCTAssertEqual(recoveryState.recoveryAttemptCount, 1)
+    }
+
+    func testKeyboardHandoffRecoveryPolicyRecoversStaleRecordingWithoutRetry() throws {
+        let requestID = UUID()
+        let now = Date(timeIntervalSince1970: 1_000)
+        let staleRecording = KeyboardHandoffState(
+            requestID: requestID,
+            phase: .recordingStarted,
+            message: "Listening",
+            createdAt: now.addingTimeInterval(-46),
+            updatedAt: now.addingTimeInterval(-46)
+        )
+
+        let action = KeyboardHandoffRecoveryPolicy.keyboardDefaults.action(
+            for: staleRecording,
+            latestRuntimeStatus: nil,
+            canUseRuntimeStart: true,
+            now: now
+        )
+
+        guard case let .recover(recoveryState) = action else {
+            return XCTFail("Expected stale recording to request recovery")
+        }
+        XCTAssertEqual(recoveryState.phase, .recoveryRequested)
+        XCTAssertEqual(recoveryState.message, "Open Muesli to continue")
+        XCTAssertEqual(recoveryState.recoveryAttemptCount, 1)
+    }
+
+    func testKeyboardHandoffRecoveryPolicyIgnoresFreshActiveRuntimeStatus() throws {
+        let requestID = UUID()
+        let now = Date(timeIntervalSince1970: 1_000)
+        let staleRecording = KeyboardHandoffState(
+            requestID: requestID,
+            phase: .recordingStarted,
+            message: "Listening",
+            createdAt: now.addingTimeInterval(-60),
+            updatedAt: now.addingTimeInterval(-60)
+        )
+        let freshRuntimeStatus = KeyboardRuntimeStatus(
+            isActive: true,
+            activeRequestID: requestID,
+            phase: .recording,
+            message: "Listening",
+            supportsBackgroundStart: true,
+            updatedAt: now.addingTimeInterval(-2)
+        )
+
+        let action = KeyboardHandoffRecoveryPolicy.keyboardDefaults.action(
+            for: staleRecording,
+            latestRuntimeStatus: freshRuntimeStatus,
+            canUseRuntimeStart: true,
+            now: now
+        )
+
+        XCTAssertEqual(action, .none)
     }
 
     func testResultsHistoryReplacesResultForSameRequest() throws {

--- a/Tests/MuesliTests/SharedStoreTests.swift
+++ b/Tests/MuesliTests/SharedStoreTests.swift
@@ -107,6 +107,38 @@ final class SharedStoreTests: XCTestCase {
         XCTAssertEqual(try store.resultsHistory().map(\.text), ["newer dictation", "older dictation"])
     }
 
+    func testKeyboardHandoffStatePersistsAndClears() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let store = SharedStore(containerURL: directory)
+        let requestID = UUID()
+        let started = KeyboardHandoffState(
+            requestID: requestID,
+            phase: .startRequested,
+            message: "Starting"
+        )
+        let acknowledged = started.advanced(
+            to: .startAcknowledged,
+            message: "Starting",
+            recoveryAttemptCount: 1
+        )
+
+        XCTAssertEqual(try store.keyboardHandoffState(), .idle)
+
+        try store.saveKeyboardHandoffState(started)
+        XCTAssertEqual(try store.keyboardHandoffState(), started)
+
+        try store.saveKeyboardHandoffState(acknowledged)
+        XCTAssertEqual(try store.keyboardHandoffState().requestID, requestID)
+        XCTAssertEqual(try store.keyboardHandoffState().phase, .startAcknowledged)
+        XCTAssertEqual(try store.keyboardHandoffState().message, "Starting")
+        XCTAssertEqual(try store.keyboardHandoffState().recoveryAttemptCount, 1)
+
+        try store.clearKeyboardHandoffState()
+        XCTAssertEqual(try store.keyboardHandoffState(), .idle)
+    }
+
     func testResultsHistoryReplacesResultForSameRequest() throws {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent("muesli-store-\(UUID().uuidString)", isDirectory: true)


### PR DESCRIPTION
## Summary
- Add a persisted keyboard handoff state machine shared by the keyboard extension and containing app.
- Move keyboard dictation away from optimistic transcribing states: the keyboard now requests start/stop, and the app writes acknowledgements, recording, audio saved, transcribing, result-ready, failure, or cancellation.
- Add bounded retry/recovery behavior for missed start/stop commands so the keyboard can prompt users to open Muesli without looping indefinitely.
- Preserve the existing recovery path for interrupted keyboard recordings and add SharedStore coverage for handoff state persistence.

## Root Cause
Keyboard stop previously wrote `Transcribing` optimistically before the containing app had consumed the stop command. Because the shared command slot is single-value and app-side polling can be interrupted, users could get stuck in a state where the keyboard believed transcription was happening while the app had not acknowledged or processed the request.

## Validation
- `xcodebuild test -scheme Muesli -project MuesliiOS.xcodeproj -destination 'platform=iOS Simulator,name=iPhone 17'`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli-ios/pr/4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783641107&installation_id=136549638&pr_number=4&repository=Muesli-HQ%2Fmuesli-ios&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli-ios%2Fpull%2F4&signature=e497bd117710c22181f630d1f547d03cef8dbbf3c365782a60bf03c519a3d112"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->