### PR TITLE
Add retained dictation audio playback

### DIFF
--- a/Muesli/DictationCoordinator.swift
+++ b/Muesli/DictationCoordinator.swift
@@ -26,6 +26,7 @@ final class DictationCoordinator {
     private var modelPreparationTask: Task<Void, Never>?
     private var modelPrewarmTask: Task<Void, Never>?
     private var meteringTask: Task<Void, Never>?
+    private var recordingTimerTask: Task<Void, Never>?
     private var commandPollingTask: Task<Void, Never>?
     private var keyboardRuntimePollingTask: Task<Void, Never>?
     private var keyboardSessionTimeoutTask: Task<Void, Never>?
@@ -90,6 +91,7 @@ final class DictationCoordinator {
     var onboardingTestError: String?
     var isRecording = false
     var inputLevel = 0.0
+    var recordingElapsedTime: TimeInterval = 0
     var statusText = "Ready"
     var meetingStatusText = "Ready"
     var lastTranscript = ""
@@ -420,6 +422,12 @@ final class DictationCoordinator {
 
     func deleteDictation(_ result: DictationResult) {
         do {
+            if let session = recordingSession(for: result) {
+                if let audioFileName = session.audioFileName {
+                    try? store.deleteAudioFile(fileName: audioFileName)
+                }
+                try? store.deleteRecordingSession(id: session.id)
+            }
             try store.deleteResult(result)
             dictationHistory.removeAll { $0.id == result.id || $0.requestID == result.requestID }
             if lastTranscript == result.text {
@@ -471,6 +479,22 @@ final class DictationCoordinator {
 
     func audioFileURL(for session: RecordingSession) -> URL? {
         guard let audioFileName = session.audioFileName else { return nil }
+        return try? store.audioFileURL(fileName: audioFileName)
+    }
+
+    func recordingSession(for result: DictationResult) -> RecordingSession? {
+        if let sessionID = result.sessionID,
+           let session = try? store.recordingSession(id: sessionID) {
+            return session
+        }
+        return nil
+    }
+
+    func audioFileURL(for result: DictationResult) -> URL? {
+        guard let session = recordingSession(for: result),
+              session.keepsAudioRecording,
+              let audioFileName = session.audioFileName
+        else { return nil }
         return try? store.audioFileURL(fileName: audioFileName)
     }
 
@@ -1028,7 +1052,11 @@ final class DictationCoordinator {
         realtimeDictationCommittedText = ""
         clearKeyboardLiveTranscript()
         let kind: RecordingSessionKind = source == "keyboard" ? .keyboardDictation : .quickDictation
-        var session = RecordingSession(requestID: request.id, kind: kind)
+        var session = RecordingSession(
+            requestID: request.id,
+            kind: kind,
+            keepsAudioRecording: MuesliPreferences.keepDictationAudioRecordingsEnabled
+        )
         if source == "keyboard" {
             saveKeyboardHandoff(
                 requestID: request.id,
@@ -1039,7 +1067,7 @@ final class DictationCoordinator {
 
         Task {
             do {
-                let audioURL = try store.newAudioFileURL(sessionID: session.id)
+                let audioURL = try store.newDictationAudioFileURL(startedAt: session.createdAt)
                 session.audioFileName = audioURL.lastPathComponent
                 session.startedAt = .now
                 try store.saveSession(session)
@@ -1055,6 +1083,7 @@ final class DictationCoordinator {
                 }
                 activeSession = session
                 isRecording = true
+                startRecordingTimer(startedAt: session.startedAt ?? .now)
                 if source == "keyboard" {
                     saveKeyboardHandoff(
                         requestID: request.id,
@@ -1091,9 +1120,11 @@ final class DictationCoordinator {
             } catch {
                 session.phase = .failed
                 session.errorMessage = error.localizedDescription
+                cleanupNonRetainedAudio(for: &session)
                 try? store.saveSession(session)
                 activeSession = nil
                 activeRequest = nil
+                stopRecordingTimer()
                 statusText = error.localizedDescription
                 clearKeyboardLiveTranscript()
                 stopMetering()
@@ -1146,12 +1177,15 @@ final class DictationCoordinator {
                 completedSession.transcriptID = savedTranscript.id
                 completedSession.engineIdentifier = engine.identifier
                 completedSession.errorMessage = nil
+                cleanupNonRetainedAudio(for: &completedSession)
                 try store.saveSession(completedSession)
+                exportRetainedAudioIfNeeded(for: completedSession)
 
                 let result = DictationResult(
                     requestID: request.id,
                     sessionID: savedTranscript.sessionID,
                     text: text,
+                    createdAt: completedSession.createdAt,
                     engineIdentifier: engine.identifier
                 )
                 try store.saveResult(result)
@@ -1183,6 +1217,7 @@ final class DictationCoordinator {
                 var failedSession = session
                 failedSession.phase = .failed
                 failedSession.errorMessage = error.localizedDescription
+                cleanupNonRetainedAudio(for: &failedSession)
                 try? store.saveSession(failedSession)
                 try? store.saveStatus(.init(
                     requestID: request.id,
@@ -1236,6 +1271,7 @@ final class DictationCoordinator {
 
         isRecording = false
         stopMetering()
+        stopRecordingTimer()
         stopCommandPolling()
         statusText = "Transcribing"
         try? store.saveStatus(.init(requestID: request.id, phase: .transcribing, message: "Transcribing"))
@@ -1321,7 +1357,9 @@ final class DictationCoordinator {
                 }
                 let completedSession = activeSession ?? session
                 let transcript: Transcript?
+                let resultCreatedAt: Date
                 if var completedSession {
+                    resultCreatedAt = completedSession.createdAt
                     let savedTranscript = Transcript(
                         sessionID: completedSession.id,
                         text: text,
@@ -1333,15 +1371,19 @@ final class DictationCoordinator {
                     completedSession.transcriptID = savedTranscript.id
                     completedSession.engineIdentifier = engine.identifier
                     completedSession.errorMessage = nil
+                    cleanupNonRetainedAudio(for: &completedSession)
                     try store.saveSession(completedSession)
+                    exportRetainedAudioIfNeeded(for: completedSession)
                     transcript = savedTranscript
                 } else {
+                    resultCreatedAt = request.createdAt
                     transcript = nil
                 }
                 let result = DictationResult(
                     requestID: request.id,
                     sessionID: transcript?.sessionID,
                     text: text,
+                    createdAt: resultCreatedAt,
                     engineIdentifier: engine.identifier
                 )
                 try store.saveResult(result)
@@ -1390,6 +1432,7 @@ final class DictationCoordinator {
                 if var session = activeSession ?? session {
                     session.phase = .failed
                     session.errorMessage = error.localizedDescription
+                    cleanupNonRetainedAudio(for: &session)
                     try? store.saveSession(session)
                 }
                 activeRequest = nil
@@ -1919,6 +1962,41 @@ final class DictationCoordinator {
         }
     }
 
+    private func startRecordingTimer(startedAt: Date) {
+        recordingTimerTask?.cancel()
+        recordingElapsedTime = 0
+        recordingTimerTask = Task { @MainActor [weak self] in
+            while !Task.isCancelled {
+                guard let self else { return }
+                self.recordingElapsedTime = max(0, Date().timeIntervalSince(startedAt))
+                try? await Task.sleep(for: .milliseconds(250))
+            }
+        }
+    }
+
+    private func stopRecordingTimer() {
+        recordingTimerTask?.cancel()
+        recordingTimerTask = nil
+        recordingElapsedTime = 0
+    }
+
+    private func cleanupNonRetainedAudio(for session: inout RecordingSession) {
+        guard !session.keepsAudioRecording,
+              let audioFileName = session.audioFileName
+        else { return }
+
+        try? store.deleteAudioFile(fileName: audioFileName)
+        session.audioFileName = nil
+    }
+
+    private func exportRetainedAudioIfNeeded(for session: RecordingSession) {
+        guard session.keepsAudioRecording,
+              let audioFileName = session.audioFileName
+        else { return }
+
+        _ = try? store.exportAudioFileToDocuments(fileName: audioFileName)
+    }
+
     private func startMeetingMetering() {
         meteringTask?.cancel()
         meteringTask = Task { @MainActor [weak self] in
@@ -2169,12 +2247,14 @@ final class DictationCoordinator {
         guard activeRequest?.id == requestID else { return }
         isRecording = false
         stopMetering()
+        stopRecordingTimer()
         stopCommandPolling()
         _ = try? recorder.stop()
         cleanupRealtimeDictationRecorder()
         if var session = activeSession {
             session.phase = .cancelled
             session.endedAt = .now
+            cleanupNonRetainedAudio(for: &session)
             try? store.saveSession(session)
             Task {
                 await liveActivityController.end(

--- a/Muesli/DictationCoordinator.swift
+++ b/Muesli/DictationCoordinator.swift
@@ -421,6 +421,7 @@ final class DictationCoordinator {
                 if let audioFileName = session.audioFileName {
                     try? store.deleteAudioFile(fileName: audioFileName)
                 }
+                try? store.deleteTranscript(for: session.id)
                 try? store.deleteRecordingSession(id: session.id)
                 recordingSessions.removeAll { $0.id == session.id }
             }

--- a/Muesli/DictationCoordinator.swift
+++ b/Muesli/DictationCoordinator.swift
@@ -412,12 +412,7 @@ final class DictationCoordinator {
         clipboardStatusText = "Copied"
         AppTelemetry.signal("dictation_copied")
 
-        Task {
-            try? await Task.sleep(for: .seconds(1.2))
-            if clipboardStatusText == "Copied" {
-                clipboardStatusText = nil
-            }
-        }
+        clearClipboardStatusSoon()
     }
 
     func deleteDictation(_ result: DictationResult) {
@@ -427,6 +422,7 @@ final class DictationCoordinator {
                     try? store.deleteAudioFile(fileName: audioFileName)
                 }
                 try? store.deleteRecordingSession(id: session.id)
+                recordingSessions.removeAll { $0.id == session.id }
             }
             try store.deleteResult(result)
             dictationHistory.removeAll { $0.id == result.id || $0.requestID == result.requestID }
@@ -499,10 +495,11 @@ final class DictationCoordinator {
     }
 
     private func clearClipboardStatusSoon() {
-        Task {
+        let statusToClear = clipboardStatusText
+        Task { @MainActor [weak self] in
             try? await Task.sleep(for: .seconds(1.2))
-            if clipboardStatusText == "Copied" {
-                clipboardStatusText = nil
+            if self?.clipboardStatusText == statusToClear {
+                self?.clipboardStatusText = nil
             }
         }
     }

--- a/Muesli/DictationView.swift
+++ b/Muesli/DictationView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UniformTypeIdentifiers
 
 struct DictationView: View {
     @Bindable var coordinator: DictationCoordinator
@@ -40,6 +41,17 @@ struct DictationView: View {
             .onAppear {
                 coordinator.refreshHistory()
             }
+            .navigationDestination(for: UUID.self) { resultID in
+                if let result = coordinator.dictationHistory.first(where: { $0.id == resultID }),
+                   let session = coordinator.recordingSession(for: result),
+                   let audioURL = coordinator.audioFileURL(for: result) {
+                    DictationAudioDetailView(result: result, session: session, audioURL: audioURL) {
+                        coordinator.copyToClipboard(result)
+                    }
+                } else {
+                    DictationAudioMissingView()
+                }
+            }
         }
     }
 
@@ -75,6 +87,19 @@ struct DictationView: View {
                     }
 
                     Spacer()
+
+                    if coordinator.isRecording {
+                        Text(formatElapsedTime(coordinator.recordingElapsedTime))
+                            .font(MuesliTheme.captionMedium())
+                            .monospacedDigit()
+                            .foregroundStyle(statusColor)
+                            .padding(.horizontal, MuesliTheme.spacing8)
+                            .padding(.vertical, MuesliTheme.spacing4)
+                            .background(statusColor.opacity(0.13))
+                            .clipShape(Capsule())
+                            .accessibilityLabel("Recording elapsed time")
+                            .accessibilityValue(formatElapsedTime(coordinator.recordingElapsedTime))
+                    }
                 }
 
                 if isWaveformActive {
@@ -182,11 +207,26 @@ struct DictationView: View {
             } else {
                 LazyVStack(spacing: MuesliTheme.spacing12) {
                     ForEach(filteredHistory) { result in
-                        DictationHistoryRow(
-                            result: result,
-                            onCopy: { coordinator.copyToClipboard(result) },
-                            onDelete: { coordinator.deleteDictation(result) }
-                        )
+                        let session = coordinator.recordingSession(for: result)
+                        let hasRetainedAudio = session?.keepsAudioRecording == true && coordinator.audioFileURL(for: result) != nil
+                        if hasRetainedAudio {
+                            NavigationLink(value: result.id) {
+                                DictationHistoryRow(
+                                    result: result,
+                                    hasRetainedAudio: true,
+                                    onCopy: { coordinator.copyToClipboard(result) },
+                                    onDelete: { coordinator.deleteDictation(result) }
+                                )
+                            }
+                            .buttonStyle(.plain)
+                        } else {
+                            DictationHistoryRow(
+                                result: result,
+                                hasRetainedAudio: false,
+                                onCopy: { coordinator.copyToClipboard(result) },
+                                onDelete: { coordinator.deleteDictation(result) }
+                            )
+                        }
                     }
                 }
             }
@@ -288,6 +328,14 @@ struct DictationView: View {
             return
         }
         coordinator.syncICloudTextIfEnabled(reason: "home_manual")
+    }
+
+    private func formatElapsedTime(_ time: TimeInterval) -> String {
+        guard time.isFinite, time > 0 else { return "0:00" }
+        let totalSeconds = Int(time.rounded(.down))
+        let minutes = totalSeconds / 60
+        let seconds = totalSeconds % 60
+        return String(format: "%d:%02d", minutes, seconds)
     }
 }
 
@@ -510,6 +558,7 @@ private struct DictationSourceFilterPicker: View {
 
 private struct DictationHistoryRow: View {
     let result: DictationResult
+    let hasRetainedAudio: Bool
     let onCopy: () -> Void
     let onDelete: () -> Void
     @State private var isConfirmingDelete = false
@@ -570,6 +619,13 @@ private struct DictationHistoryRow: View {
 
                 Spacer(minLength: MuesliTheme.spacing8)
 
+                if hasRetainedAudio {
+                    Image(systemName: "play.circle.fill")
+                        .font(.system(size: 22, weight: .semibold))
+                        .foregroundStyle(MuesliTheme.accent)
+                        .accessibilityHidden(true)
+                }
+
                 DictationOriginChip(origin: origin)
             }
 
@@ -592,6 +648,194 @@ private struct DictationHistoryRow: View {
         formatter.timeStyle = .short
         return formatter
     }()
+}
+
+private struct DictationAudioDetailView: View {
+    let result: DictationResult
+    let session: RecordingSession
+    let audioURL: URL
+    let onCopy: () -> Void
+
+    @State private var filesExportStatus: String?
+    @State private var isFilesExporterPresented = false
+    @State private var audioDocument: AudioFileDocument?
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: MuesliTheme.spacing20) {
+                VStack(alignment: .leading, spacing: MuesliTheme.spacing4) {
+                    Text(session.title ?? session.kind.title)
+                        .font(MuesliTheme.title1())
+                        .foregroundStyle(MuesliTheme.textPrimary)
+
+                    Text(result.createdAt, formatter: Self.dateFormatter)
+                        .font(MuesliTheme.callout())
+                        .foregroundStyle(MuesliTheme.textSecondary)
+                }
+
+                MuesliSurface(cornerRadius: MuesliTheme.cornerLarge) {
+                    VStack(alignment: .leading, spacing: MuesliTheme.spacing16) {
+                        HStack(alignment: .firstTextBaseline) {
+                            Text("Recording")
+                                .font(MuesliTheme.title3())
+                                .foregroundStyle(MuesliTheme.textPrimary)
+
+                            Spacer()
+
+                            if let duration = session.duration {
+                                Text(formatTime(duration))
+                                    .font(MuesliTheme.captionMedium())
+                                    .monospacedDigit()
+                                    .foregroundStyle(MuesliTheme.textTertiary)
+                            }
+                        }
+
+                        SavedAudioPlayerView(audioURL: audioURL)
+
+                        HStack(spacing: MuesliTheme.spacing12) {
+                            ShareLink(item: audioURL) {
+                                Label("Share", systemImage: "square.and.arrow.up")
+                                    .font(MuesliTheme.captionMedium())
+                            }
+                            .foregroundStyle(MuesliTheme.accent)
+
+                            Button(action: saveAudioToFiles) {
+                                Label("Save to Files", systemImage: "folder")
+                                    .font(MuesliTheme.captionMedium())
+                            }
+                            .buttonStyle(.plain)
+                            .foregroundStyle(MuesliTheme.accent)
+
+                            Spacer()
+                        }
+
+                        VStack(alignment: .leading, spacing: MuesliTheme.spacing4) {
+                            if let fileName = session.audioFileName {
+                                Label(fileName, systemImage: "iphone")
+                                    .font(MuesliTheme.caption())
+                                    .foregroundStyle(MuesliTheme.textTertiary)
+                                    .lineLimit(1)
+                                    .truncationMode(.middle)
+                            }
+
+                            if let filesExportStatus {
+                                Text(filesExportStatus)
+                                    .font(MuesliTheme.caption())
+                                    .foregroundStyle(MuesliTheme.textTertiary)
+                            }
+                        }
+                    }
+                    .padding(MuesliTheme.spacing16)
+                }
+
+                MuesliSurface(cornerRadius: MuesliTheme.cornerLarge) {
+                    VStack(alignment: .leading, spacing: MuesliTheme.spacing12) {
+                        HStack {
+                            Text("Transcript")
+                                .font(MuesliTheme.title3())
+                                .foregroundStyle(MuesliTheme.textPrimary)
+                            Spacer()
+                            Button(action: onCopy) {
+                                Label("Copy", systemImage: "doc.on.doc")
+                                    .font(MuesliTheme.captionMedium())
+                            }
+                            .buttonStyle(.plain)
+                            .foregroundStyle(MuesliTheme.accent)
+                        }
+
+                        Text(result.text.isEmpty ? "No speech detected." : result.text)
+                            .font(MuesliTheme.body())
+                            .foregroundStyle(result.text.isEmpty ? MuesliTheme.textTertiary : MuesliTheme.textPrimary)
+                            .textSelection(.enabled)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                    .padding(MuesliTheme.spacing16)
+                }
+            }
+            .padding(.horizontal, MuesliTheme.spacing20)
+            .padding(.top, MuesliTheme.spacing24)
+            .padding(.bottom, MuesliTheme.spacing24)
+        }
+        .background(MuesliTheme.backgroundBase)
+        .navigationTitle("Dictation")
+        .navigationBarTitleDisplayMode(.inline)
+        .fileExporter(
+            isPresented: $isFilesExporterPresented,
+            document: audioDocument,
+            contentType: AudioFileDocument.contentType,
+            defaultFilename: audioURL.lastPathComponent
+        ) { result in
+            switch result {
+            case .success:
+                filesExportStatus = "Saved with Files"
+            case .failure:
+                filesExportStatus = "Files export failed"
+            }
+        }
+    }
+
+    private func formatTime(_ time: TimeInterval) -> String {
+        guard time.isFinite, time > 0 else { return "0:00" }
+        let totalSeconds = Int(time.rounded())
+        let minutes = totalSeconds / 60
+        let seconds = totalSeconds % 60
+        return String(format: "%d:%02d", minutes, seconds)
+    }
+
+    private func saveAudioToFiles() {
+        do {
+            audioDocument = try AudioFileDocument(url: audioURL)
+            isFilesExporterPresented = true
+        } catch {
+            filesExportStatus = "Files export failed"
+        }
+    }
+
+    private static let dateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .short
+        return formatter
+    }()
+}
+
+private struct DictationAudioMissingView: View {
+    var body: some View {
+        VStack(spacing: MuesliTheme.spacing12) {
+            Image(systemName: "waveform.slash")
+                .font(.system(size: 28, weight: .semibold))
+                .foregroundStyle(MuesliTheme.textTertiary)
+            Text("Recording unavailable")
+                .font(MuesliTheme.title3())
+                .foregroundStyle(MuesliTheme.textPrimary)
+            Text("This dictation either was not saved with audio or its local audio file has been removed.")
+                .font(MuesliTheme.body())
+                .foregroundStyle(MuesliTheme.textSecondary)
+                .multilineTextAlignment(.center)
+        }
+        .padding(MuesliTheme.spacing24)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(MuesliTheme.backgroundBase)
+    }
+}
+
+private struct AudioFileDocument: FileDocument {
+    static let contentType = UTType(filenameExtension: "wav") ?? .audio
+    static var readableContentTypes: [UTType] { [contentType] }
+
+    private var data: Data
+
+    init(url: URL) throws {
+        data = try Data(contentsOf: url)
+    }
+
+    init(configuration: ReadConfiguration) throws {
+        data = configuration.file.regularFileContents ?? Data()
+    }
+
+    func fileWrapper(configuration: WriteConfiguration) throws -> FileWrapper {
+        FileWrapper(regularFileWithContents: data)
+    }
 }
 
 private struct DictationOriginChip: View {

--- a/Muesli/Info.plist
+++ b/Muesli/Info.plist
@@ -35,6 +35,8 @@
 	<string>public.app-category.productivity</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
+	<key>LSSupportsOpeningDocumentsInPlace</key>
+	<true/>
 	<key>MuesliTelemetryDeckAppID</key>
 	<string>$(MUESLI_TELEMETRYDECK_APP_ID)</string>
 	<key>NSMicrophoneUsageDescription</key>
@@ -49,6 +51,8 @@
 	<array>
 		<string>audio</string>
 	</array>
+	<key>UIFileSharingEnabled</key>
+	<true/>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/Muesli/MeetingsView.swift
+++ b/Muesli/MeetingsView.swift
@@ -915,16 +915,17 @@ private struct MeetingTranscriptContent: View {
     }
 }
 
-private struct SavedAudioPlayerView: View {
+struct SavedAudioPlayerView: View {
     let audioURL: URL
 
     @State private var player: AVAudioPlayer?
     @State private var isPlaying = false
     @State private var currentTime: TimeInterval = 0
     @State private var duration: TimeInterval = 0
-    @State private var samples: [CGFloat] = AudioWaveformSampler.placeholderSamples(count: 36)
+    @State private var samples: [CGFloat] = AudioWaveformSampler.placeholderSamples(count: waveformSampleCount)
     @State private var playbackError: String?
 
+    private static let waveformSampleCount = 72
     private let timer = Timer.publish(every: 0.2, on: .main, in: .common).autoconnect()
 
     var body: some View {
@@ -981,8 +982,13 @@ private struct SavedAudioPlayerView: View {
             }
         }
         .task(id: audioURL) {
-            samples = await AudioWaveformSampler.samples(from: audioURL, count: 36)
+            samples = await AudioWaveformSampler.samples(from: audioURL, count: Self.waveformSampleCount)
             preparePlayer()
+        }
+        .onAppear {
+            if player == nil {
+                preparePlayer()
+            }
         }
         .onReceive(timer) { _ in
             guard let player else { return }
@@ -990,20 +996,20 @@ private struct SavedAudioPlayerView: View {
             if !player.isPlaying, isPlaying {
                 isPlaying = false
                 if currentTime >= max(duration - 0.2, 0) {
-                    currentTime = duration
+                    resetPlayback()
                 }
             }
         }
         .onDisappear {
-            player?.stop()
-            isPlaying = false
+            resetPlayback()
+            player = nil
         }
     }
 
     private var waveform: some View {
         GeometryReader { geometry in
-            let spacing: CGFloat = 3
-            let barWidth = max(2, (geometry.size.width - spacing * CGFloat(samples.count - 1)) / CGFloat(samples.count))
+            let spacing: CGFloat = 2
+            let barWidth = max(1.2, (geometry.size.width - spacing * CGFloat(samples.count - 1)) / CGFloat(samples.count))
             let progress = duration > 0 ? min(max(currentTime / duration, 0), 1) : 0
 
             HStack(alignment: .center, spacing: spacing) {
@@ -1059,7 +1065,7 @@ private struct SavedAudioPlayerView: View {
             player.pause()
             isPlaying = false
         } else {
-            if currentTime >= duration {
+            if currentTime >= max(duration - 0.2, 0) {
                 player.currentTime = 0
                 currentTime = 0
             }
@@ -1072,6 +1078,13 @@ private struct SavedAudioPlayerView: View {
         guard let player else { return }
         player.stop()
         player.currentTime = 0
+        currentTime = 0
+        isPlaying = false
+    }
+
+    private func resetPlayback() {
+        player?.stop()
+        player?.currentTime = 0
         currentTime = 0
         isPlaying = false
     }
@@ -1098,14 +1111,16 @@ private struct SavedAudioPlayerView: View {
     }
 }
 
-private struct SavedAudioWaveformView: View {
+struct SavedAudioWaveformView: View {
     let audioURL: URL
-    @State private var samples: [CGFloat] = AudioWaveformSampler.placeholderSamples(count: 36)
+    @State private var samples: [CGFloat] = AudioWaveformSampler.placeholderSamples(count: waveformSampleCount)
+
+    private static let waveformSampleCount = 72
 
     var body: some View {
         GeometryReader { geometry in
-            let spacing: CGFloat = 3
-            let barWidth = max(2, (geometry.size.width - spacing * CGFloat(samples.count - 1)) / CGFloat(samples.count))
+            let spacing: CGFloat = 2
+            let barWidth = max(1.2, (geometry.size.width - spacing * CGFloat(samples.count - 1)) / CGFloat(samples.count))
             HStack(alignment: .center, spacing: spacing) {
                 ForEach(Array(samples.enumerated()), id: \.offset) { _, sample in
                     RoundedRectangle(cornerRadius: barWidth / 2, style: .continuous)
@@ -1119,12 +1134,12 @@ private struct SavedAudioWaveformView: View {
             .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
         .task(id: audioURL) {
-            samples = await AudioWaveformSampler.samples(from: audioURL, count: 36)
+            samples = await AudioWaveformSampler.samples(from: audioURL, count: Self.waveformSampleCount)
         }
     }
 }
 
-private enum AudioWaveformSampler {
+enum AudioWaveformSampler {
     static func placeholderSamples(count: Int) -> [CGFloat] {
         let preset: [CGFloat] = [0.24, 0.38, 0.56, 0.78, 0.62, 0.34, 0.46, 0.84, 0.70, 0.42, 0.28, 0.52]
         return (0..<count).map { preset[$0 % preset.count] }

--- a/Muesli/MuesliPreferences.swift
+++ b/Muesli/MuesliPreferences.swift
@@ -10,6 +10,7 @@ enum MuesliPreferences {
     static let fillerWordRemovalKey = "muesli.transcription.fillerWordRemoval"
     static let customDictionaryKey = "muesli.transcription.customDictionary"
     static let transcriptionModelKey = "muesli.transcription.localModel"
+    static let keepDictationAudioRecordingsKey = "muesli.dictations.keepAudioRecordings"
     static let keepMeetingAudioRecordingsKey = "muesli.meetings.keepAudioRecordings"
     static let meetingSummariesEnabledKey = "muesli.meetings.summaries.enabled"
     static let meetingSummaryBackendKey = "muesli.meetings.summary.backend"
@@ -60,6 +61,10 @@ enum MuesliPreferences {
         LocalTranscriptionModel(
             rawValue: UserDefaults.standard.string(forKey: transcriptionModelKey) ?? ""
         ) ?? .defaultModel
+    }
+
+    static var keepDictationAudioRecordingsEnabled: Bool {
+        bool(for: keepDictationAudioRecordingsKey, defaultValue: false)
     }
 
     static var keepMeetingAudioRecordingsEnabled: Bool {

--- a/Muesli/RootView.swift
+++ b/Muesli/RootView.swift
@@ -104,7 +104,6 @@ struct RootView: View {
                     )
                 }
                 .contentShape(Rectangle())
-                .simultaneousGesture(drawerSwipeGesture)
             }
         }
     }
@@ -128,21 +127,6 @@ struct RootView: View {
                 selectedSection = section
             }
         }
-    }
-
-    private var drawerSwipeGesture: some Gesture {
-        DragGesture(minimumDistance: 18, coordinateSpace: .local)
-            .onEnded { value in
-                let horizontalMovement = value.translation.width
-                let verticalMovement = abs(value.translation.height)
-                guard abs(horizontalMovement) > verticalMovement * 1.6 else { return }
-
-                if !isDrawerOpen, horizontalMovement > 78 {
-                    openDrawer()
-                } else if isDrawerOpen, horizontalMovement < -72 {
-                    closeDrawer()
-                }
-            }
     }
 
     private func openDrawer() {

--- a/Muesli/SettingsView.swift
+++ b/Muesli/SettingsView.swift
@@ -12,6 +12,7 @@ struct SettingsView: View {
     @AppStorage(MuesliPreferences.liveActivitiesForMeetingsKey) private var liveActivitiesForMeetings = true
     @AppStorage(MuesliPreferences.keyboardSessionModeKey) private var keyboardSessionMode = false
     @AppStorage(MuesliPreferences.keyboardSessionTimeoutMinutesKey) private var keyboardSessionTimeoutMinutes = 10
+    @AppStorage(MuesliPreferences.keepDictationAudioRecordingsKey) private var keepDictationAudioRecordings = false
     @AppStorage(MuesliPreferences.keepMeetingAudioRecordingsKey) private var keepMeetingAudioRecordings = false
     @AppStorage(MuesliPreferences.meetingSummariesEnabledKey) private var meetingSummariesEnabled = false
     @AppStorage(MuesliPreferences.meetingSummaryBackendKey) private var meetingSummaryBackend = MeetingSummaryBackend.openRouter.rawValue
@@ -245,10 +246,10 @@ struct SettingsView: View {
         VStack(alignment: .leading, spacing: MuesliTheme.spacing16) {
             MuesliSurface {
                 VStack(alignment: .leading, spacing: MuesliTheme.spacing12) {
-                    SettingsRow(icon: "keyboard", title: "Keyboard", value: keyboardStatusText)
+                    SettingsRow(icon: "keyboard", title: "Keyboard Extension", value: keyboardStatusText)
                     Link(destination: URL(string: UIApplication.openSettingsURLString)!) {
                         HStack {
-                            Text("Open Keyboard Settings")
+                            Text("Open iOS Keyboard Settings")
                             Spacer()
                             Image(systemName: "arrow.up.right")
                         }
@@ -264,8 +265,8 @@ struct SettingsView: View {
                 VStack(alignment: .leading, spacing: MuesliTheme.spacing12) {
                     SettingsToggleRow(
                         icon: "keyboard.badge.ellipsis",
-                        title: "Keyboard Session Mode",
-                        detail: "Keep Muesli ready for keyboard dictation with a visible microphone session.",
+                        title: "Dictation Session Mode",
+                        detail: "Keep Muesli ready for longer dictations from the keyboard with a visible microphone session.",
                         isOn: $keyboardSessionMode
                     )
                     Divider().overlay(MuesliTheme.surfaceBorder)
@@ -289,6 +290,13 @@ struct SettingsView: View {
                         title: "Dictation Live Activities",
                         detail: "Show keyboard and in-app dictation progress on the Dynamic Island and Lock Screen.",
                         isOn: $liveActivitiesForDictations
+                    )
+                    Divider().overlay(MuesliTheme.surfaceBorder)
+                    SettingsToggleRow(
+                        icon: "waveform.circle",
+                        title: "Save Dictation Audio",
+                        detail: "Keep original dictation audio locally on this iPhone for playback and troubleshooting. Audio does not sync.",
+                        isOn: $keepDictationAudioRecordings
                     )
                 }
                 .padding(MuesliTheme.spacing16)
@@ -684,11 +692,11 @@ private enum SettingsSection: String, CaseIterable, Identifiable {
     var title: String {
         switch self {
         case .general:
-            "General"
+            "Status"
         case .appearance:
             "Appearance"
         case .input:
-            "Keyboard"
+            "Dictations"
         case .dictionary:
             "Dictionary"
         case .meetings:
@@ -705,11 +713,11 @@ private enum SettingsSection: String, CaseIterable, Identifiable {
     var detail: String {
         switch self {
         case .general:
-            "App-wide behavior and local data defaults."
+            "Current local processing and storage state."
         case .appearance:
             "Color theme, light and dark mode, and app accent."
         case .input:
-            "Keyboard setup, dictation sessions, and text-field input."
+            "Recording retention, live activities, keyboard setup, and dictation sessions."
         case .dictionary:
             "Filler word removal, custom phrases, names, and acronyms."
         case .meetings:

--- a/Shared/MuesliSwipeActionRow.swift
+++ b/Shared/MuesliSwipeActionRow.swift
@@ -1,5 +1,4 @@
 import SwiftUI
-import UIKit
 
 struct MuesliSwipeActionRow<Content: View>: View {
     struct Action {
@@ -13,11 +12,6 @@ struct MuesliSwipeActionRow<Content: View>: View {
     private let trailingAction: Action?
     private let content: Content
 
-    @State private var offset: CGFloat = 0
-
-    private let actionWidth: CGFloat = 96
-    private let revealThreshold: CGFloat = 44
-
     init(
         leadingAction: Action? = nil,
         trailingAction: Action? = nil,
@@ -29,90 +23,28 @@ struct MuesliSwipeActionRow<Content: View>: View {
     }
 
     var body: some View {
-        ZStack {
-            actionBackground
-
-            content
-                .offset(x: offset)
-                .gesture(
-                    DragGesture(minimumDistance: 18)
-                        .onChanged(updateOffset)
-                        .onEnded(resolveOffset)
-                )
-        }
-        .contentShape(Rectangle())
+        content
+            .contentShape(Rectangle())
+            .contextMenu {
+                if let trailingAction {
+                    contextMenuButton(for: trailingAction)
+                }
+                if let leadingAction {
+                    contextMenuButton(for: leadingAction)
+                }
+            }
     }
 
-    private var actionBackground: some View {
-        HStack(spacing: 0) {
-            if let leadingAction {
-                actionButton(leadingAction)
-                    .frame(width: actionWidth)
+    @ViewBuilder
+    private func contextMenuButton(for action: Action) -> some View {
+        if action.title.lowercased() == "delete" {
+            Button(role: .destructive, action: action.perform) {
+                Label(action.title, systemImage: action.systemImage)
             }
-
-            Spacer(minLength: 0)
-
-            if let trailingAction {
-                actionButton(trailingAction)
-                    .frame(width: actionWidth)
-            }
-        }
-    }
-
-    private func actionButton(_ action: Action) -> some View {
-        Button {
-            UIImpactFeedbackGenerator(style: .medium).impactOccurred()
-            withAnimation(.spring(response: 0.28, dampingFraction: 0.86)) {
-                offset = 0
-            }
-            action.perform()
-        } label: {
-            VStack(spacing: MuesliTheme.spacing4) {
-                Image(systemName: action.systemImage)
-                    .font(.system(size: 18, weight: .semibold))
-                Text(action.title)
-                    .font(MuesliTheme.captionMedium())
-            }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .foregroundStyle(.white)
-            .background(action.tint)
-            .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerLarge))
-            .contentShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerLarge))
-        }
-        .buttonStyle(.plain)
-        .accessibilityLabel(action.title)
-    }
-
-    private func updateOffset(_ value: DragGesture.Value) {
-        let translation = value.translation.width
-        let allowsLeading = leadingAction != nil
-        let allowsTrailing = trailingAction != nil
-
-        let clamped: CGFloat
-        if translation > 0, allowsLeading {
-            clamped = min(translation, actionWidth)
-        } else if translation < 0, allowsTrailing {
-            clamped = max(translation, -actionWidth)
         } else {
-            clamped = 0
-        }
-
-        offset = clamped
-    }
-
-    private func resolveOffset(_ value: DragGesture.Value) {
-        let translation = value.translation.width
-        let target: CGFloat
-        if translation > revealThreshold, leadingAction != nil {
-            target = actionWidth
-        } else if translation < -revealThreshold, trailingAction != nil {
-            target = -actionWidth
-        } else {
-            target = 0
-        }
-
-        withAnimation(.spring(response: 0.28, dampingFraction: 0.86)) {
-            offset = target
+            Button(action: action.perform) {
+                Label(action.title, systemImage: action.systemImage)
+            }
         }
     }
 }

--- a/Shared/SharedStore.swift
+++ b/Shared/SharedStore.swift
@@ -201,6 +201,11 @@ struct SharedStore: Sendable {
         return try audioFileURL(fileName: fileName)
     }
 
+    func newDictationAudioFileURL(startedAt: Date) throws -> URL {
+        let fileName = audioFileName(prefix: "dictation", date: startedAt)
+        return try uniqueAudioFileURL(fileName: fileName)
+    }
+
     func audioFileURL(fileName: String) throws -> URL {
         let directory = try recordingsDirectoryURL()
         return directory.appendingPathComponent(fileName)
@@ -208,12 +213,55 @@ struct SharedStore: Sendable {
 
     func deleteAudioFile(fileName: String) throws {
         let url = try audioFileURL(fileName: fileName)
-        guard FileManager.default.fileExists(atPath: url.path) else { return }
-        try FileManager.default.removeItem(at: url)
+        if FileManager.default.fileExists(atPath: url.path) {
+            try FileManager.default.removeItem(at: url)
+        }
+        try? deleteExportedAudioFile(fileName: fileName)
+    }
+
+    @discardableResult
+    func exportAudioFileToDocuments(fileName: String) throws -> URL {
+        let sourceURL = try audioFileURL(fileName: fileName)
+        let destinationURL = try exportedRecordingsDirectoryURL().appendingPathComponent(fileName)
+
+        if FileManager.default.fileExists(atPath: destinationURL.path) {
+            try FileManager.default.removeItem(at: destinationURL)
+        }
+        try FileManager.default.copyItem(at: sourceURL, to: destinationURL)
+        return destinationURL
     }
 
     func audioFileName(sessionID: UUID) -> String {
         "session-\(sessionID.uuidString).wav"
+    }
+
+    func audioFileName(prefix: String, date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.calendar = Calendar(identifier: .gregorian)
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = .current
+        formatter.dateFormat = "yyyyMMdd-HHmmss"
+        return "\(prefix)-\(formatter.string(from: date)).wav"
+    }
+
+    private func uniqueAudioFileURL(fileName: String) throws -> URL {
+        let directory = try recordingsDirectoryURL()
+        let proposedURL = directory.appendingPathComponent(fileName)
+        guard FileManager.default.fileExists(atPath: proposedURL.path) else {
+            return proposedURL
+        }
+
+        let baseName = proposedURL.deletingPathExtension().lastPathComponent
+        let pathExtension = proposedURL.pathExtension
+        for suffix in 1...999 {
+            let candidateName = "\(baseName)-\(suffix).\(pathExtension)"
+            let candidateURL = directory.appendingPathComponent(candidateName)
+            if !FileManager.default.fileExists(atPath: candidateURL.path) {
+                return candidateURL
+            }
+        }
+
+        return directory.appendingPathComponent("\(baseName)-\(UUID().uuidString).\(pathExtension)")
     }
 
     private func database() throws -> SharedStoreDatabase {
@@ -224,6 +272,22 @@ struct SharedStore: Sendable {
         let directory = try containerURL().appendingPathComponent("Recordings", isDirectory: true)
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
         return directory
+    }
+
+    private func exportedRecordingsDirectoryURL() throws -> URL {
+        guard let documentsURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first else {
+            throw SharedStoreError.appGroupUnavailable("Documents")
+        }
+
+        let directory = documentsURL.appendingPathComponent("Muesli Recordings", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        return directory
+    }
+
+    private func deleteExportedAudioFile(fileName: String) throws {
+        let url = try exportedRecordingsDirectoryURL().appendingPathComponent(fileName)
+        guard FileManager.default.fileExists(atPath: url.path) else { return }
+        try FileManager.default.removeItem(at: url)
     }
 
     private func containerURL() throws -> URL {
@@ -1378,12 +1442,26 @@ private struct SharedStoreDatabase {
             return
         }
 
-        let resultID = UUID(uuidString: record.id) ?? UUID()
-        let requestID = resultID
+        let existingLink = try queryRows(
+            "SELECT id, request_id, session_id FROM result_history WHERE cloud_record_name = ? LIMIT 1",
+            db: db
+        ) { statement in
+            try bind(record.id, to: statement, at: 1)
+        } read: { statement in
+            (
+                id: sqliteColumnString(statement, 0),
+                requestID: sqliteColumnString(statement, 1),
+                sessionID: sqliteColumnString(statement, 2)
+            )
+        }.first ?? nil
+
+        let resultID = existingLink?.id.flatMap(UUID.init(uuidString:)) ?? UUID(uuidString: record.id) ?? UUID()
+        let requestID = existingLink?.requestID.flatMap(UUID.init(uuidString:)) ?? resultID
+        let sessionID = existingLink?.sessionID.flatMap(UUID.init(uuidString:))
         let result = DictationResult(
             id: resultID,
             requestID: requestID,
-            sessionID: nil,
+            sessionID: sessionID,
             text: record.text,
             createdAt: record.createdAt,
             engineIdentifier: record.engineIdentifier ?? "icloud",
@@ -1395,10 +1473,11 @@ private struct SharedStoreDatabase {
                 id, request_id, session_id, text, engine_identifier, created_at, updated_at,
                 deleted_at, cloud_record_name, cloud_change_tag, last_synced_at, sync_dirty, payload
             )
-            VALUES (?, ?, NULL, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?)
             ON CONFLICT(cloud_record_name) DO UPDATE SET
                 id = excluded.id,
                 request_id = excluded.request_id,
+                session_id = COALESCE(result_history.session_id, excluded.session_id),
                 text = excluded.text,
                 engine_identifier = excluded.engine_identifier,
                 created_at = excluded.created_at,
@@ -1414,15 +1493,16 @@ private struct SharedStoreDatabase {
         ) { statement in
             try bind(resultID.uuidString, to: statement, at: 1)
             try bind(requestID.uuidString, to: statement, at: 2)
-            try bind(record.text, to: statement, at: 3)
-            try bind(record.engineIdentifier ?? "icloud", to: statement, at: 4)
-            try bind(record.createdAt.timeIntervalSince1970, to: statement, at: 5)
-            try bind(record.updatedAt.timeIntervalSince1970, to: statement, at: 6)
-            try bind(record.isDeleted ? record.updatedAt.timeIntervalSince1970 : nil, to: statement, at: 7)
-            try bind(record.id, to: statement, at: 8)
-            try bind(record.cloudChangeTag, to: statement, at: 9)
-            try bind(Date().timeIntervalSince1970, to: statement, at: 10)
-            try bind(try encoder.encode(result), to: statement, at: 11)
+            try bind(sessionID?.uuidString, to: statement, at: 3)
+            try bind(record.text, to: statement, at: 4)
+            try bind(record.engineIdentifier ?? "icloud", to: statement, at: 5)
+            try bind(record.createdAt.timeIntervalSince1970, to: statement, at: 6)
+            try bind(record.updatedAt.timeIntervalSince1970, to: statement, at: 7)
+            try bind(record.isDeleted ? record.updatedAt.timeIntervalSince1970 : nil, to: statement, at: 8)
+            try bind(record.id, to: statement, at: 9)
+            try bind(record.cloudChangeTag, to: statement, at: 10)
+            try bind(Date().timeIntervalSince1970, to: statement, at: 11)
+            try bind(try encoder.encode(result), to: statement, at: 12)
         }
     }
 

--- a/Tests/MuesliTests/SharedStoreTests.swift
+++ b/Tests/MuesliTests/SharedStoreTests.swift
@@ -316,6 +316,52 @@ final class SharedStoreTests: XCTestCase {
         XCTAssertGreaterThan(try sqliteDouble("SELECT updated_at FROM result_history LIMIT 1", in: directory), 0)
     }
 
+    func testSyncedDictationPreservesLocalSessionLink() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let store = SharedStore(containerURL: directory)
+        let resultID = UUID()
+        let requestID = UUID()
+        let sessionID = UUID()
+        let result = DictationResult(
+            id: resultID,
+            requestID: requestID,
+            sessionID: sessionID,
+            text: "local text",
+            createdAt: Date(timeIntervalSince1970: 100),
+            engineIdentifier: "parakeet-v3"
+        )
+        try store.saveResult(result)
+
+        try store.upsertSyncedTextRecord(SyncTextRecord(
+            id: resultID.uuidString,
+            kind: .dictation,
+            title: nil,
+            text: "synced text",
+            speakerTranscript: nil,
+            summaryText: nil,
+            manualNotes: nil,
+            source: "ios",
+            engineIdentifier: "parakeet-v3",
+            createdAt: Date(timeIntervalSince1970: 100),
+            updatedAt: Date(timeIntervalSinceNow: 60),
+            startedAt: nil,
+            endedAt: nil,
+            durationSeconds: 0,
+            wordCount: 2,
+            isDeleted: false,
+            cloudChangeTag: "server-tag"
+        ))
+
+        let synced = try XCTUnwrap(store.resultsHistory().first)
+        XCTAssertEqual(synced.id, resultID)
+        XCTAssertEqual(synced.requestID, requestID)
+        XCTAssertEqual(synced.sessionID, sessionID)
+        XCTAssertEqual(synced.text, "synced text")
+        XCTAssertEqual(try sqliteString("SELECT session_id FROM result_history LIMIT 1", in: directory), sessionID.uuidString)
+    }
+
     func testPendingCommandRoundTripsAndClears() throws {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent("muesli-store-\(UUID().uuidString)", isDirectory: true)
@@ -528,6 +574,27 @@ final class SharedStoreTests: XCTestCase {
         try store.deleteAudioFile(fileName: "session.wav")
 
         XCTAssertFalse(FileManager.default.fileExists(atPath: url.path))
+    }
+
+    func testDictationAudioFileNameUsesTimestamp() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let store = SharedStore(containerURL: directory)
+        var components = DateComponents()
+        components.calendar = Calendar(identifier: .gregorian)
+        components.timeZone = .current
+        components.year = 2026
+        components.month = 6
+        components.day = 21
+        components.hour = 9
+        components.minute = 7
+        components.second = 5
+        let date = try XCTUnwrap(components.date)
+
+        let url = try store.newDictationAudioFileURL(startedAt: date)
+
+        XCTAssertEqual(url.lastPathComponent, "dictation-20260621-090705.wav")
     }
 
     func testTranscriptReplacesExistingTranscriptForSession() throws {


### PR DESCRIPTION
## Summary

Adds opt-in retained audio for iPhone dictations and playback from dictation history.

## What changed

- Added a Settings toggle for saving dictation audio locally on device.
- Stores retained dictation audio as timestamped `.wav` files and keeps synced text separate from local audio provenance.
- Adds playback detail UI for retained local dictation audio with denser waveform rendering.
- Adds Share and Save to Files export flows for saved recordings.
- Adds deterministic playback eligibility based on explicit local `sessionID` linkage.
- Preserves local session links when text sync updates a dictation row.
- Replaces custom swipe-row gestures with native long-press context menu actions for Copy/Delete.
- Adds elapsed recording timer in the dictation card header.

## Validation

- `git diff --check`
- `xcodebuild -quiet test -project MuesliiOS.xcodeproj -scheme Muesli -destination 'platform=iOS Simulator,name=iPhone 17' CODE_SIGNING_ALLOWED=NO`
- `xcodebuild -quiet build -project MuesliiOS.xcodeproj -scheme Muesli -destination 'platform=iOS,id=00008140-001C6D2C11FA801C'`
- Installed and launched on picophone via `xcrun devicectl`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli-ios/pr/6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784660495&installation_id=136549638&pr_number=6&repository=Muesli-HQ%2Fmuesli-ios&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli-ios%2Fpull%2F6&signature=d33adb579a89d19a91ff0fcff8e432d023cbfca5e53f579eac78787cf50b98f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/muesli-hq/muesli-ios/pull/6" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->