### PR TITLE
[codex] Polish model picker and onboarding permissions

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -39,8 +39,8 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
-          use_sticky_comment: true
+          use_sticky_comment: false
           display_report: true
-          show_full_output: false
+          show_full_output: true
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -23,6 +23,8 @@ jobs:
       contents: read
       pull-requests: write
       issues: write
+      checks: write
+      actions: read
       id-token: write
 
     steps:
@@ -39,8 +41,13 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
-          use_sticky_comment: false
+          additional_permissions: |
+            pull_requests: write
+            issues: write
+            checks: write
+            actions: read
+          use_sticky_comment: true
+          track_progress: true
           display_report: true
-          show_full_output: true
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options

--- a/Muesli/ModelsView.swift
+++ b/Muesli/ModelsView.swift
@@ -62,17 +62,10 @@ struct ModelsView: View {
                         .clipShape(Capsule())
                 }
 
-                Picker("Transcription Model", selection: $coordinator.selectedTranscriptionModel) {
-                    ForEach(LocalTranscriptionModel.allCases) { model in
-                        Text(model.displayName).tag(model)
-                    }
-                }
-                .pickerStyle(.menu)
-
-                Text(coordinator.selectedTranscriptionModel.detail)
-                    .font(MuesliTheme.callout())
-                    .foregroundStyle(MuesliTheme.textSecondary)
-                    .fixedSize(horizontal: false, vertical: true)
+                TranscriptionModelSelector(
+                    selection: $coordinator.selectedTranscriptionModel,
+                    showsHeader: false
+                )
 
                 VStack(alignment: .leading, spacing: MuesliTheme.spacing8) {
                     Text(coordinator.modelPreparation.status)

--- a/Muesli/OnboardingView.swift
+++ b/Muesli/OnboardingView.swift
@@ -21,7 +21,7 @@ struct OnboardingView: View {
     ) ?? .profile
     @State private var nameDraft = ""
     @State private var useCaseDraft: OnboardingUseCase = .keyboardDictation
-    @State private var microphoneGranted = false
+    @State private var microphoneAuthorizationStatus = AVCaptureDevice.authorizationStatus(for: .audio)
     @State private var keyboardEnabledConfirmed = UserDefaults.standard.bool(
         forKey: OnboardingPreferenceKeys.keyboardEnabledConfirmed
     )
@@ -286,11 +286,15 @@ struct OnboardingView: View {
             permissionRow(
                 icon: "mic.fill",
                 title: "Microphone",
-                detail: "Record speech for local transcription",
+                detail: microphonePermissionDetail,
                 isComplete: microphoneGranted,
-                buttonTitle: microphoneGranted ? "Granted" : "Grant"
+                buttonTitle: microphonePermissionButtonTitle
             ) {
-                requestMicrophonePermission()
+                if microphonePermissionNeedsSettings {
+                    openAppSettings()
+                } else {
+                    requestMicrophonePermission()
+                }
             }
 
             if useCaseDraft.needsKeyboardSetup {
@@ -388,7 +392,8 @@ struct OnboardingView: View {
                     Text(detail)
                         .font(MuesliTheme.caption())
                         .foregroundStyle(MuesliTheme.textTertiary)
-                        .lineLimit(2)
+                        .lineLimit(3)
+                        .fixedSize(horizontal: false, vertical: true)
                 }
 
                 Spacer()
@@ -577,49 +582,9 @@ struct OnboardingView: View {
 
     private var modelPicker: some View {
         MuesliSurface(cornerRadius: MuesliTheme.cornerLarge) {
-            VStack(alignment: .leading, spacing: MuesliTheme.spacing12) {
-                HStack(spacing: MuesliTheme.spacing12) {
-                    Image(systemName: "cpu")
-                        .font(.system(size: 18, weight: .semibold))
-                        .foregroundStyle(MuesliTheme.accent)
-                        .frame(width: 30)
-                    VStack(alignment: .leading, spacing: MuesliTheme.spacing4) {
-                        Text("Transcription Model")
-                            .font(MuesliTheme.headline())
-                            .foregroundStyle(MuesliTheme.textPrimary)
-                        Text(coordinator.selectedTranscriptionModel.detail)
-                            .font(MuesliTheme.caption())
-                            .foregroundStyle(MuesliTheme.textSecondary)
-                            .fixedSize(horizontal: false, vertical: true)
-                    }
-                    Spacer()
-                }
-
-                Picker("Transcription Model", selection: $coordinator.selectedTranscriptionModel) {
-                    ForEach(LocalTranscriptionModel.allCases) { model in
-                        Text(model.displayName).tag(model)
-                    }
-                }
-                .pickerStyle(.menu)
-                .frame(maxWidth: .infinity, alignment: .leading)
-
-                HStack(spacing: MuesliTheme.spacing8) {
-                    modelBadge(coordinator.selectedTranscriptionModel.capabilityLabel, icon: "textformat")
-                    modelBadge(coordinator.selectedTranscriptionModel.estimatedSizeLabel, icon: "internaldrive")
-                }
-            }
+            TranscriptionModelSelector(selection: $coordinator.selectedTranscriptionModel)
             .padding(MuesliTheme.spacing16)
         }
-    }
-
-    private func modelBadge(_ text: String, icon: String) -> some View {
-        Label(text, systemImage: icon)
-            .font(MuesliTheme.captionMedium())
-            .foregroundStyle(MuesliTheme.accent)
-            .padding(.horizontal, MuesliTheme.spacing8)
-            .padding(.vertical, MuesliTheme.spacing4)
-            .background(MuesliTheme.accent.opacity(0.12))
-            .clipShape(Capsule())
     }
 
     private var modelPanel: some View {
@@ -1016,6 +981,49 @@ struct OnboardingView: View {
         }
     }
 
+    private var microphoneGranted: Bool {
+        microphoneAuthorizationStatus == .authorized
+    }
+
+    private var microphonePermissionNeedsSettings: Bool {
+        switch microphoneAuthorizationStatus {
+        case .denied, .restricted:
+            true
+        case .authorized, .notDetermined:
+            false
+        @unknown default:
+            false
+        }
+    }
+
+    private var microphonePermissionDetail: String {
+        switch microphoneAuthorizationStatus {
+        case .authorized:
+            "Microphone access is enabled."
+        case .denied:
+            "Microphone access was denied. Open iOS Settings to enable recording."
+        case .restricted:
+            "Microphone access is restricted on this iPhone. Check iOS Settings."
+        case .notDetermined:
+            "Record speech for local transcription."
+        @unknown default:
+            "Check microphone access before continuing."
+        }
+    }
+
+    private var microphonePermissionButtonTitle: String {
+        switch microphoneAuthorizationStatus {
+        case .authorized:
+            "Granted"
+        case .denied, .restricted:
+            "Open Settings"
+        case .notDetermined:
+            "Grant"
+        @unknown default:
+            "Check"
+        }
+    }
+
     private var isLastStep: Bool {
         currentStep.position(in: orderedSteps) == orderedSteps.count - 1
     }
@@ -1093,7 +1101,7 @@ struct OnboardingView: View {
     }
 
     private func refreshMicrophoneStatus() {
-        microphoneGranted = AVCaptureDevice.authorizationStatus(for: .audio) == .authorized
+        microphoneAuthorizationStatus = AVCaptureDevice.authorizationStatus(for: .audio)
     }
 
     private func refreshKeyboardPermissionStatus() {
@@ -1115,7 +1123,7 @@ struct OnboardingView: View {
     private func requestMicrophonePermission() {
         AVCaptureDevice.requestAccess(for: .audio) { granted in
             Task { @MainActor in
-                microphoneGranted = granted
+                microphoneAuthorizationStatus = AVCaptureDevice.authorizationStatus(for: .audio)
                 AppTelemetry.signal("onboarding_permission_result", parameters: [
                     "permission": "microphone",
                     "granted": granted ? "true" : "false"

--- a/Muesli/RootView.swift
+++ b/Muesli/RootView.swift
@@ -24,7 +24,6 @@ struct RootView: View {
         .background(MuesliTheme.backgroundBase)
         .tint(MuesliTheme.accent)
         .preferredColorScheme(preferredColorScheme)
-        .id("theme-\(appearanceMode)-\(accentTheme)")
         .onChange(of: coordinator.syncSetupRequestID) { _, requestID in
             guard requestID != nil else { return }
             if coordinator.hasCompletedOnboarding {

--- a/Muesli/RootView.swift
+++ b/Muesli/RootView.swift
@@ -22,7 +22,8 @@ struct RootView: View {
             }
         }
         .background(MuesliTheme.backgroundBase)
-        .tint(MuesliTheme.accent)
+        .tint(currentAccent)
+        .environment(\.muesliAccent, currentAccent)
         .preferredColorScheme(preferredColorScheme)
         .onChange(of: coordinator.syncSetupRequestID) { _, requestID in
             guard requestID != nil else { return }
@@ -31,6 +32,10 @@ struct RootView: View {
             }
             isDrawerOpen = false
         }
+    }
+
+    private var currentAccent: Color {
+        MuesliTheme.color(for: MuesliAccentTheme(rawValue: accentTheme) ?? .blue)
     }
 
     private var preferredColorScheme: ColorScheme? {
@@ -311,6 +316,7 @@ private struct MuesliSidebar: View {
 }
 
 private struct MuesliTabSwitcher: View {
+    @Environment(\.muesliAccent) private var accent
     @Binding var selectedSection: AppSection
     let pinnedSections: [AppSection]
 
@@ -324,7 +330,7 @@ private struct MuesliTabSwitcher: View {
                         .font(.system(size: 14, weight: .semibold))
                         .lineLimit(1)
                         .minimumScaleFactor(0.82)
-                    .foregroundStyle(selectedSection == section ? MuesliTheme.accent : MuesliTheme.textSecondary)
+                    .foregroundStyle(selectedSection == section ? accent : MuesliTheme.textSecondary)
                     .frame(maxWidth: .infinity)
                     .frame(height: 44)
                     .background(selectedSection == section ? MuesliTheme.surfaceSelected : Color.clear)
@@ -449,6 +455,7 @@ private struct MuesliDrawer: View {
 }
 
 private struct SidebarSectionRow: View {
+    @Environment(\.muesliAccent) private var accent
     let section: AppSection
     let isSelected: Bool
     let isPinned: Bool
@@ -472,7 +479,7 @@ private struct SidebarSectionRow: View {
                         .font(.system(size: 15, weight: .semibold))
                         .frame(width: 22)
                 }
-                .foregroundStyle(isSelected ? MuesliTheme.accent : MuesliTheme.textSecondary)
+                .foregroundStyle(isSelected ? accent : MuesliTheme.textSecondary)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .frame(height: 52)
                 .padding(.leading, MuesliTheme.spacing12)
@@ -485,9 +492,9 @@ private struct SidebarSectionRow: View {
             Button(action: onTogglePin) {
                 Image(systemName: isPinned ? "pin.fill" : "pin")
                     .font(.system(size: 13, weight: .semibold))
-                    .foregroundStyle(isPinned ? MuesliTheme.accent : MuesliTheme.textTertiary)
+                    .foregroundStyle(isPinned ? accent : MuesliTheme.textTertiary)
                     .frame(width: 36, height: 36)
-                    .background(isPinned ? MuesliTheme.accentSubtle : Color.clear)
+                    .background(isPinned ? accent.opacity(0.15) : Color.clear)
                     .clipShape(Circle())
                     .contentShape(Circle())
             }

--- a/Muesli/SettingsView.swift
+++ b/Muesli/SettingsView.swift
@@ -338,16 +338,7 @@ struct SettingsView: View {
                         valueColor: MuesliTheme.textSecondary
                     )
                     Divider().overlay(MuesliTheme.surfaceBorder)
-                    Picker("Transcription Model", selection: $coordinator.selectedTranscriptionModel) {
-                        ForEach(LocalTranscriptionModel.allCases) { model in
-                            Text(model.displayName).tag(model)
-                        }
-                    }
-                    .pickerStyle(.menu)
-                    Text(coordinator.selectedTranscriptionModel.detail)
-                        .font(MuesliTheme.callout())
-                        .foregroundStyle(MuesliTheme.textSecondary)
-                        .fixedSize(horizontal: false, vertical: true)
+                    TranscriptionModelSelector(selection: $coordinator.selectedTranscriptionModel)
                     Divider().overlay(MuesliTheme.surfaceBorder)
                     SettingsRow(icon: "cpu", title: "Runtime", value: "CoreML / ANE")
                     Divider().overlay(MuesliTheme.surfaceBorder)

--- a/Muesli/TranscriptionModelSelector.swift
+++ b/Muesli/TranscriptionModelSelector.swift
@@ -1,0 +1,176 @@
+import SwiftUI
+
+struct TranscriptionModelSelector: View {
+    @Binding var selection: LocalTranscriptionModel
+    var showsHeader = true
+
+    private let models = LocalTranscriptionModel.allCases
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: MuesliTheme.spacing12) {
+            if showsHeader {
+                HStack(alignment: .center, spacing: MuesliTheme.spacing12) {
+                    Image(systemName: "waveform.badge.magnifyingglass")
+                        .font(.system(size: 16, weight: .semibold))
+                        .foregroundStyle(MuesliTheme.accent)
+                        .frame(width: 28, height: 28)
+                        .background(MuesliTheme.accentSubtle)
+                        .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+
+                    VStack(alignment: .leading, spacing: MuesliTheme.spacing4) {
+                        Text("Choose model")
+                            .font(MuesliTheme.headline())
+                            .foregroundStyle(MuesliTheme.textPrimary)
+                        Text("Tap to switch local transcription model.")
+                            .font(MuesliTheme.caption())
+                            .foregroundStyle(MuesliTheme.textSecondary)
+                    }
+
+                    Spacer(minLength: MuesliTheme.spacing12)
+                }
+            }
+
+            Menu {
+                ForEach(models) { model in
+                    Button {
+                        withAnimation(.snappy(duration: 0.18)) {
+                            selection = model
+                        }
+                    } label: {
+                        Label(
+                            model.displayName,
+                            systemImage: selection == model ? "checkmark" : model.selectorIcon
+                        )
+                    }
+                }
+            } label: {
+                HStack(alignment: .center, spacing: MuesliTheme.spacing12) {
+                    Image(systemName: selection.selectorIcon)
+                        .font(.system(size: 16, weight: .semibold))
+                        .foregroundStyle(.white)
+                        .frame(width: 34, height: 34)
+                        .background(MuesliTheme.accent)
+                        .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+
+                    VStack(alignment: .leading, spacing: MuesliTheme.spacing4) {
+                        Text("Active model")
+                            .font(MuesliTheme.captionMedium())
+                            .foregroundStyle(MuesliTheme.textSecondary)
+                        Text(selection.displayName)
+                            .font(MuesliTheme.headline())
+                            .foregroundStyle(MuesliTheme.textPrimary)
+                            .lineLimit(1)
+                            .minimumScaleFactor(0.82)
+                    }
+
+                    Spacer(minLength: MuesliTheme.spacing8)
+
+                    Image(systemName: "chevron.up.chevron.down")
+                        .font(.system(size: 14, weight: .semibold))
+                        .foregroundStyle(MuesliTheme.accent)
+                }
+                .padding(MuesliTheme.spacing12)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(MuesliTheme.surfaceSelected.opacity(0.72))
+                .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+                .overlay(
+                    RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall)
+                        .strokeBorder(MuesliTheme.accent.opacity(0.34), lineWidth: 1)
+                )
+                .contentShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+            }
+            .menuOrder(.fixed)
+
+            SelectedTranscriptionModelDetails(model: selection)
+        }
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Transcription model")
+        .accessibilityValue(selection.displayName)
+    }
+}
+
+private struct SelectedTranscriptionModelDetails: View {
+    let model: LocalTranscriptionModel
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: MuesliTheme.spacing10) {
+            Text(model.detail)
+                .font(MuesliTheme.callout())
+                .foregroundStyle(MuesliTheme.textSecondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            ViewThatFits(in: .horizontal) {
+                HStack(spacing: MuesliTheme.spacing8) {
+                    ForEach(model.selectorBadges, id: \.label) { badge in
+                        TranscriptionModelBadge(icon: badge.icon, label: badge.label)
+                    }
+                }
+
+                VStack(alignment: .leading, spacing: MuesliTheme.spacing6) {
+                    ForEach(model.selectorBadges, id: \.label) { badge in
+                        TranscriptionModelBadge(icon: badge.icon, label: badge.label)
+                    }
+                }
+            }
+        }
+        .padding(MuesliTheme.spacing12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(MuesliTheme.surfacePrimary.opacity(0.34))
+        .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+        .overlay(
+            RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall)
+                .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
+        )
+    }
+}
+
+private struct TranscriptionModelBadge: View {
+    let icon: String
+    let label: String
+
+    var body: some View {
+        Label(label, systemImage: icon)
+            .font(MuesliTheme.captionMedium())
+            .foregroundStyle(MuesliTheme.textSecondary)
+            .labelStyle(.titleAndIcon)
+            .padding(.horizontal, MuesliTheme.spacing8)
+            .padding(.vertical, MuesliTheme.spacing4)
+            .background(MuesliTheme.backgroundRaised)
+            .clipShape(Capsule())
+            .overlay(
+                Capsule()
+                    .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
+            )
+    }
+}
+
+private extension MuesliTheme {
+    static let spacing6: CGFloat = 6
+    static let spacing10: CGFloat = 10
+}
+
+private extension LocalTranscriptionModel {
+    var selectorIcon: String {
+        switch self {
+        case .parakeetTdtCtc110m:
+            "bolt.fill"
+        case .parakeetRealtimeEou120m:
+            "dot.radiowaves.left.and.right"
+        case .parakeetV3:
+            "globe"
+        }
+    }
+
+    var selectorBadges: [(icon: String, label: String)] {
+        var badges: [(icon: String, label: String)] = [
+            ("textformat", capabilityLabel),
+            ("internaldrive", estimatedSizeLabel)
+        ]
+
+        if supportsRealtimeStreaming {
+            badges.insert(("waveform.path.ecg", "Streaming"), at: 0)
+        }
+
+        return badges
+    }
+}

--- a/Shared/MuesliTheme.swift
+++ b/Shared/MuesliTheme.swift
@@ -76,6 +76,17 @@ enum MuesliTheme {
     }
 }
 
+private struct MuesliAccentEnvironmentKey: EnvironmentKey {
+    static let defaultValue = MuesliTheme.accent
+}
+
+extension EnvironmentValues {
+    var muesliAccent: Color {
+        get { self[MuesliAccentEnvironmentKey.self] }
+        set { self[MuesliAccentEnvironmentKey.self] = newValue }
+    }
+}
+
 extension Color {
     init(hex: Int) {
         self.init(


### PR DESCRIPTION
## Summary
- replace the plain transcription model picker with a reusable polished dropdown that keeps selected model details visible
- reuse the selector in Settings, onboarding, and the Models screen
- stop remounting the root shell when Appearance settings change, so choosing an accent color does not pop the user back to Settings
- handle denied/restricted microphone permission during onboarding by showing an Open Settings recovery path

## Why
The old model picker was visually bare and repeated across surfaces. The Appearance page also remounted the root view on theme changes, which made accent selection feel broken. Onboarding treated microphone access as a Boolean, so users who denied mic permission could get stuck with a Grant button that could no longer present the system prompt.

## Validation
- `xcodebuild -project MuesliiOS.xcodeproj -scheme Muesli -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli-ios/pr/8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784940971&installation_id=136549638&pr_number=8&repository=Muesli-HQ%2Fmuesli-ios&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli-ios%2Fpull%2F8&signature=a74ee44940c755eb43d87b03c3f1ac1cba4271730491f75269fcc4dcfb378953"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a menu-based transcription model selector with an active model display and a details card featuring capability badges.
  * Updated onboarding, settings, and models screens to use the shared selector.

* **Bug Fixes**
  * Improved microphone permission handling by deriving the UI (granted state, guidance text, and primary action) from the current authorization status, including the correct “open Settings” behavior.
  * Refreshed microphone permission status after both status checks and permission requests.

* **Refactor**
  * Updated theme handling to avoid forcing view identity changes when appearance/accent changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->