### PR TITLE
Revamp iOS voice notes UI and onboarding

### DIFF
--- a/Muesli/DictationCoordinator.swift
+++ b/Muesli/DictationCoordinator.swift
@@ -33,6 +33,7 @@ final class DictationCoordinator {
     private var iCloudSyncTask: Task<Void, Never>?
     private var iCloudSyncDebounceTask: Task<Void, Never>?
     private var pendingICloudSyncReason: String?
+    private var onboardingModelReadyCueModel: LocalTranscriptionModel?
     private var meetingChunkTasks: [Task<MeetingChunkTranscription?, Never>] = []
     private var meetingChunkTranscriptions: [MeetingChunkTranscription] = []
     private var meetingChunksDirectory: URL?
@@ -122,6 +123,8 @@ final class DictationCoordinator {
     }
 
     init() {
+        ModelBackgroundDownloadService.shared.delegate = self
+
         #if DEBUG
         if Self.shouldConfigureForUITestingFromLaunchArguments() {
             configureForUITesting()
@@ -440,6 +443,37 @@ final class DictationCoordinator {
         }
     }
 
+    @discardableResult
+    func deleteDictationAudio(for result: DictationResult) -> Bool {
+        do {
+            guard var session = recordingSession(for: result),
+                  let audioFileName = session.audioFileName
+            else {
+                clipboardStatusText = "Audio already removed"
+                clearClipboardStatusSoon()
+                return true
+            }
+
+            try store.deleteAudioFile(fileName: audioFileName)
+            session.audioFileName = nil
+            session.keepsAudioRecording = false
+            try store.saveSession(session)
+
+            if let index = recordingSessions.firstIndex(where: { $0.id == session.id }) {
+                recordingSessions[index] = session
+            }
+
+            clipboardStatusText = "Audio deleted"
+            AppTelemetry.signal("dictation_audio_deleted")
+            clearClipboardStatusSoon()
+            return true
+        } catch {
+            clipboardStatusText = "Audio delete failed"
+            clearClipboardStatusSoon()
+            return false
+        }
+    }
+
     func deleteMeeting(_ session: RecordingSession) {
         do {
             if let audioFileName = session.audioFileName {
@@ -742,6 +776,13 @@ final class DictationCoordinator {
         modelPreparationTask = Task { [engine, model] in
             do {
                 await engine.selectModel(model)
+                let didStartBackgroundDownload = try await ModelBackgroundDownloadService.shared.startDownload(for: model)
+                if didStartBackgroundDownload {
+                    await MainActor.run {
+                        coordinator.modelPreparationTask = nil
+                    }
+                    return
+                }
                 try await engine.prepare { progress, status in
                     Task { @MainActor in
                         coordinator.applyModelPreparationProgress(progress, status: status)
@@ -756,6 +797,7 @@ final class DictationCoordinator {
                         status: "\(model.shortName) ready",
                         detail: model.detail
                     )
+                    coordinator.playOnboardingModelReadyCueIfNeeded(for: model)
                     AppTelemetry.signal("model_prepare_completed", parameters: ["engine": model.engineIdentifier])
                 }
             } catch is CancellationError {
@@ -944,6 +986,70 @@ final class DictationCoordinator {
                 : "Downloading \(selectedTranscriptionModel.shortName)",
             detail: detail
         )
+    }
+
+    private func prepareDownloadedModelAfterBackgroundDownload(_ model: LocalTranscriptionModel) {
+        guard selectedTranscriptionModel == model else { return }
+        guard modelPreparationTask == nil else { return }
+
+        modelPreparation = ModelPreparationState(
+            phase: .preparing,
+            progress: nil,
+            status: "Optimizing for this iPhone...",
+            detail: "Download complete"
+        )
+
+        let coordinator = self
+        modelPreparationTask = Task { [engine, model] in
+            do {
+                await engine.selectModel(model)
+                try await engine.prepare { progress, status in
+                    Task { @MainActor in
+                        coordinator.applyModelPreparationProgress(progress, status: status)
+                    }
+                }
+
+                await MainActor.run {
+                    coordinator.modelPreparationTask = nil
+                    coordinator.modelPreparation = ModelPreparationState(
+                        phase: .ready,
+                        progress: 1,
+                        status: "\(model.shortName) ready",
+                        detail: model.detail
+                    )
+                    coordinator.playOnboardingModelReadyCueIfNeeded(for: model)
+                    AppTelemetry.signal("model_prepare_completed", parameters: ["engine": model.engineIdentifier])
+                }
+            } catch is CancellationError {
+                await MainActor.run {
+                    coordinator.modelPreparationTask = nil
+                }
+            } catch {
+                await MainActor.run {
+                    coordinator.modelPreparationTask = nil
+                    coordinator.modelPreparation = ModelPreparationState(
+                        phase: .failed,
+                        progress: nil,
+                        status: "Model setup paused",
+                        detail: "Download finished, but optimization failed"
+                    )
+                    AppTelemetry.signal(
+                        "model_prepare_failed",
+                        parameters: [
+                            "engine": model.engineIdentifier,
+                            "error": String(describing: type(of: error))
+                        ]
+                    )
+                }
+            }
+        }
+    }
+
+    private func playOnboardingModelReadyCueIfNeeded(for model: LocalTranscriptionModel) {
+        guard !hasCompletedOnboarding else { return }
+        guard onboardingModelReadyCueModel != model else { return }
+        onboardingModelReadyCueModel = model
+        MuesliAudioCues.modelReady()
     }
 
     private func startRealtimeDictationRecorder(audioURL: URL, sessionID: UUID) async throws {
@@ -2294,6 +2400,47 @@ final class DictationCoordinator {
         realtimeDictationChunksDirectory = nil
         realtimeDictationCommittedText = ""
         liveDictationTranscript = ""
+    }
+}
+
+extension DictationCoordinator: ModelBackgroundDownloadServiceDelegate {
+    func modelBackgroundDownloadDidUpdate(model: LocalTranscriptionModel, progress: Double, detail: String) {
+        guard selectedTranscriptionModel == model else { return }
+        modelPreparation = ModelPreparationState(
+            phase: .downloading,
+            progress: progress,
+            status: "Downloading \(model.shortName)",
+            detail: detail
+        )
+    }
+
+    func modelBackgroundDownloadDidFinish(model: LocalTranscriptionModel) {
+        guard selectedTranscriptionModel == model else { return }
+        modelPreparation = ModelPreparationState(
+            phase: .preparing,
+            progress: nil,
+            status: "Optimizing for this iPhone...",
+            detail: "Download complete"
+        )
+        prepareDownloadedModelAfterBackgroundDownload(model)
+    }
+
+    func modelBackgroundDownloadDidFail(model: LocalTranscriptionModel, message: String) {
+        guard selectedTranscriptionModel == model else { return }
+        modelPreparationTask = nil
+        modelPreparation = ModelPreparationState(
+            phase: .failed,
+            progress: nil,
+            status: "Download paused",
+            detail: message
+        )
+        AppTelemetry.signal(
+            "model_prepare_failed",
+            parameters: [
+                "engine": model.engineIdentifier,
+                "error": "background_download_failed"
+            ]
+        )
     }
 }
 

--- a/Muesli/DictationView.swift
+++ b/Muesli/DictationView.swift
@@ -166,6 +166,7 @@ struct DictationView: View {
                         title: dictationButtonTitle,
                         systemImage: dictationButtonIcon,
                         color: statusColor,
+                        isStopState: coordinator.isRecording,
                         isDisabled: isDictationButtonDisabled
                     )
                 }
@@ -516,31 +517,77 @@ private struct VoiceNoteRecordButtonLabel: View {
     let title: String
     let systemImage: String
     let color: Color
+    let isStopState: Bool
     let isDisabled: Bool
 
     var body: some View {
         VStack(spacing: MuesliTheme.spacing8) {
             ZStack {
                 Circle()
-                    .fill(isDisabled ? MuesliTheme.surfacePrimary : color)
+                    .fill(circleFill)
                     .frame(width: 74, height: 74)
                     .overlay(
                         Circle()
-                            .strokeBorder((isDisabled ? MuesliTheme.surfaceBorder : color.opacity(0.36)), lineWidth: 1)
+                            .strokeBorder(circleBorder, lineWidth: 1)
                     )
+                    .shadow(color: circleShadow, radius: isStopState ? 10 : 0, x: 0, y: 5)
 
                 Image(systemName: systemImage)
                     .font(.system(size: 26, weight: .semibold))
-                    .foregroundStyle(isDisabled ? MuesliTheme.textTertiary : .white)
+                    .foregroundStyle(iconColor)
             }
 
             Text(title)
                 .font(MuesliTheme.headline())
-                .foregroundStyle(isDisabled ? MuesliTheme.textTertiary : MuesliTheme.textPrimary)
+                .foregroundStyle(titleColor)
         }
         .frame(maxWidth: .infinity)
         .frame(minHeight: 112)
         .contentShape(Rectangle())
+    }
+
+    private var circleFill: Color {
+        if isDisabled {
+            MuesliTheme.surfacePrimary
+        } else if isStopState {
+            MuesliTheme.destructiveSubtle
+        } else {
+            color
+        }
+    }
+
+    private var circleBorder: Color {
+        if isDisabled {
+            MuesliTheme.surfaceBorder
+        } else if isStopState {
+            MuesliTheme.destructive.opacity(0.38)
+        } else {
+            color.opacity(0.36)
+        }
+    }
+
+    private var circleShadow: Color {
+        isStopState && !isDisabled ? MuesliTheme.destructive.opacity(0.16) : .clear
+    }
+
+    private var iconColor: Color {
+        if isDisabled {
+            MuesliTheme.textTertiary
+        } else if isStopState {
+            MuesliTheme.destructive
+        } else {
+            .white
+        }
+    }
+
+    private var titleColor: Color {
+        if isDisabled {
+            MuesliTheme.textTertiary
+        } else if isStopState {
+            MuesliTheme.destructive
+        } else {
+            MuesliTheme.textPrimary
+        }
     }
 }
 

--- a/Muesli/DictationView.swift
+++ b/Muesli/DictationView.swift
@@ -12,7 +12,6 @@ struct DictationView: View {
     @State private var sourceFilter: DictationSourceFilter = .all
     @State private var isSyncSetupPromptPresented = false
     @State private var shouldShowKeyboardSetupRow = false
-    @State private var focusedHistoryResultID: UUID?
     @State private var previewInputLevel = 0.0
 
     var body: some View {
@@ -30,9 +29,6 @@ struct DictationView: View {
             }
             .background(MuesliTheme.backgroundBase)
             .toolbar(.hidden, for: .navigationBar)
-            .onPreferenceChange(DictationHistoryRowOffsetPreferenceKey.self) { offsets in
-                updateFocusedHistoryResult(using: offsets)
-            }
             .confirmationDialog(
                 "Turn on private iCloud sync?",
                 isPresented: $isSyncSetupPromptPresented,
@@ -269,13 +265,11 @@ struct DictationView: View {
                     ForEach(filteredHistory) { result in
                         let session = coordinator.recordingSession(for: result)
                         let hasRetainedAudio = session?.keepsAudioRecording == true && coordinator.audioFileURL(for: result) != nil
-                        let isFocused = result.id == effectiveFocusedHistoryResultID
                         if hasRetainedAudio {
                             NavigationLink(value: result.id) {
                                 DictationHistoryRow(
                                     result: result,
                                     hasRetainedAudio: true,
-                                    isFocused: isFocused,
                                     onCopy: { coordinator.copyToClipboard(result) },
                                     onDelete: { coordinator.deleteDictation(result) }
                                 )
@@ -285,7 +279,6 @@ struct DictationView: View {
                             DictationHistoryRow(
                                 result: result,
                                 hasRetainedAudio: false,
-                                isFocused: isFocused,
                                 onCopy: { coordinator.copyToClipboard(result) },
                                 onDelete: { coordinator.deleteDictation(result) }
                             )
@@ -297,7 +290,6 @@ struct DictationView: View {
             .padding(.horizontal, MuesliTheme.spacing20)
             .padding(.bottom, 112)
         }
-        .coordinateSpace(name: DictationScrollCoordinateSpace.name)
         .refreshable {
             triggerHomeSync()
         }
@@ -315,10 +307,6 @@ struct DictationView: View {
         #endif
 
         return coordinator.dictationHistory
-    }
-
-    private var effectiveFocusedHistoryResultID: UUID? {
-        focusedHistoryResultID ?? filteredHistory.first?.id
     }
 
     private var shouldUseMockDictations: Bool {
@@ -484,32 +472,13 @@ struct DictationView: View {
             let phrase = (sin(tick * 0.82) + 1) * 0.28
             let syllable = (sin(tick * 2.7) + 1) * 0.18
             let transient = (sin(tick * 7.1) + 1) * 0.08
-            let pause = sin(tick * 0.31) > 0.72 ? 0.12 : 1.0
-            previewInputLevel = min(0.95, max(0.02, (0.08 + phrase + syllable + transient) * pause))
+            if sin(tick * 0.31) > 0.72 {
+                previewInputLevel = 0.02
+            } else {
+                previewInputLevel = min(0.95, max(0.02, 0.08 + phrase + syllable + transient))
+            }
             tick += 0.18
             try? await Task.sleep(for: .milliseconds(55))
-        }
-    }
-
-    private func updateFocusedHistoryResult(using offsets: [UUID: CGFloat]) {
-        guard !filteredHistory.isEmpty else {
-            focusedHistoryResultID = nil
-            return
-        }
-
-        let visibleTop: CGFloat = 0
-        let bestCandidate = filteredHistory
-            .compactMap { result -> (id: UUID, distance: CGFloat)? in
-                guard let minY = offsets[result.id] else { return nil }
-                guard minY >= -44 else { return nil }
-                return (result.id, abs(minY - visibleTop))
-            }
-            .min { lhs, rhs in lhs.distance < rhs.distance }
-
-        if let bestCandidate, focusedHistoryResultID != bestCandidate.id {
-            withAnimation(.snappy(duration: 0.24)) {
-                focusedHistoryResultID = bestCandidate.id
-            }
         }
     }
 
@@ -623,18 +592,6 @@ private struct ICloudSyncStatusButton: View {
         .disabled(isSyncing)
         .accessibilityLabel(accessibilityLabel)
         .accessibilityHint("Double tap to sync text with your Mac through private iCloud.")
-    }
-}
-
-private enum DictationScrollCoordinateSpace {
-    static let name = "dictationScroll"
-}
-
-private struct DictationHistoryRowOffsetPreferenceKey: PreferenceKey {
-    static let defaultValue: [UUID: CGFloat] = [:]
-
-    static func reduce(value: inout [UUID: CGFloat], nextValue: () -> [UUID: CGFloat]) {
-        value.merge(nextValue(), uniquingKeysWith: { _, new in new })
     }
 }
 
@@ -797,7 +754,6 @@ private struct DictationSourceFilterPicker: View {
 private struct DictationHistoryRow: View {
     let result: DictationResult
     let hasRetainedAudio: Bool
-    let isFocused: Bool
     let onCopy: () -> Void
     let onDelete: () -> Void
     @State private var isConfirmingDelete = false
@@ -817,32 +773,20 @@ private struct DictationHistoryRow: View {
                 perform: onCopy
             )
         ) {
-            MuesliSurface(
-                cornerRadius: isFocused ? MuesliTheme.cornerXL : MuesliTheme.cornerMedium,
-                tint: isFocused ? origin.accentColor : nil
-            ) {
+            MuesliSurface {
                 HStack(spacing: 0) {
                     RoundedRectangle(cornerRadius: 2)
                         .fill(origin.accentColor)
-                        .frame(width: isFocused ? 4 : 3)
-                        .padding(.vertical, isFocused ? MuesliTheme.spacing16 : MuesliTheme.spacing12)
+                        .frame(width: 3)
+                        .padding(.vertical, MuesliTheme.spacing12)
 
                     rowContent
-                        .padding(.vertical, isFocused ? MuesliTheme.spacing20 : MuesliTheme.spacing16)
-                        .padding(.leading, isFocused ? MuesliTheme.spacing16 : MuesliTheme.spacing12)
-                        .padding(.trailing, isFocused ? MuesliTheme.spacing20 : MuesliTheme.spacing16)
+                        .padding(.vertical, MuesliTheme.spacing16)
+                        .padding(.leading, MuesliTheme.spacing12)
+                        .padding(.trailing, MuesliTheme.spacing16)
                 }
             }
         }
-        .background {
-            GeometryReader { proxy in
-                Color.clear.preference(
-                    key: DictationHistoryRowOffsetPreferenceKey.self,
-                    value: [result.id: proxy.frame(in: .named(DictationScrollCoordinateSpace.name)).minY]
-                )
-            }
-        }
-        .animation(.snappy(duration: 0.24), value: isFocused)
         .confirmationDialog(
             "Delete this voice note?",
             isPresented: $isConfirmingDelete,
@@ -856,7 +800,7 @@ private struct DictationHistoryRow: View {
     }
 
     private var rowContent: some View {
-        VStack(alignment: .leading, spacing: isFocused ? MuesliTheme.spacing16 : MuesliTheme.spacing12) {
+        VStack(alignment: .leading, spacing: MuesliTheme.spacing12) {
             HStack(alignment: .top, spacing: MuesliTheme.spacing12) {
                 VStack(alignment: .leading, spacing: MuesliTheme.spacing4) {
                     Text(result.createdAt, formatter: Self.dateFormatter)
@@ -881,19 +825,13 @@ private struct DictationHistoryRow: View {
             }
 
             Text(result.text)
-                .font(transcriptFont)
+                .font(.system(size: 17, weight: .regular))
                 .foregroundStyle(MuesliTheme.textPrimary)
-                .lineSpacing(isFocused ? 4 : 1)
+                .lineSpacing(2)
                 .textSelection(.enabled)
                 .fixedSize(horizontal: false, vertical: true)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
-    }
-
-    private var transcriptFont: Font {
-        isFocused
-            ? .system(size: 20, weight: .regular)
-            : MuesliTheme.body()
     }
 
     private var origin: DictationSyncOrigin {

--- a/Muesli/DictationView.swift
+++ b/Muesli/DictationView.swift
@@ -623,9 +623,8 @@ private struct ICloudSyncStatusButton: View {
                     .opacity(hasError ? 0 : 1)
             }
             .foregroundStyle(tint)
-            .frame(width: 38, height: 38)
-            .muesliGlassButton(cornerRadius: 19, tint: tint)
-            .padding(3)
+            .frame(width: 44, height: 44)
+            .muesliGlassButton(cornerRadius: 22, tint: tint)
             .contentShape(Circle())
         }
         .buttonStyle(.plain)

--- a/Muesli/DictationView.swift
+++ b/Muesli/DictationView.swift
@@ -121,7 +121,7 @@ struct DictationView: View {
                 if isWaveformActive {
                     VStack(spacing: MuesliTheme.spacing8) {
                         MuesliInlineWaveformView(
-                            mode: isPreviewWaveformActive ? .level : (coordinator.isRecording ? .level : .waiting),
+                            mode: isListeningWaveformActive ? .level : .waiting,
                             color: statusColor,
                             level: waveformLevel,
                             barCount: 24
@@ -130,7 +130,7 @@ struct DictationView: View {
                         .frame(height: 54)
                         .padding(.horizontal, MuesliTheme.spacing16)
 
-                        Text(isPreviewWaveformActive || coordinator.isRecording ? "Listening" : "Transcribing")
+                        Text(isListeningWaveformActive ? "Listening" : "Transcribing")
                             .font(MuesliTheme.captionMedium())
                             .foregroundStyle(MuesliTheme.textSecondary)
                     }
@@ -311,27 +311,11 @@ struct DictationView: View {
     }
 
     private var shouldUseMockDictations: Bool {
-        #if DEBUG
-        #if targetEnvironment(simulator)
-        return ProcessInfo.processInfo.arguments.contains("--muesli-mock-dictations")
-        #else
-        return false
-        #endif
-        #else
-        return false
-        #endif
+        Self.hasDebugSimulatorLaunchArgument("--muesli-mock-dictations")
     }
 
     private var isPreviewWaveformActive: Bool {
-        #if DEBUG
-        #if targetEnvironment(simulator)
-        return ProcessInfo.processInfo.arguments.contains("--muesli-preview-waveform")
-        #else
-        return false
-        #endif
-        #else
-        return false
-        #endif
+        Self.hasDebugSimulatorLaunchArgument("--muesli-preview-waveform")
     }
 
     private var waveformLevel: Double? {
@@ -342,11 +326,7 @@ struct DictationView: View {
     }
 
     private var shouldHideKeyboardSetupRowForMockPreview: Bool {
-        #if DEBUG
-        return shouldUseMockDictations
-        #else
-        return false
-        #endif
+        shouldUseMockDictations
     }
 
     private var emptyHistory: some View {
@@ -392,7 +372,11 @@ struct DictationView: View {
     }
 
     private var isWaveformActive: Bool {
-        isPreviewWaveformActive || coordinator.isRecording || coordinator.statusText == "Transcribing"
+        isListeningWaveformActive || isTranscribing
+    }
+
+    private var isListeningWaveformActive: Bool {
+        isPreviewWaveformActive || coordinator.isRecording
     }
 
     private var isTranscribing: Bool {
@@ -481,6 +465,14 @@ struct DictationView: View {
             tick += 0.18
             try? await Task.sleep(for: .milliseconds(55))
         }
+    }
+
+    private static func hasDebugSimulatorLaunchArgument(_ argument: String) -> Bool {
+        #if DEBUG && targetEnvironment(simulator)
+        ProcessInfo.processInfo.arguments.contains(argument)
+        #else
+        false
+        #endif
     }
 
     #if DEBUG
@@ -633,6 +625,7 @@ private struct ICloudSyncStatusButton: View {
             .foregroundStyle(tint)
             .frame(width: 38, height: 38)
             .muesliGlassButton(cornerRadius: 19, tint: tint)
+            .padding(3)
             .contentShape(Circle())
         }
         .buttonStyle(.plain)
@@ -788,6 +781,9 @@ private struct DictationSourceFilterPicker: View {
                         .frame(height: 32)
                         .background(selection == filter ? MuesliTheme.accent.opacity(0.13) : Color.clear)
                         .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall, style: .continuous))
+                        .frame(maxWidth: .infinity)
+                        .frame(height: 44)
+                        .contentShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall, style: .continuous))
                 }
                 .buttonStyle(.plain)
                 .accessibilityLabel("Show \(filter.title.lowercased()) voice notes")
@@ -810,7 +806,7 @@ private struct DictationHistoryRow: View {
             leadingAction: .init(
                 title: "Delete",
                 systemImage: "trash",
-                tint: MuesliTheme.recording,
+                tint: MuesliTheme.destructive,
                 perform: { isConfirmingDelete = true }
             ),
             trailingAction: .init(

--- a/Muesli/DictationView.swift
+++ b/Muesli/DictationView.swift
@@ -12,23 +12,26 @@ struct DictationView: View {
     @State private var sourceFilter: DictationSourceFilter = .all
     @State private var isSyncSetupPromptPresented = false
     @State private var shouldShowKeyboardSetupRow = false
+    @State private var focusedHistoryResultID: UUID?
+    @State private var previewInputLevel = 0.0
 
     var body: some View {
         NavigationStack {
-            ScrollView {
-                VStack(alignment: .leading, spacing: MuesliTheme.spacing20) {
+            VStack(alignment: .leading, spacing: MuesliTheme.spacing16) {
+                VStack(alignment: .leading, spacing: MuesliTheme.spacing16) {
                     header
                     recorderPanel
-                    historySection
+                    historyHeader
                 }
                 .padding(.horizontal, MuesliTheme.spacing20)
                 .padding(.top, MuesliTheme.spacing24)
-                .padding(.bottom, MuesliTheme.spacing24)
+
+                historyList
             }
             .background(MuesliTheme.backgroundBase)
             .toolbar(.hidden, for: .navigationBar)
-            .refreshable {
-                triggerHomeSync()
+            .onPreferenceChange(DictationHistoryRowOffsetPreferenceKey.self) { offsets in
+                updateFocusedHistoryResult(using: offsets)
             }
             .confirmationDialog(
                 "Turn on private iCloud sync?",
@@ -58,6 +61,8 @@ struct DictationView: View {
                    let audioURL = coordinator.audioFileURL(for: result) {
                     DictationAudioDetailView(result: result, session: session, audioURL: audioURL) {
                         coordinator.copyToClipboard(result)
+                    } onDeleteAudio: {
+                        coordinator.deleteDictationAudio(for: result)
                     }
                 } else {
                     DictationAudioMissingView()
@@ -85,8 +90,12 @@ struct DictationView: View {
     }
 
     private var recorderPanel: some View {
-        MuesliSurface(cornerRadius: MuesliTheme.cornerLarge) {
-            VStack(spacing: MuesliTheme.spacing20) {
+        MuesliSurface(
+            cornerRadius: MuesliTheme.cornerLarge,
+            tint: statusColor,
+            isInteractive: true
+        ) {
+            VStack(spacing: MuesliTheme.spacing16) {
                 HStack(alignment: .top) {
                     VStack(alignment: .leading, spacing: MuesliTheme.spacing4) {
                         Text("Voice Note")
@@ -116,23 +125,22 @@ struct DictationView: View {
                 if isWaveformActive {
                     VStack(spacing: MuesliTheme.spacing8) {
                         MuesliInlineWaveformView(
-                            mode: coordinator.isRecording ? .level : .waiting,
+                            mode: isPreviewWaveformActive ? .level : (coordinator.isRecording ? .level : .waiting),
                             color: statusColor,
-                            level: coordinator.isRecording ? coordinator.inputLevel : nil,
+                            level: waveformLevel,
                             barCount: 24
                         )
                         .frame(maxWidth: .infinity)
                         .frame(height: 54)
                         .padding(.horizontal, MuesliTheme.spacing16)
 
-                        Text(coordinator.isRecording ? "Listening" : "Transcribing")
+                        Text(isPreviewWaveformActive || coordinator.isRecording ? "Listening" : "Transcribing")
                             .font(MuesliTheme.captionMedium())
                             .foregroundStyle(MuesliTheme.textSecondary)
                     }
                     .frame(maxWidth: .infinity)
                     .padding(.vertical, MuesliTheme.spacing16)
-                    .background(statusColor.opacity(0.08))
-                    .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+                    .muesliGlassSurface(cornerRadius: MuesliTheme.cornerMedium, tint: statusColor)
                 }
 
                 if shouldShowRealtimeTranscript {
@@ -152,8 +160,7 @@ struct DictationView: View {
                             .frame(maxWidth: .infinity, alignment: .leading)
                     }
                     .padding(MuesliTheme.spacing12)
-                    .background(MuesliTheme.surfacePrimary)
-                    .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+                    .muesliGlassSurface(cornerRadius: MuesliTheme.cornerMedium, tint: MuesliTheme.accent)
                 }
 
                 Button {
@@ -168,18 +175,22 @@ struct DictationView: View {
                 }
                 .buttonStyle(.plain)
                 .disabled(isDictationButtonDisabled)
+                .sensoryFeedback(.impact, trigger: coordinator.isRecording)
                 .accessibilityElement(children: .ignore)
                 .accessibilityLabel(dictationButtonTitle)
                 .accessibilityAddTraits(.isButton)
                 .accessibilityIdentifier("dictation.primaryButton")
 
-                if shouldShowKeyboardSetupRow {
+                if shouldShowKeyboardSetupRow && !shouldHideKeyboardSetupRowForMockPreview {
                     keyboardShortcutRow
                 }
             }
-            .padding()
+            .padding(MuesliTheme.spacing16)
         }
         .accessibilityIdentifier("dictation.recorderPanel")
+        .task {
+            await runPreviewWaveformIfNeeded()
+        }
     }
 
     private var keyboardShortcutRow: some View {
@@ -209,19 +220,18 @@ struct DictationView: View {
                 .foregroundStyle(MuesliTheme.accent)
         }
         .padding(MuesliTheme.spacing12)
-        .background(MuesliTheme.surfacePrimary.opacity(0.72))
-        .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+        .muesliGlassSurface(cornerRadius: MuesliTheme.cornerMedium, tint: MuesliTheme.accent)
     }
 
     @ViewBuilder
-    private var historySection: some View {
+    private var historyHeader: some View {
         VStack(alignment: .leading, spacing: MuesliTheme.spacing12) {
             HStack(alignment: .center) {
                 VStack(alignment: .leading, spacing: MuesliTheme.spacing4) {
                     Text("Recent Voice Notes")
                         .font(MuesliTheme.title3())
                         .foregroundStyle(MuesliTheme.textPrimary)
-                    Text("\(coordinator.dictationHistory.count) saved")
+                    Text("\(displayHistory.count) saved")
                         .font(MuesliTheme.caption())
                         .foregroundStyle(MuesliTheme.textTertiary)
                 }
@@ -242,10 +252,16 @@ struct DictationView: View {
                 }
             }
 
-            if !coordinator.dictationHistory.isEmpty {
+            if !displayHistory.isEmpty {
                 DictationSourceFilterPicker(selection: $sourceFilter)
             }
+        }
+    }
 
+    @ViewBuilder
+    private var historyList: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: MuesliTheme.spacing12) {
             if filteredHistory.isEmpty {
                 emptyHistory
             } else {
@@ -253,11 +269,13 @@ struct DictationView: View {
                     ForEach(filteredHistory) { result in
                         let session = coordinator.recordingSession(for: result)
                         let hasRetainedAudio = session?.keepsAudioRecording == true && coordinator.audioFileURL(for: result) != nil
+                        let isFocused = result.id == effectiveFocusedHistoryResultID
                         if hasRetainedAudio {
                             NavigationLink(value: result.id) {
                                 DictationHistoryRow(
                                     result: result,
                                     hasRetainedAudio: true,
+                                    isFocused: isFocused,
                                     onCopy: { coordinator.copyToClipboard(result) },
                                     onDelete: { coordinator.deleteDictation(result) }
                                 )
@@ -267,6 +285,7 @@ struct DictationView: View {
                             DictationHistoryRow(
                                 result: result,
                                 hasRetainedAudio: false,
+                                isFocused: isFocused,
                                 onCopy: { coordinator.copyToClipboard(result) },
                                 onDelete: { coordinator.deleteDictation(result) }
                             )
@@ -274,11 +293,71 @@ struct DictationView: View {
                     }
                 }
             }
+            }
+            .padding(.horizontal, MuesliTheme.spacing20)
+            .padding(.bottom, 112)
+        }
+        .coordinateSpace(name: DictationScrollCoordinateSpace.name)
+        .refreshable {
+            triggerHomeSync()
         }
     }
 
     private var filteredHistory: [DictationResult] {
-        coordinator.dictationHistory.filter { sourceFilter.includes($0.syncOrigin) }
+        displayHistory.filter { sourceFilter.includes($0.syncOrigin) }
+    }
+
+    private var displayHistory: [DictationResult] {
+        #if DEBUG
+        if shouldUseMockDictations {
+            return Self.mockDictationHistory
+        }
+        #endif
+
+        return coordinator.dictationHistory
+    }
+
+    private var effectiveFocusedHistoryResultID: UUID? {
+        focusedHistoryResultID ?? filteredHistory.first?.id
+    }
+
+    private var shouldUseMockDictations: Bool {
+        #if DEBUG
+        #if targetEnvironment(simulator)
+        return ProcessInfo.processInfo.arguments.contains("--muesli-mock-dictations")
+        #else
+        return false
+        #endif
+        #else
+        return false
+        #endif
+    }
+
+    private var isPreviewWaveformActive: Bool {
+        #if DEBUG
+        #if targetEnvironment(simulator)
+        return ProcessInfo.processInfo.arguments.contains("--muesli-preview-waveform")
+        #else
+        return false
+        #endif
+        #else
+        return false
+        #endif
+    }
+
+    private var waveformLevel: Double? {
+        if isPreviewWaveformActive {
+            return previewInputLevel
+        }
+        return coordinator.isRecording ? coordinator.inputLevel : nil
+    }
+
+    private var shouldHideKeyboardSetupRowForMockPreview: Bool {
+        #if DEBUG
+        return shouldUseMockDictations
+        #else
+        return false
+        #endif
     }
 
     private var emptyHistory: some View {
@@ -303,11 +382,11 @@ struct DictationView: View {
     }
 
     private var emptyHistoryTitle: String {
-        coordinator.dictationHistory.isEmpty ? "No voice notes yet" : "No \(sourceFilter.title.lowercased()) voice notes"
+        displayHistory.isEmpty ? "No voice notes yet" : "No \(sourceFilter.title.lowercased()) voice notes"
     }
 
     private var emptyHistoryDetail: String {
-        if coordinator.dictationHistory.isEmpty {
+        if displayHistory.isEmpty {
             return "Recorded voice notes from the app will appear here as a timeline."
         }
         return "Switch filters to see the complete voice note history."
@@ -324,7 +403,7 @@ struct DictationView: View {
     }
 
     private var isWaveformActive: Bool {
-        coordinator.isRecording || coordinator.statusText == "Transcribing"
+        isPreviewWaveformActive || coordinator.isRecording || coordinator.statusText == "Transcribing"
     }
 
     private var isTranscribing: Bool {
@@ -396,6 +475,72 @@ struct DictationView: View {
         let seconds = totalSeconds % 60
         return String(format: "%d:%02d", minutes, seconds)
     }
+
+    private func runPreviewWaveformIfNeeded() async {
+        guard isPreviewWaveformActive else { return }
+
+        var tick = 0.0
+        while !Task.isCancelled {
+            let phrase = (sin(tick * 0.82) + 1) * 0.28
+            let syllable = (sin(tick * 2.7) + 1) * 0.18
+            let transient = (sin(tick * 7.1) + 1) * 0.08
+            let pause = sin(tick * 0.31) > 0.72 ? 0.12 : 1.0
+            previewInputLevel = min(0.95, max(0.02, (0.08 + phrase + syllable + transient) * pause))
+            tick += 0.18
+            try? await Task.sleep(for: .milliseconds(55))
+        }
+    }
+
+    private func updateFocusedHistoryResult(using offsets: [UUID: CGFloat]) {
+        guard !filteredHistory.isEmpty else {
+            focusedHistoryResultID = nil
+            return
+        }
+
+        let visibleTop: CGFloat = 0
+        let bestCandidate = filteredHistory
+            .compactMap { result -> (id: UUID, distance: CGFloat)? in
+                guard let minY = offsets[result.id] else { return nil }
+                guard minY >= -44 else { return nil }
+                return (result.id, abs(minY - visibleTop))
+            }
+            .min { lhs, rhs in lhs.distance < rhs.distance }
+
+        if let bestCandidate, focusedHistoryResultID != bestCandidate.id {
+            withAnimation(.snappy(duration: 0.24)) {
+                focusedHistoryResultID = bestCandidate.id
+            }
+        }
+    }
+
+    #if DEBUG
+    private static let mockDictationHistory: [DictationResult] = {
+        let calendar = Calendar.current
+        let baseDate = calendar.date(from: DateComponents(year: 2026, month: 6, day: 30, hour: 13, minute: 30)) ?? .now
+        let samples: [(String, String?)] = [
+            ("Is this the best animation and UI that we could come up with", "ios"),
+            ("The capture screen should feel like a local first console, fast enough to open and start speaking without thinking about folders or setup.", "ios"),
+            ("Currently bleeding talent to the inference giants", "macOS"),
+            ("We should test the magnified top note while scrolling because this is the exact state people will read after recording a quick thought.", "ios"),
+            ("The Mac companion app can stay focused on longer workflows while the phone stays optimized for immediate capture.", "macOS"),
+            ("Meeting notes need the same private sync language, but the voice note screen should remain lighter and faster.", "ios"),
+            ("If a note is imported from the Mac, keep the provenance visible but do not let the chip overpower the transcript.", "macOS"),
+            ("The tab bar should feel stable and tappable, with blue as the active state and green reserved for sync confidence.", "ios"),
+            ("Keep the interface blue black white and green so the product feels consistent across phone and Mac.", "ios"),
+            ("When the top card grows, the surrounding cards should stay quiet so the reading focus feels intentional rather than busy.", "macOS")
+        ]
+
+        return samples.enumerated().map { index, sample in
+            DictationResult(
+                requestID: UUID(),
+                text: sample.0,
+                createdAt: calendar.date(byAdding: .minute, value: -index * 47, to: baseDate) ?? baseDate,
+                engineIdentifier: sample.1 == "macOS" ? "icloud" : "parakeet",
+                source: sample.1
+            )
+        }
+    }()
+    #endif
 }
 
 private struct VoiceNoteRecordButtonLabel: View {
@@ -409,14 +554,14 @@ private struct VoiceNoteRecordButtonLabel: View {
             ZStack {
                 Circle()
                     .fill(isDisabled ? MuesliTheme.surfacePrimary : color)
-                    .frame(width: 86, height: 86)
+                    .frame(width: 74, height: 74)
                     .overlay(
                         Circle()
                             .strokeBorder((isDisabled ? MuesliTheme.surfaceBorder : color.opacity(0.36)), lineWidth: 1)
                     )
 
                 Image(systemName: systemImage)
-                    .font(.system(size: 30, weight: .semibold))
+                    .font(.system(size: 26, weight: .semibold))
                     .foregroundStyle(isDisabled ? MuesliTheme.textTertiary : .white)
             }
 
@@ -425,6 +570,7 @@ private struct VoiceNoteRecordButtonLabel: View {
                 .foregroundStyle(isDisabled ? MuesliTheme.textTertiary : MuesliTheme.textPrimary)
         }
         .frame(maxWidth: .infinity)
+        .frame(minHeight: 112)
         .contentShape(Rectangle())
     }
 }
@@ -470,18 +616,25 @@ private struct ICloudSyncStatusButton: View {
             }
             .foregroundStyle(tint)
             .frame(width: 38, height: 38)
-            .background(tint.opacity(isEnabled || hasError ? 0.14 : 0.08))
-            .clipShape(Circle())
-            .overlay(
-                Circle()
-                    .strokeBorder(tint.opacity(isEnabled || hasError ? 0.28 : 0.14), lineWidth: 1)
-            )
+            .muesliGlassButton(cornerRadius: 19, tint: tint)
             .contentShape(Circle())
         }
         .buttonStyle(.plain)
         .disabled(isSyncing)
         .accessibilityLabel(accessibilityLabel)
         .accessibilityHint("Double tap to sync text with your Mac through private iCloud.")
+    }
+}
+
+private enum DictationScrollCoordinateSpace {
+    static let name = "dictationScroll"
+}
+
+private struct DictationHistoryRowOffsetPreferenceKey: PreferenceKey {
+    static let defaultValue: [UUID: CGFloat] = [:]
+
+    static func reduce(value: inout [UUID: CGFloat], nextValue: () -> [UUID: CGFloat]) {
+        value.merge(nextValue(), uniquingKeysWith: { _, new in new })
     }
 }
 
@@ -585,7 +738,7 @@ private enum DictationSyncOrigin: Equatable {
         case .thisIPhone:
             MuesliTheme.accent
         case .fromMac:
-            Color(hex: 0x2DD4BF)
+            MuesliTheme.success
         }
     }
 }
@@ -629,26 +782,22 @@ private struct DictationSourceFilterPicker: View {
                         .minimumScaleFactor(0.82)
                         .frame(maxWidth: .infinity)
                         .frame(height: 32)
-                        .background(selection == filter ? MuesliTheme.surfaceSelected : Color.clear)
-                        .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+                        .background(selection == filter ? MuesliTheme.accent.opacity(0.13) : Color.clear)
+                        .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall, style: .continuous))
                 }
                 .buttonStyle(.plain)
                 .accessibilityLabel("Show \(filter.title.lowercased()) voice notes")
             }
         }
         .padding(3)
-        .background(MuesliTheme.surfacePrimary.opacity(0.72))
-        .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium))
-        .overlay(
-            RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium)
-                .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
-        )
+        .muesliGlassSurface(cornerRadius: MuesliTheme.cornerMedium, tint: MuesliTheme.accent)
     }
 }
 
 private struct DictationHistoryRow: View {
     let result: DictationResult
     let hasRetainedAudio: Bool
+    let isFocused: Bool
     let onCopy: () -> Void
     let onDelete: () -> Void
     @State private var isConfirmingDelete = false
@@ -668,20 +817,32 @@ private struct DictationHistoryRow: View {
                 perform: onCopy
             )
         ) {
-            MuesliSurface {
+            MuesliSurface(
+                cornerRadius: isFocused ? MuesliTheme.cornerXL : MuesliTheme.cornerMedium,
+                tint: isFocused ? origin.accentColor : nil
+            ) {
                 HStack(spacing: 0) {
                     RoundedRectangle(cornerRadius: 2)
                         .fill(origin.accentColor)
-                        .frame(width: 3)
-                        .padding(.vertical, MuesliTheme.spacing12)
+                        .frame(width: isFocused ? 4 : 3)
+                        .padding(.vertical, isFocused ? MuesliTheme.spacing16 : MuesliTheme.spacing12)
 
                     rowContent
-                        .padding(.vertical, MuesliTheme.spacing16)
-                        .padding(.leading, MuesliTheme.spacing12)
-                        .padding(.trailing, MuesliTheme.spacing16)
+                        .padding(.vertical, isFocused ? MuesliTheme.spacing20 : MuesliTheme.spacing16)
+                        .padding(.leading, isFocused ? MuesliTheme.spacing16 : MuesliTheme.spacing12)
+                        .padding(.trailing, isFocused ? MuesliTheme.spacing20 : MuesliTheme.spacing16)
                 }
             }
         }
+        .background {
+            GeometryReader { proxy in
+                Color.clear.preference(
+                    key: DictationHistoryRowOffsetPreferenceKey.self,
+                    value: [result.id: proxy.frame(in: .named(DictationScrollCoordinateSpace.name)).minY]
+                )
+            }
+        }
+        .animation(.snappy(duration: 0.24), value: isFocused)
         .confirmationDialog(
             "Delete this voice note?",
             isPresented: $isConfirmingDelete,
@@ -695,7 +856,7 @@ private struct DictationHistoryRow: View {
     }
 
     private var rowContent: some View {
-        VStack(alignment: .leading, spacing: MuesliTheme.spacing12) {
+        VStack(alignment: .leading, spacing: isFocused ? MuesliTheme.spacing16 : MuesliTheme.spacing12) {
             HStack(alignment: .top, spacing: MuesliTheme.spacing12) {
                 VStack(alignment: .leading, spacing: MuesliTheme.spacing4) {
                     Text(result.createdAt, formatter: Self.dateFormatter)
@@ -720,12 +881,19 @@ private struct DictationHistoryRow: View {
             }
 
             Text(result.text)
-                .font(MuesliTheme.body())
+                .font(transcriptFont)
                 .foregroundStyle(MuesliTheme.textPrimary)
+                .lineSpacing(isFocused ? 4 : 1)
                 .textSelection(.enabled)
                 .fixedSize(horizontal: false, vertical: true)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var transcriptFont: Font {
+        isFocused
+            ? .system(size: 20, weight: .regular)
+            : MuesliTheme.body()
     }
 
     private var origin: DictationSyncOrigin {
@@ -745,9 +913,12 @@ private struct DictationAudioDetailView: View {
     let session: RecordingSession
     let audioURL: URL
     let onCopy: () -> Void
+    let onDeleteAudio: () -> Bool
 
+    @Environment(\.dismiss) private var dismiss
     @State private var filesExportStatus: String?
     @State private var isFilesExporterPresented = false
+    @State private var isDeleteAudioConfirmationPresented = false
     @State private var audioDocument: AudioFileDocument?
 
     var body: some View {
@@ -797,6 +968,14 @@ private struct DictationAudioDetailView: View {
                             .foregroundStyle(MuesliTheme.accent)
 
                             Spacer()
+
+                            Button(role: .destructive) {
+                                isDeleteAudioConfirmationPresented = true
+                            } label: {
+                                Label("Delete Audio", systemImage: "trash")
+                                    .font(MuesliTheme.captionMedium())
+                            }
+                            .buttonStyle(.plain)
                         }
 
                         VStack(alignment: .leading, spacing: MuesliTheme.spacing4) {
@@ -849,6 +1028,21 @@ private struct DictationAudioDetailView: View {
         .background(MuesliTheme.backgroundBase)
         .navigationTitle("Voice Note")
         .navigationBarTitleDisplayMode(.inline)
+        .alert(
+            "Delete saved audio?",
+            isPresented: $isDeleteAudioConfirmationPresented,
+        ) {
+            Button("Delete Audio Only", role: .destructive) {
+                if onDeleteAudio() {
+                    dismiss()
+                } else {
+                    filesExportStatus = "Audio delete failed"
+                }
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("This removes only the local WAV recording. The transcript and voice note stay in history.")
+        }
         .fileExporter(
             isPresented: $isFilesExporterPresented,
             document: audioDocument,

--- a/Muesli/DictationView.swift
+++ b/Muesli/DictationView.swift
@@ -550,7 +550,7 @@ private struct VoiceNoteRecordButtonLabel: View {
         if isDisabled {
             MuesliTheme.surfacePrimary
         } else if isStopState {
-            MuesliTheme.destructiveSubtle
+            MuesliTheme.destructive.opacity(0.32)
         } else {
             color
         }
@@ -574,7 +574,7 @@ private struct VoiceNoteRecordButtonLabel: View {
         if isDisabled {
             MuesliTheme.textTertiary
         } else if isStopState {
-            MuesliTheme.destructive
+            .white
         } else {
             .white
         }

--- a/Muesli/DictionaryView.swift
+++ b/Muesli/DictionaryView.swift
@@ -97,15 +97,16 @@ struct DictionarySettingsContent: View {
                             .font(MuesliTheme.headline())
                             .frame(maxWidth: .infinity)
                             .frame(height: 44)
+                            .foregroundStyle(.white)
+                            .background(
+                                newWord.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                                    ? MuesliTheme.surfacePrimary
+                                    : MuesliTheme.accent
+                            )
+                            .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+                            .contentShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
                     }
                     .buttonStyle(.plain)
-                    .foregroundStyle(.white)
-                    .background(
-                        newWord.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-                            ? MuesliTheme.surfacePrimary
-                            : MuesliTheme.accent
-                    )
-                    .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
                     .disabled(newWord.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
                 }
 
@@ -242,11 +243,12 @@ private struct CustomWordRow: View {
                 Image(systemName: "trash")
                     .font(.system(size: 15, weight: .semibold))
                     .frame(width: 36, height: 36)
+                    .foregroundStyle(MuesliTheme.recording)
+                    .background(MuesliTheme.recording.opacity(0.12))
+                    .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+                    .contentShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
             }
             .buttonStyle(.plain)
-            .foregroundStyle(MuesliTheme.recording)
-            .background(MuesliTheme.recording.opacity(0.12))
-            .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
             .accessibilityLabel("Delete dictionary entry")
         }
         .padding(MuesliTheme.spacing12)

--- a/Muesli/DictionaryView.swift
+++ b/Muesli/DictionaryView.swift
@@ -113,7 +113,7 @@ struct DictionarySettingsContent: View {
                 if let dictionaryError {
                     Text(dictionaryError)
                         .font(MuesliTheme.caption())
-                        .foregroundStyle(MuesliTheme.recording)
+                        .foregroundStyle(MuesliTheme.destructive)
                 }
 
                 if customWords.isEmpty {
@@ -243,8 +243,8 @@ private struct CustomWordRow: View {
                 Image(systemName: "trash")
                     .font(.system(size: 15, weight: .semibold))
                     .frame(width: 36, height: 36)
-                    .foregroundStyle(MuesliTheme.recording)
-                    .background(MuesliTheme.recording.opacity(0.12))
+                    .foregroundStyle(MuesliTheme.destructive)
+                    .background(MuesliTheme.destructive.opacity(0.12))
                     .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
                     .contentShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
             }

--- a/Muesli/MeetingsView.swift
+++ b/Muesli/MeetingsView.swift
@@ -315,15 +315,12 @@ struct MeetingsView: View {
 
     private var meetingPrimaryButtonBackground: some View {
         RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall, style: .continuous)
-            .fill(coordinator.hasMeetingRecordingInProgress ? MuesliTheme.destructive.opacity(0.32) : statusColor)
+            .fill(coordinator.hasMeetingRecordingInProgress ? MuesliTheme.destructive : statusColor)
     }
 
     private var meetingPrimaryButtonBorder: some View {
         RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall, style: .continuous)
-            .strokeBorder(
-                coordinator.hasMeetingRecordingInProgress ? MuesliTheme.destructive.opacity(0.34) : .clear,
-                lineWidth: 1
-            )
+            .strokeBorder(.clear, lineWidth: 1)
     }
 
     private func copyText(for session: RecordingSession) -> String {

--- a/Muesli/MeetingsView.swift
+++ b/Muesli/MeetingsView.swift
@@ -89,7 +89,11 @@ struct MeetingsView: View {
     }
 
     private var recorderPanel: some View {
-        MuesliSurface(cornerRadius: MuesliTheme.cornerLarge) {
+        MuesliSurface(
+            cornerRadius: MuesliTheme.cornerLarge,
+            tint: statusColor,
+            isInteractive: true
+        ) {
             VStack(alignment: .leading, spacing: MuesliTheme.spacing16) {
                 HStack(alignment: .top, spacing: MuesliTheme.spacing12) {
                     VStack(alignment: .leading, spacing: MuesliTheme.spacing4) {
@@ -113,8 +117,7 @@ struct MeetingsView: View {
                     .foregroundStyle(MuesliTheme.textPrimary)
                     .padding(.horizontal, MuesliTheme.spacing12)
                     .frame(height: 44)
-                    .background(MuesliTheme.surfacePrimary)
-                    .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+                    .muesliGlassSurface(cornerRadius: MuesliTheme.cornerMedium)
                     .disabled(coordinator.hasMeetingRecordingInProgress || coordinator.isMeetingTranscribing)
 
                 meetingTemplatePicker
@@ -137,8 +140,7 @@ struct MeetingsView: View {
                     }
                     .frame(maxWidth: .infinity)
                     .padding(.vertical, MuesliTheme.spacing16)
-                    .background(statusColor.opacity(0.08))
-                    .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+                    .muesliGlassSurface(cornerRadius: MuesliTheme.cornerMedium, tint: statusColor)
                 }
 
                 Button {
@@ -162,6 +164,7 @@ struct MeetingsView: View {
                 }
                 .buttonStyle(.plain)
                 .disabled(coordinator.isMeetingTranscribing)
+                .sensoryFeedback(.impact, trigger: coordinator.hasMeetingRecordingInProgress)
                 .accessibilityIdentifier("meetings.primaryButton")
             }
             .padding(MuesliTheme.spacing16)
@@ -206,9 +209,8 @@ struct MeetingsView: View {
                     .foregroundStyle(MuesliTheme.textTertiary)
             }
             .padding(MuesliTheme.spacing12)
-            .background(MuesliTheme.surfacePrimary)
-            .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
-            .contentShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+            .muesliGlassSurface(cornerRadius: MuesliTheme.cornerMedium, tint: MuesliTheme.accent)
+            .contentShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium, style: .continuous))
         }
         .buttonStyle(.plain)
         .disabled(coordinator.hasMeetingRecordingInProgress || coordinator.isMeetingTranscribing)

--- a/Muesli/MeetingsView.swift
+++ b/Muesli/MeetingsView.swift
@@ -157,8 +157,9 @@ struct MeetingsView: View {
                     .font(MuesliTheme.headline())
                     .frame(maxWidth: .infinity)
                     .frame(height: 48)
-                    .foregroundStyle(.white)
-                    .background(statusColor)
+                    .foregroundStyle(meetingPrimaryButtonTextColor)
+                    .background(meetingPrimaryButtonBackground)
+                    .overlay(meetingPrimaryButtonBorder)
                     .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
                     .contentShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
                 }
@@ -306,6 +307,23 @@ struct MeetingsView: View {
         } else {
             MuesliTheme.accent
         }
+    }
+
+    private var meetingPrimaryButtonTextColor: Color {
+        coordinator.hasMeetingRecordingInProgress ? MuesliTheme.destructive : .white
+    }
+
+    private var meetingPrimaryButtonBackground: some View {
+        RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall, style: .continuous)
+            .fill(coordinator.hasMeetingRecordingInProgress ? MuesliTheme.destructiveSubtle : statusColor)
+    }
+
+    private var meetingPrimaryButtonBorder: some View {
+        RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall, style: .continuous)
+            .strokeBorder(
+                coordinator.hasMeetingRecordingInProgress ? MuesliTheme.destructive.opacity(0.34) : .clear,
+                lineWidth: 1
+            )
     }
 
     private func copyText(for session: RecordingSession) -> String {

--- a/Muesli/MeetingsView.swift
+++ b/Muesli/MeetingsView.swift
@@ -310,12 +310,12 @@ struct MeetingsView: View {
     }
 
     private var meetingPrimaryButtonTextColor: Color {
-        coordinator.hasMeetingRecordingInProgress ? MuesliTheme.destructive : .white
+        .white
     }
 
     private var meetingPrimaryButtonBackground: some View {
         RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall, style: .continuous)
-            .fill(coordinator.hasMeetingRecordingInProgress ? MuesliTheme.destructiveSubtle : statusColor)
+            .fill(coordinator.hasMeetingRecordingInProgress ? MuesliTheme.destructive.opacity(0.32) : statusColor)
     }
 
     private var meetingPrimaryButtonBorder: some View {

--- a/Muesli/MeetingsView.swift
+++ b/Muesli/MeetingsView.swift
@@ -248,7 +248,7 @@ struct MeetingsView: View {
                             leadingAction: .init(
                                 title: "Delete",
                                 systemImage: "trash",
-                                tint: MuesliTheme.recording,
+                                tint: MuesliTheme.destructive,
                                 perform: { sessionPendingDelete = session }
                             ),
                             trailingAction: .init(
@@ -409,7 +409,7 @@ private struct MeetingSessionRow: View {
     }
 
     private var previewColor: Color {
-        session.errorMessage == nil ? MuesliTheme.textSecondary : MuesliTheme.recording
+        session.errorMessage == nil ? MuesliTheme.textSecondary : MuesliTheme.destructive
     }
 
     fileprivate static let dateFormatter: DateFormatter = {
@@ -620,8 +620,8 @@ private struct MeetingSessionDetailView: View {
             .font(MuesliTheme.headline())
             .frame(maxWidth: .infinity)
             .frame(height: 44)
-            .foregroundStyle(MuesliTheme.recording)
-            .background(MuesliTheme.recording.opacity(0.12))
+            .foregroundStyle(MuesliTheme.destructive)
+            .background(MuesliTheme.destructive.opacity(0.12))
             .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
             .contentShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
         }
@@ -644,7 +644,7 @@ private struct MeetingSessionDetailView: View {
                 } else if let error = session.errorMessage {
                     Text(error)
                         .font(MuesliTheme.body())
-                        .foregroundStyle(MuesliTheme.recording)
+                        .foregroundStyle(MuesliTheme.destructive)
                         .fixedSize(horizontal: false, vertical: true)
                 } else {
                     Text(session.phase.description)
@@ -997,7 +997,7 @@ struct SavedAudioPlayerView: View {
             if let playbackError {
                 Text(playbackError)
                     .font(MuesliTheme.caption())
-                    .foregroundStyle(MuesliTheme.recording)
+                    .foregroundStyle(MuesliTheme.destructive)
                     .frame(maxWidth: .infinity, alignment: .leading)
             }
         }
@@ -1375,8 +1375,10 @@ private extension RecordingSessionPhase {
 
     var tint: Color {
         switch self {
-        case .recording, .failed, .cancelled:
+        case .recording:
             MuesliTheme.recording
+        case .failed, .cancelled:
+            MuesliTheme.destructive
         case .transcriptionQueued, .transcribing:
             MuesliTheme.transcribing
         case .completed:

--- a/Muesli/ModelBackgroundDownloadService.swift
+++ b/Muesli/ModelBackgroundDownloadService.swift
@@ -18,6 +18,9 @@ final class ModelBackgroundDownloadService: NSObject, @unchecked Sendable {
     private let stateQueue = DispatchQueue(label: "com.phequals7.muesli.model-background-download")
     private var activePlan: DownloadPlan?
     private var taskBytes: [Int: Int64] = [:]
+    private var activeTaskIDs = Set<Int>()
+    private var failedTaskIDs = Set<Int>()
+    private var failedModelRawValues = Set<String>()
     private var backgroundCompletionHandler: SendableCompletionHandler?
     private var completedModelsDuringBackgroundEvents = Set<String>()
 
@@ -48,10 +51,6 @@ final class ModelBackgroundDownloadService: NSObject, @unchecked Sendable {
             return false
         }
 
-        if spec.requiredModelsExist {
-            return false
-        }
-
         let files = try await Self.listFiles(for: spec)
         let missingFiles = files.filter { file in
             !FileManager.default.fileExists(atPath: spec.destinationURL(for: file.localPath).path)
@@ -77,6 +76,9 @@ final class ModelBackgroundDownloadService: NSObject, @unchecked Sendable {
         stateQueue.sync {
             activePlan = plan
             taskBytes = [:]
+            activeTaskIDs = []
+            failedTaskIDs = []
+            failedModelRawValues.remove(model.rawValue)
         }
 
         for file in missingFiles {
@@ -102,6 +104,7 @@ final class ModelBackgroundDownloadService: NSObject, @unchecked Sendable {
             task.taskDescription = file.taskDescription(model: model)
             stateQueue.sync {
                 taskBytes[task.taskIdentifier] = 0
+                activeTaskIDs.insert(task.taskIdentifier)
             }
             task.resume()
         }
@@ -158,6 +161,7 @@ final class ModelBackgroundDownloadService: NSObject, @unchecked Sendable {
         var snapshot: (LocalTranscriptionModel, Double)?
         stateQueue.sync {
             guard let plan = activePlan,
+                  activeTaskIDs.contains(taskIdentifier),
                   let model = LocalTranscriptionModel(rawValue: plan.modelRawValue)
             else {
                 snapshot = nil
@@ -198,11 +202,18 @@ final class ModelBackgroundDownloadService: NSObject, @unchecked Sendable {
 
         stateQueue.async {
             if self.activePlan == nil {
+                guard !self.failedModelRawValues.contains(file.model.rawValue) else { return }
                 self.completedModelsDuringBackgroundEvents.insert(file.model.rawValue)
-            } else {
-                self.activePlan?.pendingCount -= 1
-                self.taskBytes[task.taskIdentifier] = max(self.taskBytes[task.taskIdentifier] ?? 0, file.size)
+                return
             }
+
+            guard self.activeTaskIDs.remove(task.taskIdentifier) != nil,
+                  self.failedTaskIDs.remove(task.taskIdentifier) == nil,
+                  self.activePlan?.modelRawValue == file.model.rawValue
+            else { return }
+
+            self.activePlan?.pendingCount -= 1
+            self.taskBytes[task.taskIdentifier] = max(self.taskBytes[task.taskIdentifier] ?? 0, file.size)
             self.completeIfNeeded()
         }
     }
@@ -211,11 +222,15 @@ final class ModelBackgroundDownloadService: NSObject, @unchecked Sendable {
         guard let plan = activePlan, plan.pendingCount <= 0 else { return }
         activePlan = nil
         taskBytes = [:]
+        activeTaskIDs = []
+        failedTaskIDs = []
         let handler = backgroundCompletionHandler
         backgroundCompletionHandler = nil
 
         guard let model = LocalTranscriptionModel(rawValue: plan.modelRawValue) else {
-            handler?()
+            Task { @MainActor in
+                handler?()
+            }
             return
         }
 
@@ -226,18 +241,37 @@ final class ModelBackgroundDownloadService: NSObject, @unchecked Sendable {
     }
 
     private func fail(_ task: URLSessionTask?, error: Error) {
-        let model = task?.taskDescription.flatMap { ModelDownloadFile(taskDescription: $0)?.model }
-            ?? activePlan.flatMap { LocalTranscriptionModel(rawValue: $0.modelRawValue) }
-        let handler: SendableCompletionHandler? = stateQueue.sync {
+        let taskModel = task?.taskDescription.flatMap { ModelDownloadFile(taskDescription: $0)?.model }
+        let (model, handler): (LocalTranscriptionModel?, SendableCompletionHandler?) = stateQueue.sync {
+            let resolvedModel = taskModel ?? activePlan.flatMap { LocalTranscriptionModel(rawValue: $0.modelRawValue) }
+            if let resolvedModel, failedModelRawValues.contains(resolvedModel.rawValue) {
+                return (nil, nil)
+            }
+            if let task {
+                failedTaskIDs.insert(task.taskIdentifier)
+            }
+            if let resolvedModel {
+                failedModelRawValues.insert(resolvedModel.rawValue)
+            }
             activePlan = nil
             taskBytes = [:]
+            activeTaskIDs = []
             let handler = backgroundCompletionHandler
             backgroundCompletionHandler = nil
-            return handler
+            return (resolvedModel, handler)
+        }
+
+        session.getAllTasks { tasks in
+            let tasksToCancel = tasks.filter { task in
+                task.taskDescription.flatMap(ModelDownloadFile.init(taskDescription:))?.model == model
+            }
+            tasksToCancel.forEach { $0.cancel() }
         }
 
         guard let model else {
-            handler?()
+            Task { @MainActor in
+                handler?()
+            }
             return
         }
 
@@ -290,6 +324,7 @@ extension ModelBackgroundDownloadService: URLSessionDownloadDelegate {
             let handler = self.backgroundCompletionHandler
             let completedModels = self.completedModelsDuringBackgroundEvents.compactMap(LocalTranscriptionModel.init(rawValue:))
             self.completedModelsDuringBackgroundEvents = []
+            completedModels.forEach { self.failedModelRawValues.remove($0.rawValue) }
             self.backgroundCompletionHandler = nil
             DispatchQueue.main.async {
                 completedModels.forEach { model in
@@ -397,12 +432,6 @@ private struct ModelDownloadSpec {
 
     var repoRoot: URL {
         modelsRoot.appendingPathComponent(repoFolderName, isDirectory: true)
-    }
-
-    var requiredModelsExist: Bool {
-        requiredModels.allSatisfy {
-            FileManager.default.fileExists(atPath: repoRoot.appendingPathComponent($0).path)
-        }
     }
 
     func destinationURL(for localPath: String) -> URL {

--- a/Muesli/ModelBackgroundDownloadService.swift
+++ b/Muesli/ModelBackgroundDownloadService.swift
@@ -1,0 +1,434 @@
+import Foundation
+@preconcurrency import FluidAudio
+
+@MainActor
+protocol ModelBackgroundDownloadServiceDelegate: AnyObject {
+    func modelBackgroundDownloadDidUpdate(model: LocalTranscriptionModel, progress: Double, detail: String)
+    func modelBackgroundDownloadDidFinish(model: LocalTranscriptionModel)
+    func modelBackgroundDownloadDidFail(model: LocalTranscriptionModel, message: String)
+}
+
+final class ModelBackgroundDownloadService: NSObject, @unchecked Sendable {
+    static let shared = ModelBackgroundDownloadService()
+
+    private static let sessionIdentifier = "com.phequals7.muesli.ios.model-downloads"
+
+    @MainActor weak var delegate: ModelBackgroundDownloadServiceDelegate?
+
+    private let stateQueue = DispatchQueue(label: "com.phequals7.muesli.model-background-download")
+    private var activePlan: DownloadPlan?
+    private var taskBytes: [Int: Int64] = [:]
+    private var backgroundCompletionHandler: SendableCompletionHandler?
+    private var completedModelsDuringBackgroundEvents = Set<String>()
+
+    private lazy var session: URLSession = {
+        let configuration = URLSessionConfiguration.background(withIdentifier: Self.sessionIdentifier)
+        configuration.sessionSendsLaunchEvents = true
+        configuration.isDiscretionary = false
+        configuration.allowsCellularAccess = true
+        configuration.waitsForConnectivity = true
+        configuration.timeoutIntervalForResource = 60 * 60
+        return URLSession(configuration: configuration, delegate: self, delegateQueue: nil)
+    }()
+
+    private override init() {
+        super.init()
+    }
+
+    func setBackgroundCompletionHandler(_ handler: @escaping () -> Void) {
+        let handler = SendableCompletionHandler(handler)
+        _ = session
+        stateQueue.async {
+            self.backgroundCompletionHandler = handler
+        }
+    }
+
+    func startDownload(for model: LocalTranscriptionModel) async throws -> Bool {
+        guard let spec = ModelDownloadSpec(model: model) else {
+            return false
+        }
+
+        if spec.requiredModelsExist {
+            return false
+        }
+
+        let files = try await Self.listFiles(for: spec)
+        let missingFiles = files.filter { file in
+            !FileManager.default.fileExists(atPath: spec.destinationURL(for: file.localPath).path)
+        }
+
+        guard !missingFiles.isEmpty else {
+            return false
+        }
+
+        let totalBytes = missingFiles.reduce(Int64(0)) { partial, file in
+            partial + max(0, file.size)
+        }
+        let plan = DownloadPlan(modelRawValue: model.rawValue, totalBytes: max(totalBytes, 1), pendingCount: missingFiles.count)
+
+        await MainActor.run {
+            delegate?.modelBackgroundDownloadDidUpdate(
+                model: model,
+                progress: 0,
+                detail: "Downloading model files..."
+            )
+        }
+
+        stateQueue.sync {
+            activePlan = plan
+            taskBytes = [:]
+        }
+
+        for file in missingFiles {
+            try Task.checkCancellation()
+            let destination = spec.destinationURL(for: file.localPath)
+            try FileManager.default.createDirectory(
+                at: destination.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+
+            if file.size == 0 {
+                FileManager.default.createFile(atPath: destination.path, contents: Data())
+                stateQueue.async {
+                    self.activePlan?.pendingCount -= 1
+                    self.completeIfNeeded()
+                }
+                continue
+            }
+
+            var request = URLRequest(url: file.remoteURL)
+            request.timeoutInterval = 60 * 30
+            let task = session.downloadTask(with: request)
+            task.taskDescription = file.taskDescription(model: model)
+            stateQueue.sync {
+                taskBytes[task.taskIdentifier] = 0
+            }
+            task.resume()
+        }
+
+        return true
+    }
+
+    private static func listFiles(for spec: ModelDownloadSpec) async throws -> [ModelDownloadFile] {
+        var files: [ModelDownloadFile] = []
+
+        func listDirectory(path: String) async throws {
+            let apiPath = path.isEmpty ? "tree/main" : "tree/main/\(path)"
+            let urlString = "https://huggingface.co/api/models/\(spec.remotePath)/\(apiPath)"
+            guard let url = URL(string: urlString) else { return }
+            let (data, response) = try await URLSession.shared.data(from: url)
+            if let http = response as? HTTPURLResponse, !(200..<300).contains(http.statusCode) {
+                throw URLError(.badServerResponse)
+            }
+            guard let items = try JSONSerialization.jsonObject(with: data) as? [[String: Any]] else {
+                throw URLError(.cannotParseResponse)
+            }
+
+            for item in items {
+                guard let itemPath = item["path"] as? String,
+                      let itemType = item["type"] as? String
+                else { continue }
+
+                if itemType == "directory" {
+                    if spec.shouldProcessDirectory(itemPath) {
+                        try await listDirectory(path: itemPath)
+                    }
+                } else if itemType == "file", spec.shouldDownloadFile(itemPath) {
+                    let localPath = spec.localPath(forRemotePath: itemPath)
+                    guard let encodedPath = itemPath.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed),
+                          let remoteURL = URL(string: "https://huggingface.co/\(spec.remotePath)/resolve/main/\(encodedPath)")
+                    else { continue }
+                    files.append(
+                        ModelDownloadFile(
+                            remotePath: itemPath,
+                            localPath: localPath,
+                            remoteURL: remoteURL,
+                            size: Int64(item["size"] as? Int ?? 0)
+                        )
+                    )
+                }
+            }
+        }
+
+        try await listDirectory(path: spec.subPath ?? "")
+        return files
+    }
+
+    private func updateProgress(taskIdentifier: Int, bytesWritten: Int64) {
+        var snapshot: (LocalTranscriptionModel, Double)?
+        stateQueue.sync {
+            guard let plan = activePlan,
+                  let model = LocalTranscriptionModel(rawValue: plan.modelRawValue)
+            else {
+                snapshot = nil
+                return
+            }
+            taskBytes[taskIdentifier] = bytesWritten
+            let completed = taskBytes.values.reduce(Int64(0), +)
+            snapshot = (model, min(max(Double(completed) / Double(plan.totalBytes), 0), 0.98))
+        }
+
+        guard let snapshot else { return }
+        Task { @MainActor in
+            delegate?.modelBackgroundDownloadDidUpdate(
+                model: snapshot.0,
+                progress: snapshot.1,
+                detail: "\(Int((snapshot.1 * 100).rounded()))% downloaded"
+            )
+        }
+    }
+
+    private func completeTask(_ task: URLSessionTask, location: URL) throws {
+        guard let description = task.taskDescription,
+              let file = ModelDownloadFile(taskDescription: description),
+              let spec = ModelDownloadSpec(model: file.model)
+        else {
+            throw URLError(.badURL)
+        }
+
+        let destination = spec.destinationURL(for: file.localPath)
+        try FileManager.default.createDirectory(
+            at: destination.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        if FileManager.default.fileExists(atPath: destination.path) {
+            try FileManager.default.removeItem(at: destination)
+        }
+        try FileManager.default.moveItem(at: location, to: destination)
+
+        stateQueue.async {
+            if self.activePlan == nil {
+                self.completedModelsDuringBackgroundEvents.insert(file.model.rawValue)
+            } else {
+                self.activePlan?.pendingCount -= 1
+                self.taskBytes[task.taskIdentifier] = max(self.taskBytes[task.taskIdentifier] ?? 0, file.size)
+            }
+            self.completeIfNeeded()
+        }
+    }
+
+    private func completeIfNeeded() {
+        guard let plan = activePlan, plan.pendingCount <= 0 else { return }
+        activePlan = nil
+        taskBytes = [:]
+        let handler = backgroundCompletionHandler
+        backgroundCompletionHandler = nil
+
+        guard let model = LocalTranscriptionModel(rawValue: plan.modelRawValue) else {
+            handler?()
+            return
+        }
+
+        Task { @MainActor in
+            delegate?.modelBackgroundDownloadDidFinish(model: model)
+            handler?()
+        }
+    }
+
+    private func fail(_ task: URLSessionTask?, error: Error) {
+        let model = task?.taskDescription.flatMap { ModelDownloadFile(taskDescription: $0)?.model }
+            ?? activePlan.flatMap { LocalTranscriptionModel(rawValue: $0.modelRawValue) }
+        let handler: SendableCompletionHandler? = stateQueue.sync {
+            activePlan = nil
+            taskBytes = [:]
+            let handler = backgroundCompletionHandler
+            backgroundCompletionHandler = nil
+            return handler
+        }
+
+        guard let model else {
+            handler?()
+            return
+        }
+
+        Task { @MainActor in
+            delegate?.modelBackgroundDownloadDidFail(
+                model: model,
+                message: "Download paused. Check your connection and try again."
+            )
+            handler?()
+        }
+    }
+}
+
+extension ModelBackgroundDownloadService: URLSessionDownloadDelegate {
+    nonisolated func urlSession(
+        _ session: URLSession,
+        downloadTask: URLSessionDownloadTask,
+        didWriteData bytesWritten: Int64,
+        totalBytesWritten: Int64,
+        totalBytesExpectedToWrite: Int64
+    ) {
+        updateProgress(taskIdentifier: downloadTask.taskIdentifier, bytesWritten: totalBytesWritten)
+    }
+
+    nonisolated func urlSession(
+        _ session: URLSession,
+        downloadTask: URLSessionDownloadTask,
+        didFinishDownloadingTo location: URL
+    ) {
+        do {
+            try completeTask(downloadTask, location: location)
+        } catch {
+            fail(downloadTask, error: error)
+        }
+    }
+
+    nonisolated func urlSession(
+        _ session: URLSession,
+        task: URLSessionTask,
+        didCompleteWithError error: Error?
+    ) {
+        if let error {
+            fail(task, error: error)
+        }
+    }
+
+    nonisolated func urlSessionDidFinishEvents(forBackgroundURLSession session: URLSession) {
+        stateQueue.async {
+            guard self.activePlan == nil else { return }
+            let handler = self.backgroundCompletionHandler
+            let completedModels = self.completedModelsDuringBackgroundEvents.compactMap(LocalTranscriptionModel.init(rawValue:))
+            self.completedModelsDuringBackgroundEvents = []
+            self.backgroundCompletionHandler = nil
+            DispatchQueue.main.async {
+                completedModels.forEach { model in
+                    self.delegate?.modelBackgroundDownloadDidFinish(model: model)
+                }
+                handler?()
+            }
+        }
+    }
+}
+
+private final class SendableCompletionHandler: @unchecked Sendable {
+    private let handler: () -> Void
+
+    init(_ handler: @escaping () -> Void) {
+        self.handler = handler
+    }
+
+    func callAsFunction() {
+        handler()
+    }
+}
+
+private struct DownloadPlan {
+    let modelRawValue: String
+    let totalBytes: Int64
+    var pendingCount: Int
+}
+
+private struct ModelDownloadFile {
+    let remotePath: String
+    let localPath: String
+    let remoteURL: URL
+    let size: Int64
+    let model: LocalTranscriptionModel
+
+    init(remotePath: String, localPath: String, remoteURL: URL, size: Int64, model: LocalTranscriptionModel? = nil) {
+        self.remotePath = remotePath
+        self.localPath = localPath
+        self.remoteURL = remoteURL
+        self.size = size
+        self.model = model ?? .defaultModel
+    }
+
+    init?(taskDescription: String) {
+        let parts = taskDescription.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+        guard parts.count == 5,
+              let model = LocalTranscriptionModel(rawValue: parts[0]),
+              let remoteURL = URL(string: parts[3]),
+              let size = Int64(parts[4])
+        else {
+            return nil
+        }
+        self.model = model
+        remotePath = parts[1]
+        localPath = parts[2]
+        self.remoteURL = remoteURL
+        self.size = size
+    }
+
+    func taskDescription(model: LocalTranscriptionModel) -> String {
+        [model.rawValue, remotePath, localPath, remoteURL.absoluteString, String(size)].joined(separator: "\n")
+    }
+}
+
+private struct ModelDownloadSpec {
+    let model: LocalTranscriptionModel
+    let repoFolderName: String
+    let remotePath: String
+    let subPath: String?
+    let requiredModels: Set<String>
+
+    init?(model: LocalTranscriptionModel) {
+        self.model = model
+        switch model {
+        case .parakeetTdtCtc110m:
+            repoFolderName = "parakeet-tdt-ctc-110m"
+            remotePath = "FluidInference/parakeet-tdt-ctc-110m-coreml"
+            subPath = nil
+            requiredModels = [
+                "Preprocessor.mlmodelc",
+                "Decoder.mlmodelc",
+                "JointDecision.mlmodelc"
+            ]
+        case .parakeetV3:
+            repoFolderName = "parakeet-tdt-0.6b-v3-coreml"
+            remotePath = "FluidInference/parakeet-tdt-0.6b-v3-coreml"
+            subPath = nil
+            requiredModels = [
+                "Preprocessor.mlmodelc",
+                "Encoder.mlmodelc",
+                "Decoder.mlmodelc",
+                "JointDecisionv3.mlmodelc"
+            ]
+        case .parakeetRealtimeEou120m:
+            return nil
+        }
+    }
+
+    var modelsRoot: URL {
+        FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+            .appendingPathComponent("FluidAudio", isDirectory: true)
+            .appendingPathComponent("Models", isDirectory: true)
+    }
+
+    var repoRoot: URL {
+        modelsRoot.appendingPathComponent(repoFolderName, isDirectory: true)
+    }
+
+    var requiredModelsExist: Bool {
+        requiredModels.allSatisfy {
+            FileManager.default.fileExists(atPath: repoRoot.appendingPathComponent($0).path)
+        }
+    }
+
+    func destinationURL(for localPath: String) -> URL {
+        repoRoot.appendingPathComponent(localPath)
+    }
+
+    func localPath(forRemotePath remotePath: String) -> String {
+        guard let subPath, remotePath.hasPrefix("\(subPath)/") else {
+            return remotePath
+        }
+        return String(remotePath.dropFirst(subPath.count + 1))
+    }
+
+    func shouldProcessDirectory(_ path: String) -> Bool {
+        if let subPath {
+            return path == subPath
+                || path.hasPrefix("\(subPath)/")
+                || requiredModels.contains { "\($0)/".hasPrefix(path + "/") }
+        }
+        return requiredModels.contains { path == $0 || $0.hasPrefix(path + "/") || path.hasPrefix("\($0)/") }
+    }
+
+    func shouldDownloadFile(_ path: String) -> Bool {
+        let local = localPath(forRemotePath: path)
+        return requiredModels.contains { local.hasPrefix("\($0)/") }
+            || local.hasSuffix(".json")
+            || local.hasSuffix(".txt")
+    }
+}

--- a/Muesli/ModelsView.swift
+++ b/Muesli/ModelsView.swift
@@ -90,11 +90,12 @@ struct ModelsView: View {
                         .font(MuesliTheme.headline())
                         .frame(maxWidth: .infinity)
                         .frame(height: 48)
+                        .foregroundStyle(modelButtonDisabled ? MuesliTheme.textTertiary : .white)
+                        .background(modelButtonDisabled ? MuesliTheme.surfacePrimary : MuesliTheme.accent)
+                        .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+                        .contentShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
                 }
                 .buttonStyle(.plain)
-                .foregroundStyle(modelButtonDisabled ? MuesliTheme.textTertiary : .white)
-                .background(modelButtonDisabled ? MuesliTheme.surfacePrimary : MuesliTheme.accent)
-                .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
                 .disabled(modelButtonDisabled)
             }
             .padding(MuesliTheme.spacing16)

--- a/Muesli/ModelsView.swift
+++ b/Muesli/ModelsView.swift
@@ -135,7 +135,7 @@ struct ModelsView: View {
         case .ready:
             MuesliTheme.success
         case .failed:
-            MuesliTheme.recording
+            MuesliTheme.destructive
         case .downloading, .preparing:
             MuesliTheme.transcribing
         case .idle:

--- a/Muesli/MuesliApp.swift
+++ b/Muesli/MuesliApp.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 @main
 struct MuesliApp: App {
+    @UIApplicationDelegateAdaptor(MuesliAppDelegate.self) private var appDelegate
     @State private var coordinator = DictationCoordinator()
     @Environment(\.scenePhase) private var scenePhase
 

--- a/Muesli/MuesliAppDelegate.swift
+++ b/Muesli/MuesliAppDelegate.swift
@@ -1,0 +1,11 @@
+import UIKit
+
+final class MuesliAppDelegate: NSObject, UIApplicationDelegate {
+    func application(
+        _ application: UIApplication,
+        handleEventsForBackgroundURLSession identifier: String,
+        completionHandler: @escaping () -> Void
+    ) {
+        ModelBackgroundDownloadService.shared.setBackgroundCompletionHandler(completionHandler)
+    }
+}

--- a/Muesli/MuesliAudioCues.swift
+++ b/Muesli/MuesliAudioCues.swift
@@ -1,0 +1,10 @@
+import AudioToolbox
+import UIKit
+
+@MainActor
+enum MuesliAudioCues {
+    static func modelReady() {
+        UINotificationFeedbackGenerator().notificationOccurred(.success)
+        AudioServicesPlayAlertSound(SystemSoundID(1007))
+    }
+}

--- a/Muesli/MuesliLiveActivityController.swift
+++ b/Muesli/MuesliLiveActivityController.swift
@@ -178,9 +178,9 @@ actor MuesliLiveActivityController {
     private func accent(for phase: String) -> String {
         switch phase.lowercased() {
         case "listening", "recording":
-            "red"
+            "blue"
         case "transcribing":
-            "orange"
+            "green"
         default:
             "blue"
         }

--- a/Muesli/MuesliPreferences.swift
+++ b/Muesli/MuesliPreferences.swift
@@ -27,9 +27,9 @@ enum MuesliPreferences {
     }
 
     static var accentTheme: MuesliAccentTheme {
-        MuesliAccentTheme(
+        MuesliAccentTheme.resolved(
             rawValue: UserDefaults.standard.string(forKey: accentThemeKey) ?? ""
-        ) ?? .blue
+        )
     }
 
     static var liveActivitiesForDictationsEnabled: Bool {

--- a/Muesli/OnboardingView.swift
+++ b/Muesli/OnboardingView.swift
@@ -420,6 +420,8 @@ struct OnboardingView: View {
                                     lineWidth: 1
                                 )
                         )
+                        .padding(.vertical, 5)
+                        .contentShape(Capsule())
                 }
                 .buttonStyle(.plain)
                 .disabled(isComplete)
@@ -706,7 +708,7 @@ struct OnboardingView: View {
         case .failed:
             Label("Model setup needs another try", systemImage: "exclamationmark.triangle.fill")
                 .font(MuesliTheme.captionMedium())
-                .foregroundStyle(MuesliTheme.recording)
+                .foregroundStyle(MuesliTheme.destructive)
         }
     }
 
@@ -774,7 +776,7 @@ struct OnboardingView: View {
                     if let error = coordinator.onboardingTestError {
                         Text(error)
                             .font(MuesliTheme.caption())
-                            .foregroundStyle(MuesliTheme.recording)
+                            .foregroundStyle(MuesliTheme.destructive)
                     }
 
                     if coordinator.modelPreparation.isReady {
@@ -1392,7 +1394,7 @@ struct OnboardingView: View {
         case .ready:
             MuesliTheme.success
         case .failed:
-            MuesliTheme.recording
+            MuesliTheme.destructive
         case .preparing:
             MuesliTheme.transcribing
         default:
@@ -1442,7 +1444,7 @@ private struct CompactModelPreparationIndicator: View {
             case .failed:
                 Image(systemName: "exclamationmark")
                     .font(.system(size: 14, weight: .bold))
-                    .foregroundStyle(MuesliTheme.recording)
+                    .foregroundStyle(MuesliTheme.destructive)
             case .idle:
                 EmptyView()
             }

--- a/Muesli/OnboardingView.swift
+++ b/Muesli/OnboardingView.swift
@@ -792,8 +792,9 @@ struct OnboardingView: View {
                             .font(MuesliTheme.headline())
                             .frame(maxWidth: .infinity)
                             .frame(height: 48)
-                            .foregroundStyle(.white)
-                            .background(onboardingTestColor)
+                            .foregroundStyle(onboardingTestButtonTextColor)
+                            .background(onboardingTestButtonBackground)
+                            .overlay(onboardingTestButtonBorder)
                             .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
                             .contentShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
                         }
@@ -1131,6 +1132,23 @@ struct OnboardingView: View {
         } else {
             MuesliTheme.accent
         }
+    }
+
+    private var onboardingTestButtonTextColor: Color {
+        coordinator.isOnboardingTestRecording ? MuesliTheme.destructive : .white
+    }
+
+    private var onboardingTestButtonBackground: some View {
+        RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall, style: .continuous)
+            .fill(coordinator.isOnboardingTestRecording ? MuesliTheme.destructiveSubtle : onboardingTestColor)
+    }
+
+    private var onboardingTestButtonBorder: some View {
+        RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall, style: .continuous)
+            .strokeBorder(
+                coordinator.isOnboardingTestRecording ? MuesliTheme.destructive.opacity(0.34) : .clear,
+                lineWidth: 1
+            )
     }
 
     private var onboardingTestButtonTitle: String {

--- a/Muesli/OnboardingView.swift
+++ b/Muesli/OnboardingView.swift
@@ -79,7 +79,7 @@ struct OnboardingView: View {
                 }
                 .padding(.horizontal, MuesliTheme.spacing20)
                 .padding(.top, MuesliTheme.spacing24)
-                .padding(.bottom, MuesliTheme.spacing24)
+                .padding(.bottom, MuesliTheme.spacing32 + 64)
             }
 
             footer
@@ -181,6 +181,12 @@ struct OnboardingView: View {
                         .font(MuesliTheme.callout())
                         .foregroundStyle(MuesliTheme.textSecondary)
                 }
+
+                Spacer(minLength: MuesliTheme.spacing12)
+
+                if shouldShowCompactModelPreparation {
+                    CompactModelPreparationIndicator(state: coordinator.modelPreparation)
+                }
             }
 
             HStack(spacing: MuesliTheme.spacing8) {
@@ -262,10 +268,14 @@ struct OnboardingView: View {
             }
             .frame(maxWidth: .infinity, minHeight: 104, alignment: .topLeading)
             .padding(MuesliTheme.spacing12)
-            .background(selected ? MuesliTheme.surfaceSelected : MuesliTheme.backgroundRaised)
-            .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium))
+            .background(selected ? MuesliTheme.accent.opacity(0.10) : Color.clear)
+            .muesliGlassSurface(
+                cornerRadius: MuesliTheme.cornerMedium,
+                tint: selected ? MuesliTheme.accent : nil,
+                isInteractive: true
+            )
             .overlay(
-                RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium)
+                RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium, style: .continuous)
                     .strokeBorder(selected ? MuesliTheme.accent : MuesliTheme.surfaceBorder, lineWidth: selected ? 1.5 : 1)
             )
         }
@@ -308,12 +318,7 @@ struct OnboardingView: View {
                 }
                 .buttonStyle(.plain)
                 .foregroundStyle(MuesliTheme.accent)
-                .background(MuesliTheme.backgroundRaised)
-                .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
-                .overlay(
-                    RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall)
-                        .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
-                )
+                .muesliGlassButton(cornerRadius: MuesliTheme.cornerMedium, tint: MuesliTheme.accent)
 
                 permissionRow(
                     icon: "keyboard.fill",
@@ -398,10 +403,26 @@ struct OnboardingView: View {
 
                 Spacer()
 
-                Button(buttonTitle, action: action)
-                    .font(MuesliTheme.captionMedium())
-                    .buttonStyle(.borderedProminent)
-                    .disabled(isComplete)
+                Button(action: action) {
+                    Text(buttonTitle)
+                        .font(MuesliTheme.captionMedium())
+                        .foregroundStyle(isComplete ? MuesliTheme.success : .white)
+                        .padding(.horizontal, MuesliTheme.spacing12)
+                        .frame(height: 34)
+                        .background(
+                            Capsule()
+                                .fill(isComplete ? MuesliTheme.success.opacity(0.13) : MuesliTheme.accent)
+                        )
+                        .overlay(
+                            Capsule()
+                                .strokeBorder(
+                                    isComplete ? MuesliTheme.success.opacity(0.45) : MuesliTheme.accent.opacity(0.55),
+                                    lineWidth: 1
+                                )
+                        )
+                }
+                .buttonStyle(.plain)
+                .disabled(isComplete)
             }
             .padding(MuesliTheme.spacing16)
         }
@@ -573,6 +594,9 @@ struct OnboardingView: View {
                 Text("\(coordinator.selectedTranscriptionModel.shortName) runs on CoreML / ANE. First setup downloads and compiles the model for this iPhone.")
                     .font(MuesliTheme.body())
                     .foregroundStyle(MuesliTheme.textSecondary)
+                Text("You can continue setup while this runs in the background. Muesli will keep preparing the model as long as the app stays open.")
+                    .font(MuesliTheme.callout())
+                    .foregroundStyle(MuesliTheme.textTertiary)
             }
 
             modelPicker
@@ -608,7 +632,7 @@ struct OnboardingView: View {
                     Spacer()
                 }
 
-                modelProgress
+                modelBackgroundHint
 
                 if coordinator.modelPreparation.phase == .failed || coordinator.modelPreparation.phase == .idle {
                     Button {
@@ -618,14 +642,18 @@ struct OnboardingView: View {
                             .font(MuesliTheme.headline())
                             .frame(maxWidth: .infinity)
                             .frame(height: 48)
+                            .foregroundStyle(.white)
+                            .background(modelButtonColor)
+                            .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+                            .contentShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
                     }
                     .buttonStyle(.plain)
-                    .foregroundStyle(.white)
-                    .background(modelButtonColor)
-                    .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
                 }
             }
             .padding(MuesliTheme.spacing16)
+        }
+        .onAppear {
+            coordinator.prepareModelForOnboarding()
         }
     }
 
@@ -682,13 +710,30 @@ struct OnboardingView: View {
         }
     }
 
+    @ViewBuilder
+    private var modelBackgroundHint: some View {
+        switch coordinator.modelPreparation.phase {
+        case .downloading, .preparing:
+            Label("Model setup will continue after you leave this step.", systemImage: "arrow.down.circle")
+                .font(MuesliTheme.captionMedium())
+                .foregroundStyle(MuesliTheme.accent)
+        case .ready:
+            EmptyView()
+        case .idle, .failed:
+            Text("If your connection is slow, you can retry here or finish onboarding and prepare the model later from Settings.")
+                .font(MuesliTheme.caption())
+                .foregroundStyle(MuesliTheme.textTertiary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
     private var testStep: some View {
         VStack(alignment: .leading, spacing: MuesliTheme.spacing20) {
             VStack(alignment: .leading, spacing: MuesliTheme.spacing8) {
                 Text("Test Voice Note")
                     .font(MuesliTheme.title1())
                     .foregroundStyle(MuesliTheme.textPrimary)
-                Text("Try saying: \"testing this one out\"")
+                Text(coordinator.modelPreparation.isReady ? "Try saying: \"testing this one out\"" : "You can skip this test while the model finishes preparing in the background.")
                     .font(MuesliTheme.body())
                     .foregroundStyle(MuesliTheme.textSecondary)
             }
@@ -717,10 +762,14 @@ struct OnboardingView: View {
                         .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
                     }
 
-                    Text(coordinator.onboardingTestTranscript.isEmpty ? "Your transcription will appear here." : coordinator.onboardingTestTranscript)
-                        .font(coordinator.onboardingTestTranscript.isEmpty ? MuesliTheme.body() : .system(size: 14, design: .monospaced))
-                        .foregroundStyle(coordinator.onboardingTestTranscript.isEmpty ? MuesliTheme.textTertiary : MuesliTheme.textPrimary)
-                        .frame(maxWidth: .infinity, minHeight: 96, alignment: .topLeading)
+                    if coordinator.modelPreparation.isReady {
+                        Text(coordinator.onboardingTestTranscript.isEmpty ? "Your transcription will appear here." : coordinator.onboardingTestTranscript)
+                            .font(MuesliTheme.body())
+                            .foregroundStyle(coordinator.onboardingTestTranscript.isEmpty ? MuesliTheme.textTertiary : MuesliTheme.textPrimary)
+                            .frame(maxWidth: .infinity, minHeight: 96, alignment: .topLeading)
+                    } else {
+                        modelPreparationInlineStatus
+                    }
 
                     if let error = coordinator.onboardingTestError {
                         Text(error)
@@ -728,31 +777,42 @@ struct OnboardingView: View {
                             .foregroundStyle(MuesliTheme.recording)
                     }
 
-                    Button {
-                        if coordinator.isOnboardingTestRecording {
-                            coordinator.stopOnboardingTestDictation()
-                        } else {
-                            coordinator.startOnboardingTestDictation()
+                    if coordinator.modelPreparation.isReady {
+                        Button {
+                            if coordinator.isOnboardingTestRecording {
+                                coordinator.stopOnboardingTestDictation()
+                            } else {
+                                coordinator.startOnboardingTestDictation()
+                            }
+                        } label: {
+                            Label(
+                                onboardingTestButtonTitle,
+                                systemImage: onboardingTestButtonIcon
+                            )
+                            .font(MuesliTheme.headline())
+                            .frame(maxWidth: .infinity)
+                            .frame(height: 48)
+                            .foregroundStyle(.white)
+                            .background(onboardingTestColor)
+                            .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+                            .contentShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
                         }
-                    } label: {
-                        Label(
-                            onboardingTestButtonTitle,
-                            systemImage: onboardingTestButtonIcon
-                        )
-                        .font(MuesliTheme.headline())
-                        .frame(maxWidth: .infinity)
-                        .frame(height: 48)
-                    }
-                    .buttonStyle(.plain)
-                    .foregroundStyle(.white)
-                    .background(onboardingTestColor)
-                    .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
-                    .disabled(!coordinator.modelPreparation.isReady || coordinator.isOnboardingTestTranscribing)
-
-                    if !coordinator.modelPreparation.isReady {
-                        Text("The test unlocks after model preparation completes.")
-                            .font(MuesliTheme.caption())
-                            .foregroundStyle(MuesliTheme.textTertiary)
+                        .buttonStyle(.plain)
+                        .disabled(coordinator.isOnboardingTestTranscribing)
+                    } else if coordinator.modelPreparation.phase == .failed || coordinator.modelPreparation.phase == .idle {
+                        Button {
+                            coordinator.prepareModelForOnboarding()
+                        } label: {
+                            Label("Retry Model Setup", systemImage: "arrow.clockwise")
+                                .font(MuesliTheme.headline())
+                                .frame(maxWidth: .infinity)
+                                .frame(height: 48)
+                                .foregroundStyle(.white)
+                                .background(MuesliTheme.accent)
+                                .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+                                .contentShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+                        }
+                        .buttonStyle(.plain)
                     }
                 }
                 .padding(MuesliTheme.spacing16)
@@ -763,6 +823,30 @@ struct OnboardingView: View {
                 coordinator.prepareModelForOnboarding()
             }
         }
+    }
+
+    private var modelPreparationInlineStatus: some View {
+        VStack(alignment: .leading, spacing: MuesliTheme.spacing12) {
+            HStack(alignment: .top, spacing: MuesliTheme.spacing12) {
+                modelStatusIcon
+
+                VStack(alignment: .leading, spacing: MuesliTheme.spacing4) {
+                    Text(coordinator.modelPreparation.status)
+                        .font(MuesliTheme.headline())
+                        .foregroundStyle(MuesliTheme.textPrimary)
+                    Text(coordinator.modelPreparation.detail)
+                        .font(MuesliTheme.caption())
+                        .foregroundStyle(MuesliTheme.textSecondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+
+            Text("Finish onboarding now, or come back here when setup is ready to test voice notes.")
+                .font(MuesliTheme.caption())
+                .foregroundStyle(MuesliTheme.textTertiary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .frame(maxWidth: .infinity, minHeight: 96, alignment: .topLeading)
     }
 
     private var meetingSummaryStep: some View {
@@ -916,9 +1000,8 @@ struct OnboardingView: View {
                         .font(.system(size: 15, weight: .semibold))
                         .frame(width: 44, height: 48)
                         .foregroundStyle(MuesliTheme.textSecondary)
-                        .background(MuesliTheme.backgroundRaised)
-                        .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
-                        .contentShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+                        .muesliGlassButton(cornerRadius: MuesliTheme.cornerMedium)
+                        .contentShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium, style: .continuous))
                 }
                 .buttonStyle(.plain)
             }
@@ -935,8 +1018,12 @@ struct OnboardingView: View {
                 .frame(height: 48)
                 .foregroundStyle(.white)
                 .background(canContinue ? MuesliTheme.accent : MuesliTheme.surfacePrimary)
-                .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
-                .contentShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+                .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium, style: .continuous))
+                .overlay(
+                    RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium, style: .continuous)
+                        .strokeBorder(MuesliTheme.glassHighlight, lineWidth: canContinue ? 0.8 : 0)
+                )
+                .contentShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium, style: .continuous))
             }
             .buttonStyle(.plain)
             .disabled(!canContinue)
@@ -956,9 +1043,13 @@ struct OnboardingView: View {
         case .sync:
             iCloudSyncEnabled ? "Continue" : "Skip for Now"
         case .model:
-            coordinator.modelPreparation.isReady ? "Continue" : "Skip for Now"
+            coordinator.modelPreparation.isReady ? "Continue" : "Continue in Background"
         case .test:
-            isLastStep ? "Finish" : "Continue"
+            if coordinator.onboardingTestTranscript.isEmpty {
+                "Skip Test"
+            } else {
+                isLastStep ? "Finish" : "Continue"
+            }
         case .summary:
             isLastStep ? "Finish" : "Continue"
         }
@@ -973,9 +1064,9 @@ struct OnboardingView: View {
         case .sync:
             true
         case .model:
-            !coordinator.modelPreparation.isPreparing
+            true
         case .test:
-            !isOnboardingTestActive && !coordinator.onboardingTestTranscript.isEmpty
+            !isOnboardingTestActive
         case .summary:
             !isSigningInChatGPT
         }
@@ -1289,6 +1380,92 @@ struct OnboardingView: View {
         default:
             MuesliTheme.accent
         }
+    }
+
+    private var shouldShowCompactModelPreparation: Bool {
+        switch coordinator.modelPreparation.phase {
+        case .downloading, .preparing, .ready, .failed:
+            true
+        case .idle:
+            false
+        }
+    }
+}
+
+private struct CompactModelPreparationIndicator: View {
+    let state: ModelPreparationState
+
+    var body: some View {
+        ZStack {
+            Circle()
+                .fill(MuesliTheme.backgroundRaised.opacity(0.86))
+                .frame(width: 38, height: 38)
+                .overlay(
+                    Circle()
+                        .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
+                )
+
+            switch state.phase {
+            case .downloading:
+                ModelPreparationPie(progress: state.progress ?? 0)
+                    .fill(MuesliTheme.accent)
+                    .frame(width: 24, height: 24)
+                    .overlay(
+                        Circle()
+                            .stroke(MuesliTheme.accent.opacity(0.45), lineWidth: 1.5)
+                    )
+            case .preparing:
+                ProgressView()
+                    .controlSize(.small)
+            case .ready:
+                Image(systemName: "checkmark")
+                    .font(.system(size: 14, weight: .bold))
+                    .foregroundStyle(MuesliTheme.success)
+            case .failed:
+                Image(systemName: "exclamationmark")
+                    .font(.system(size: 14, weight: .bold))
+                    .foregroundStyle(MuesliTheme.recording)
+            case .idle:
+                EmptyView()
+            }
+        }
+        .accessibilityLabel(accessibilityLabel)
+    }
+
+    private var accessibilityLabel: String {
+        switch state.phase {
+        case .downloading:
+            "Model downloading"
+        case .preparing:
+            "Model preparing"
+        case .ready:
+            "Model ready"
+        case .failed:
+            "Model setup failed"
+        case .idle:
+            "Model setup idle"
+        }
+    }
+}
+
+private struct ModelPreparationPie: Shape {
+    var progress: Double
+
+    func path(in rect: CGRect) -> Path {
+        let normalized = min(max(progress, 0), 1)
+        var path = Path()
+        let center = CGPoint(x: rect.midX, y: rect.midY)
+        let radius = min(rect.width, rect.height) / 2
+        path.move(to: center)
+        path.addArc(
+            center: center,
+            radius: radius,
+            startAngle: .degrees(-90),
+            endAngle: .degrees(-90 + normalized * 360),
+            clockwise: false
+        )
+        path.closeSubpath()
+        return path
     }
 }
 

--- a/Muesli/OnboardingView.swift
+++ b/Muesli/OnboardingView.swift
@@ -1135,12 +1135,12 @@ struct OnboardingView: View {
     }
 
     private var onboardingTestButtonTextColor: Color {
-        coordinator.isOnboardingTestRecording ? MuesliTheme.destructive : .white
+        .white
     }
 
     private var onboardingTestButtonBackground: some View {
         RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall, style: .continuous)
-            .fill(coordinator.isOnboardingTestRecording ? MuesliTheme.destructiveSubtle : onboardingTestColor)
+            .fill(coordinator.isOnboardingTestRecording ? MuesliTheme.destructive.opacity(0.32) : onboardingTestColor)
     }
 
     private var onboardingTestButtonBorder: some View {

--- a/Muesli/RootView.swift
+++ b/Muesli/RootView.swift
@@ -35,7 +35,7 @@ struct RootView: View {
     }
 
     private var currentAccent: Color {
-        MuesliTheme.color(for: MuesliAccentTheme(rawValue: accentTheme) ?? .blue)
+        MuesliTheme.color(for: MuesliAccentTheme.resolved(rawValue: accentTheme))
     }
 
     private var preferredColorScheme: ColorScheme? {

--- a/Muesli/RootView.swift
+++ b/Muesli/RootView.swift
@@ -88,9 +88,7 @@ struct RootView: View {
                             .font(.system(size: 18, weight: .semibold))
                             .foregroundStyle(MuesliTheme.textPrimary)
                             .frame(width: 44, height: 44)
-                            .background(.regularMaterial)
-                            .clipShape(Circle())
-                            .overlay(Circle().strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1))
+                            .muesliGlassButton(cornerRadius: 22, tint: currentAccent)
                             .contentShape(Circle())
                     }
                     .buttonStyle(.plain)
@@ -209,8 +207,10 @@ private struct KeyboardHandoffOverlay: View {
                     .foregroundStyle(MuesliTheme.textPrimary)
                     .frame(maxWidth: .infinity)
                     .frame(height: 52)
-                    .background(MuesliTheme.backgroundRaised)
-                    .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+                    .muesliGlassSurface(
+                        cornerRadius: MuesliTheme.cornerMedium,
+                        tint: coordinator.isRecording ? MuesliTheme.recording : MuesliTheme.transcribing
+                    )
             }
             .padding(MuesliTheme.spacing24)
         }
@@ -321,33 +321,33 @@ private struct MuesliTabSwitcher: View {
     let pinnedSections: [AppSection]
 
     var body: some View {
-        HStack(spacing: MuesliTheme.spacing4) {
-            ForEach(pinnedSections, id: \.self) { section in
-                Button {
-                    selectedSection = section
-                } label: {
-                    Text(section.title)
-                        .font(.system(size: 14, weight: .semibold))
-                        .lineLimit(1)
-                        .minimumScaleFactor(0.82)
-                    .foregroundStyle(selectedSection == section ? accent : MuesliTheme.textSecondary)
-                    .frame(maxWidth: .infinity)
-                    .frame(height: 44)
-                    .background(selectedSection == section ? MuesliTheme.surfaceSelected : Color.clear)
-                    .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium))
-                    .contentShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium))
+        MuesliGlassGroup(spacing: MuesliTheme.spacing8) {
+            HStack(spacing: MuesliTheme.spacing4) {
+                ForEach(pinnedSections, id: \.self) { section in
+                    Button {
+                        withAnimation(.snappy(duration: 0.18)) {
+                            selectedSection = section
+                        }
+                    } label: {
+                        Label(section.title, systemImage: section.icon)
+                            .labelStyle(.titleAndIcon)
+                            .font(.system(size: 13, weight: .semibold))
+                            .lineLimit(1)
+                            .minimumScaleFactor(0.82)
+                            .foregroundStyle(selectedSection == section ? accent : MuesliTheme.textSecondary)
+                            .frame(maxWidth: .infinity)
+                            .frame(height: 44)
+                            .background(selectedSection == section ? accent.opacity(0.13) : Color.clear)
+                            .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium, style: .continuous))
+                            .contentShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium, style: .continuous))
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityIdentifier("tab.\(section.rawValue)")
                 }
-                .buttonStyle(.plain)
-                .accessibilityIdentifier("tab.\(section.rawValue)")
             }
+            .padding(MuesliTheme.spacing4)
+            .muesliGlassSurface(cornerRadius: MuesliTheme.cornerLarge, tint: accent, isInteractive: true)
         }
-        .padding(MuesliTheme.spacing4)
-        .background(.regularMaterial)
-        .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerLarge))
-        .overlay(
-            RoundedRectangle(cornerRadius: MuesliTheme.cornerLarge)
-                .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
-        )
     }
 }
 
@@ -416,8 +416,7 @@ private struct MuesliDrawer: View {
                         .font(.system(size: 14, weight: .bold))
                         .foregroundStyle(MuesliTheme.textSecondary)
                         .frame(width: 34, height: 34)
-                        .background(MuesliTheme.surfacePrimary)
-                        .clipShape(Circle())
+                        .muesliGlassButton(cornerRadius: 17)
                         .contentShape(Circle())
                 }
                 .buttonStyle(.plain)
@@ -483,9 +482,9 @@ private struct SidebarSectionRow: View {
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .frame(height: 52)
                 .padding(.leading, MuesliTheme.spacing12)
-                .background(isSelected ? MuesliTheme.surfaceSelected : Color.clear)
-                .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
-                .contentShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+                .background(isSelected ? accent.opacity(0.12) : Color.clear)
+                .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium, style: .continuous))
+                .contentShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium, style: .continuous))
             }
             .buttonStyle(.plain)
 

--- a/Muesli/SettingsView.swift
+++ b/Muesli/SettingsView.swift
@@ -554,7 +554,7 @@ struct SettingsView: View {
     }
 
     private var selectedAccentTheme: MuesliAccentTheme {
-        MuesliAccentTheme(rawValue: accentTheme) ?? .blue
+        MuesliAccentTheme.resolved(rawValue: accentTheme)
     }
 
     private var modelButtonTitle: String {
@@ -1030,7 +1030,7 @@ private struct SettingsAccentThemePicker: View {
     @Binding var selection: String
 
     private var selectedTheme: MuesliAccentTheme {
-        MuesliAccentTheme(rawValue: selection) ?? .blue
+        MuesliAccentTheme.resolved(rawValue: selection)
     }
 
     var body: some View {
@@ -1085,8 +1085,9 @@ private struct SettingsAccentThemePicker: View {
     }
 
     private func normalizeSelectionIfNeeded() {
-        guard MuesliAccentTheme(rawValue: selection) == nil else { return }
-        selection = MuesliAccentTheme.blue.rawValue
+        let resolved = MuesliAccentTheme.resolved(rawValue: selection)
+        guard selection != resolved.rawValue else { return }
+        selection = resolved.rawValue
     }
 }
 

--- a/Muesli/SettingsView.swift
+++ b/Muesli/SettingsView.swift
@@ -367,11 +367,12 @@ struct SettingsView: View {
                             .font(MuesliTheme.headline())
                             .frame(maxWidth: .infinity)
                             .frame(height: 48)
+                            .foregroundStyle(modelButtonDisabled ? MuesliTheme.textTertiary : .white)
+                            .background(modelButtonDisabled ? MuesliTheme.surfacePrimary : MuesliTheme.accent)
+                            .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+                            .contentShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
                     }
                     .buttonStyle(.plain)
-                    .foregroundStyle(modelButtonDisabled ? MuesliTheme.textTertiary : .white)
-                    .background(modelButtonDisabled ? MuesliTheme.surfacePrimary : MuesliTheme.accent)
-                    .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
                     .disabled(modelButtonDisabled)
                 }
                 .padding(MuesliTheme.spacing16)

--- a/Muesli/SyncQRCodeScannerView.swift
+++ b/Muesli/SyncQRCodeScannerView.swift
@@ -144,11 +144,12 @@ struct SyncQRCodeScannerView: View {
                         .font(MuesliTheme.headline())
                         .frame(maxWidth: .infinity)
                         .frame(height: 44)
+                        .foregroundStyle(.white)
+                        .background(MuesliTheme.accent)
+                        .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+                        .contentShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
                 }
                 .buttonStyle(.plain)
-                .foregroundStyle(.white)
-                .background(MuesliTheme.accent)
-                .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
             }
             .padding(MuesliTheme.spacing16)
         }

--- a/Muesli/SyncQRCodeScannerView.swift
+++ b/Muesli/SyncQRCodeScannerView.swift
@@ -301,7 +301,7 @@ private enum ScanResult {
         case .readyToEnable:
             return MuesliTheme.accent
         case .needsICloud:
-            return MuesliTheme.recording
+            return MuesliTheme.destructive
         }
     }
 

--- a/Muesli/TranscriptionModelSelector.swift
+++ b/Muesli/TranscriptionModelSelector.swift
@@ -71,13 +71,13 @@ struct TranscriptionModelSelector: View {
                 }
                 .padding(MuesliTheme.spacing12)
                 .frame(maxWidth: .infinity, alignment: .leading)
-                .background(MuesliTheme.surfaceSelected.opacity(0.72))
-                .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+                .background(MuesliTheme.accent.opacity(0.10))
+                .muesliGlassSurface(cornerRadius: MuesliTheme.cornerMedium, tint: MuesliTheme.accent, isInteractive: true)
                 .overlay(
-                    RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall)
+                    RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium, style: .continuous)
                         .strokeBorder(MuesliTheme.accent.opacity(0.34), lineWidth: 1)
                 )
-                .contentShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+                .contentShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium, style: .continuous))
             }
             .menuOrder(.fixed)
 
@@ -115,12 +115,7 @@ private struct SelectedTranscriptionModelDetails: View {
         }
         .padding(MuesliTheme.spacing12)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .background(MuesliTheme.surfacePrimary.opacity(0.34))
-        .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
-        .overlay(
-            RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall)
-                .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
-        )
+        .muesliGlassSurface(cornerRadius: MuesliTheme.cornerMedium)
     }
 }
 
@@ -135,12 +130,7 @@ private struct TranscriptionModelBadge: View {
             .labelStyle(.titleAndIcon)
             .padding(.horizontal, MuesliTheme.spacing8)
             .padding(.vertical, MuesliTheme.spacing4)
-            .background(MuesliTheme.backgroundRaised)
-            .clipShape(Capsule())
-            .overlay(
-                Capsule()
-                    .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
-            )
+            .muesliGlassSurface(cornerRadius: 14)
     }
 }
 

--- a/MuesliKeyboard/KeyboardController.swift
+++ b/MuesliKeyboard/KeyboardController.swift
@@ -36,57 +36,76 @@ final class KeyboardController {
     }
 
     var primaryButtonTitle: String {
-        if recoveryRequestID != nil {
-            return "Open Muesli"
-        }
-
-        if latestHandoffState?.phase == .stopRequested {
-            return "Waiting for Muesli"
-        }
-
-        return switch dictationPhase {
-        case .requested:
-            activeRequestID == nil ? "Open Muesli" : "Stop"
-        case .recording:
+        return switch primaryButtonRole {
+        case .openMuesliRecovery:
+            "Open Muesli"
+        case .waitingForMuesli:
+            "Waiting for Muesli"
+        case .openMuesliRequested:
+            "Open Muesli"
+        case .stop:
             "Stop"
         case .transcribing:
             "Transcribing"
-        case .finished:
+        case .inserted:
             "Inserted"
-        default:
+        case .record:
             "Record"
         }
     }
 
     var primaryButtonIcon: String {
-        if recoveryRequestID != nil {
-            return "arrow.up.forward.app"
-        }
-
-        if latestHandoffState?.phase == .stopRequested {
-            return "hourglass"
-        }
-
-        return switch dictationPhase {
-        case .requested, .recording:
+        return switch primaryButtonRole {
+        case .openMuesliRecovery:
+            "arrow.up.forward.app"
+        case .waitingForMuesli:
+            "hourglass"
+        case .openMuesliRequested, .stop:
             "stop.fill"
         case .transcribing:
             "waveform"
-        case .finished:
+        case .inserted:
             "checkmark"
-        default:
+        case .record:
             "mic.fill"
         }
     }
 
     var primaryButtonColor: ColorToken {
-        switch dictationPhase {
+        return switch dictationPhase {
         case .requested, .recording:
             .recording
         case .transcribing:
             .transcribing
         default:
             .accent
+        }
+    }
+
+    var stylesPrimaryButtonAsStop: Bool {
+        primaryButtonRole == .stop
+    }
+
+    var primaryButtonRole: KeyboardPrimaryButtonRole {
+        if recoveryRequestID != nil {
+            return .openMuesliRecovery
+        }
+
+        if latestHandoffState?.phase == .stopRequested {
+            return .waitingForMuesli
+        }
+
+        return switch dictationPhase {
+        case .requested:
+            activeRequestID == nil ? .openMuesliRequested : .stop
+        case .recording:
+            .stop
+        case .transcribing:
+            .transcribing
+        case .finished:
+            .inserted
+        default:
+            .record
         }
     }
 
@@ -613,4 +632,14 @@ enum ColorToken {
     case accent
     case recording
     case transcribing
+}
+
+enum KeyboardPrimaryButtonRole {
+    case openMuesliRecovery
+    case waitingForMuesli
+    case openMuesliRequested
+    case stop
+    case transcribing
+    case inserted
+    case record
 }

--- a/MuesliKeyboard/KeyboardController.swift
+++ b/MuesliKeyboard/KeyboardController.swift
@@ -60,7 +60,9 @@ final class KeyboardController {
             "arrow.up.forward.app"
         case .waitingForMuesli:
             "hourglass"
-        case .openMuesliRequested, .stop:
+        case .openMuesliRequested:
+            "arrow.up.forward.app"
+        case .stop:
             "stop.fill"
         case .transcribing:
             "waveform"

--- a/MuesliKeyboard/KeyboardRootView.swift
+++ b/MuesliKeyboard/KeyboardRootView.swift
@@ -114,9 +114,7 @@ struct KeyboardRootView: View {
     }
 
     private var isPrimaryStopButton: Bool {
-        !controller.isPrimaryButtonDisabled
-            && controller.primaryButtonTitle == "Stop"
-            && controller.primaryButtonIcon == "stop.fill"
+        controller.stylesPrimaryButtonAsStop
     }
 
     private var primaryButtonCircleFill: Color {

--- a/MuesliKeyboard/KeyboardRootView.swift
+++ b/MuesliKeyboard/KeyboardRootView.swift
@@ -123,7 +123,7 @@ struct KeyboardRootView: View {
         if controller.isPrimaryButtonDisabled {
             MuesliTheme.surfacePrimary
         } else if isPrimaryStopButton {
-            MuesliTheme.destructiveSubtle
+            MuesliTheme.destructive.opacity(0.32)
         } else {
             buttonColor
         }
@@ -143,7 +143,7 @@ struct KeyboardRootView: View {
         if controller.isPrimaryButtonDisabled {
             MuesliTheme.textTertiary
         } else if isPrimaryStopButton {
-            MuesliTheme.destructive
+            .white
         } else {
             .white
         }

--- a/MuesliKeyboard/KeyboardRootView.swift
+++ b/MuesliKeyboard/KeyboardRootView.swift
@@ -38,11 +38,10 @@ struct KeyboardRootView: View {
                 }
             }
             .padding(MuesliTheme.spacing12)
-            .background(MuesliTheme.backgroundRaised)
-            .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium))
-            .overlay(
-                RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium)
-                    .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
+            .muesliGlassSurface(
+                cornerRadius: MuesliTheme.cornerLarge,
+                tint: buttonColor,
+                isInteractive: true
             )
 
             HStack(spacing: MuesliTheme.spacing8) {
@@ -171,8 +170,7 @@ private struct KeyboardLiveTranscriptPreview: View {
                 .frame(maxWidth: .infinity, alignment: .leading)
         }
         .padding(MuesliTheme.spacing12)
-        .background(MuesliTheme.surfacePrimary)
-        .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+        .muesliGlassSurface(cornerRadius: MuesliTheme.cornerMedium, tint: MuesliTheme.accent)
     }
 }
 
@@ -210,12 +208,7 @@ private struct KeyboardKey: View {
                 .frame(height: 44)
         }
         .buttonStyle(.plain)
-        .background(MuesliTheme.surfacePrimary)
-        .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
-        .overlay(
-            RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall)
-                .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
-        )
+        .muesliGlassButton(cornerRadius: MuesliTheme.cornerMedium)
     }
 
     @ViewBuilder

--- a/MuesliKeyboard/KeyboardRootView.swift
+++ b/MuesliKeyboard/KeyboardRootView.swift
@@ -88,21 +88,21 @@ struct KeyboardRootView: View {
             VStack(spacing: MuesliTheme.spacing4) {
                 ZStack {
                     Circle()
-                        .fill(controller.isPrimaryButtonDisabled ? MuesliTheme.surfacePrimary : buttonColor)
+                        .fill(primaryButtonCircleFill)
                         .frame(width: 62, height: 62)
                         .overlay(
                             Circle()
-                                .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: controller.isPrimaryButtonDisabled ? 1 : 0)
+                                .strokeBorder(primaryButtonCircleBorder, lineWidth: 1)
                         )
 
                     Image(systemName: controller.primaryButtonIcon)
                         .font(.system(size: 23, weight: .semibold))
-                        .foregroundStyle(controller.isPrimaryButtonDisabled ? MuesliTheme.textTertiary : .white)
+                        .foregroundStyle(primaryButtonIconColor)
                 }
 
                 Text(controller.primaryButtonTitle)
                     .font(.system(size: 10, weight: .semibold))
-                    .foregroundStyle(controller.isPrimaryButtonDisabled ? MuesliTheme.textTertiary : MuesliTheme.textPrimary)
+                    .foregroundStyle(primaryButtonTitleColor)
                     .lineLimit(1)
                     .minimumScaleFactor(0.75)
             }
@@ -111,6 +111,52 @@ struct KeyboardRootView: View {
         .frame(maxWidth: .infinity)
         .padding(MuesliTheme.spacing12)
         .contentShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium))
+    }
+
+    private var isPrimaryStopButton: Bool {
+        !controller.isPrimaryButtonDisabled
+            && controller.primaryButtonTitle == "Stop"
+            && controller.primaryButtonIcon == "stop.fill"
+    }
+
+    private var primaryButtonCircleFill: Color {
+        if controller.isPrimaryButtonDisabled {
+            MuesliTheme.surfacePrimary
+        } else if isPrimaryStopButton {
+            MuesliTheme.destructiveSubtle
+        } else {
+            buttonColor
+        }
+    }
+
+    private var primaryButtonCircleBorder: Color {
+        if controller.isPrimaryButtonDisabled {
+            MuesliTheme.surfaceBorder
+        } else if isPrimaryStopButton {
+            MuesliTheme.destructive.opacity(0.38)
+        } else {
+            .clear
+        }
+    }
+
+    private var primaryButtonIconColor: Color {
+        if controller.isPrimaryButtonDisabled {
+            MuesliTheme.textTertiary
+        } else if isPrimaryStopButton {
+            MuesliTheme.destructive
+        } else {
+            .white
+        }
+    }
+
+    private var primaryButtonTitleColor: Color {
+        if controller.isPrimaryButtonDisabled {
+            MuesliTheme.textTertiary
+        } else if isPrimaryStopButton {
+            MuesliTheme.destructive
+        } else {
+            MuesliTheme.textPrimary
+        }
     }
 
     private var keyboardHint: String {

--- a/MuesliLiveActivityExtension/MuesliRecordingLiveActivity.swift
+++ b/MuesliLiveActivityExtension/MuesliRecordingLiveActivity.swift
@@ -114,6 +114,8 @@ private func color(for accent: String) -> Color {
         .red
     case "orange":
         .orange
+    case "green":
+        .green
     default:
         .blue
     }

--- a/Shared/MuesliTheme.swift
+++ b/Shared/MuesliTheme.swift
@@ -228,8 +228,10 @@ private struct MuesliGlassSurfaceModifier: ViewModifier {
                 .shadow(color: MuesliTheme.glassShadow, radius: 10, x: 0, y: 5)
         } else {
             content
-                .background(.regularMaterial, in: shape)
-                .overlay(shape.fill(tintBackground))
+                .background {
+                    shape.fill(.regularMaterial)
+                    shape.fill(tintBackground)
+                }
                 .overlay(shape.strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1))
                 .shadow(color: MuesliTheme.glassShadow, radius: 8, x: 0, y: 4)
         }
@@ -261,8 +263,10 @@ private struct MuesliGlassButtonModifier: ViewModifier {
                 .contentShape(shape)
         } else {
             content
-                .background(.ultraThinMaterial, in: shape)
-                .overlay(shape.fill((tint ?? MuesliTheme.accent).opacity(0.12)))
+                .background {
+                    shape.fill(.ultraThinMaterial)
+                    shape.fill((tint ?? MuesliTheme.accent).opacity(0.12))
+                }
                 .overlay(shape.strokeBorder((tint ?? MuesliTheme.accent).opacity(0.24), lineWidth: 1))
                 .contentShape(shape)
         }

--- a/Shared/MuesliTheme.swift
+++ b/Shared/MuesliTheme.swift
@@ -2,18 +2,18 @@ import SwiftUI
 import UIKit
 
 enum MuesliTheme {
-    static let backgroundDeep = Color.adaptive(dark: 0x111214, light: 0xF5F5F7)
-    static let backgroundBase = Color.adaptive(dark: 0x161719, light: 0xFFFFFF)
-    static let backgroundRaised = Color.adaptive(dark: 0x1C1D20, light: 0xF0F0F2)
-    static let backgroundHover = Color.adaptive(dark: 0x232528, light: 0xE8E8EC)
+    static let backgroundDeep = Color.adaptive(dark: 0x111214, light: 0xF0F4FA)
+    static let backgroundBase = Color.adaptive(dark: 0x15171B, light: 0xF7F9FC)
+    static let backgroundRaised = Color.adaptive(dark: 0x1B1D22, light: 0xFFFFFF)
+    static let backgroundHover = Color.adaptive(dark: 0x252A32, light: 0xE8EEF8)
 
-    static let surfacePrimary = Color.adaptive(dark: 0x262830, light: 0xE5E5EA)
-    static let surfaceSelected = Color.adaptive(dark: 0x2E3340, light: 0xD6DFFE)
+    static let surfacePrimary = Color.adaptive(dark: 0x252934, light: 0xEEF3FB)
+    static let surfaceSelected = Color.adaptive(dark: 0x2A3243, light: 0xE4EEFF)
     static let surfaceBorder = Color.adaptiveAlpha(
         dark: .white,
-        darkAlpha: 0.07,
+        darkAlpha: 0.12,
         light: .black,
-        lightAlpha: 0.08
+        lightAlpha: 0.10
     )
 
     static let textPrimary = Color.adaptiveAlpha(
@@ -37,11 +37,28 @@ enum MuesliTheme {
 
     static var defaultAccent: Color { color(for: .blue) }
     static var accent: Color { color(for: selectedAccentTheme) }
-    static var accentSubtle: Color { accent.opacity(0.15) }
+    static var accentSubtle: Color { accent.opacity(0.14) }
 
-    static let recording = Color(hex: 0xEF4444)
-    static let transcribing = Color(hex: 0xF59E0B)
-    static let success = Color(hex: 0x34D399)
+    static let brandBlue = Color(hex: 0x69A1FF)
+    static let brandBlueSubtle = Color.adaptive(dark: 0x18253A, light: 0xE6F0FF)
+    static let syncGreen = Color(hex: 0x34D8C3)
+    static let syncGreenSubtle = Color.adaptive(dark: 0x173633, light: 0xDCFDF6)
+    static let glassHighlight = Color.adaptiveAlpha(
+        dark: .white,
+        darkAlpha: 0.10,
+        light: .white,
+        lightAlpha: 0.52
+    )
+    static let glassShadow = Color.adaptiveAlpha(
+        dark: .black,
+        darkAlpha: 0.22,
+        light: .black,
+        lightAlpha: 0.045
+    )
+
+    static let recording = Color(hex: 0x69A1FF)
+    static let transcribing = Color(hex: 0x6BA3F7)
+    static let success = syncGreen
 
     static func title1() -> Font { .system(size: 28, weight: .bold) }
     static func title2() -> Font { .system(size: 22, weight: .semibold) }
@@ -60,10 +77,10 @@ enum MuesliTheme {
     static let spacing24: CGFloat = 24
     static let spacing32: CGFloat = 32
 
-    static let cornerSmall: CGFloat = 6
-    static let cornerMedium: CGFloat = 10
-    static let cornerLarge: CGFloat = 14
-    static let cornerXL: CGFloat = 20
+    static let cornerSmall: CGFloat = 8
+    static let cornerMedium: CGFloat = 12
+    static let cornerLarge: CGFloat = 16
+    static let cornerXL: CGFloat = 22
 
     static func color(for accent: MuesliAccentTheme) -> Color {
         Color.adaptive(dark: accent.darkHex, light: accent.lightHex)
@@ -124,21 +141,129 @@ extension Color {
 
 struct MuesliSurface<Content: View>: View {
     let cornerRadius: CGFloat
+    let tint: Color?
+    let isInteractive: Bool
     @ViewBuilder var content: Content
 
-    init(cornerRadius: CGFloat = MuesliTheme.cornerMedium, @ViewBuilder content: () -> Content) {
+    init(
+        cornerRadius: CGFloat = MuesliTheme.cornerMedium,
+        tint: Color? = nil,
+        isInteractive: Bool = false,
+        @ViewBuilder content: () -> Content
+    ) {
         self.cornerRadius = cornerRadius
+        self.tint = tint
+        self.isInteractive = isInteractive
         self.content = content()
     }
 
     var body: some View {
         content
-            .background(MuesliTheme.backgroundRaised)
-            .clipShape(RoundedRectangle(cornerRadius: cornerRadius))
-            .overlay(
-                RoundedRectangle(cornerRadius: cornerRadius)
-                    .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
+            .muesliGlassSurface(
+                cornerRadius: cornerRadius,
+                tint: tint,
+                isInteractive: isInteractive
             )
+    }
+}
+
+struct MuesliGlassGroup<Content: View>: View {
+    let spacing: CGFloat
+    @ViewBuilder var content: Content
+
+    init(spacing: CGFloat = MuesliTheme.spacing16, @ViewBuilder content: () -> Content) {
+        self.spacing = spacing
+        self.content = content()
+    }
+
+    var body: some View {
+        if #available(iOS 26.0, *) {
+            GlassEffectContainer(spacing: spacing) {
+                content
+            }
+        } else {
+            content
+        }
+    }
+}
+
+extension View {
+    func muesliGlassSurface(
+        cornerRadius: CGFloat = MuesliTheme.cornerMedium,
+        tint: Color? = nil,
+        isInteractive: Bool = false
+    ) -> some View {
+        modifier(
+            MuesliGlassSurfaceModifier(
+                cornerRadius: cornerRadius,
+                tint: tint,
+                isInteractive: isInteractive
+            )
+        )
+    }
+
+    func muesliGlassButton(
+        cornerRadius: CGFloat = MuesliTheme.cornerMedium,
+        tint: Color? = nil
+    ) -> some View {
+        modifier(MuesliGlassButtonModifier(cornerRadius: cornerRadius, tint: tint))
+    }
+}
+
+private struct MuesliGlassSurfaceModifier: ViewModifier {
+    let cornerRadius: CGFloat
+    let tint: Color?
+    let isInteractive: Bool
+
+    func body(content: Content) -> some View {
+        let shape = RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+
+        if #available(iOS 26.0, *) {
+            content
+                .background(tintBackground, in: shape)
+                .glassEffect(glassEffect, in: .rect(cornerRadius: cornerRadius))
+                .overlay(shape.strokeBorder(MuesliTheme.glassHighlight, lineWidth: 0.7))
+                .shadow(color: MuesliTheme.glassShadow, radius: 10, x: 0, y: 5)
+        } else {
+            content
+                .background(.regularMaterial, in: shape)
+                .overlay(shape.fill(tintBackground))
+                .overlay(shape.strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1))
+                .shadow(color: MuesliTheme.glassShadow, radius: 8, x: 0, y: 4)
+        }
+    }
+
+    private var tintBackground: Color {
+        tint?.opacity(0.08) ?? MuesliTheme.backgroundRaised.opacity(0.74)
+    }
+
+    @available(iOS 26.0, *)
+    private var glassEffect: Glass {
+        let base = Glass.regular.tint(tint?.opacity(0.18) ?? .clear)
+        return isInteractive ? base.interactive() : base
+    }
+}
+
+private struct MuesliGlassButtonModifier: ViewModifier {
+    let cornerRadius: CGFloat
+    let tint: Color?
+
+    func body(content: Content) -> some View {
+        let shape = RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+
+        if #available(iOS 26.0, *) {
+            content
+                .background((tint ?? MuesliTheme.accent).opacity(0.10), in: shape)
+                .glassEffect(.regular.tint((tint ?? MuesliTheme.accent).opacity(0.22)).interactive(), in: .rect(cornerRadius: cornerRadius))
+                .overlay(shape.strokeBorder((tint ?? MuesliTheme.accent).opacity(0.24), lineWidth: 1))
+                .contentShape(shape)
+        } else {
+            content
+                .background(.ultraThinMaterial, in: shape)
+                .overlay(shape.fill((tint ?? MuesliTheme.accent).opacity(0.12)))
+                .overlay(shape.strokeBorder((tint ?? MuesliTheme.accent).opacity(0.24), lineWidth: 1))
+                .contentShape(shape)
+        }
     }
 }
 
@@ -164,9 +289,7 @@ enum MuesliAppearanceMode: String, CaseIterable, Identifiable {
 enum MuesliAccentTheme: String, CaseIterable, Identifiable {
     case blue
     case green
-    case purple
-    case orange
-    case pink
+    case slate
 
     var id: String { rawValue }
 
@@ -176,12 +299,8 @@ enum MuesliAccentTheme: String, CaseIterable, Identifiable {
             "Blue"
         case .green:
             "Green"
-        case .purple:
-            "Purple"
-        case .orange:
-            "Orange"
-        case .pink:
-            "Pink"
+        case .slate:
+            "Slate"
         }
     }
 
@@ -191,12 +310,8 @@ enum MuesliAccentTheme: String, CaseIterable, Identifiable {
             0x2563EB
         case .green:
             0x059669
-        case .purple:
-            0x7C3AED
-        case .orange:
-            0xEA580C
-        case .pink:
-            0xDB2777
+        case .slate:
+            0x475569
         }
     }
 
@@ -206,12 +321,8 @@ enum MuesliAccentTheme: String, CaseIterable, Identifiable {
             0x6BA3F7
         case .green:
             0x34D399
-        case .purple:
-            0xA78BFA
-        case .orange:
-            0xFB923C
-        case .pink:
-            0xF472B6
+        case .slate:
+            0xCBD5E1
         }
     }
 }

--- a/Shared/MuesliTheme.swift
+++ b/Shared/MuesliTheme.swift
@@ -59,6 +59,8 @@ enum MuesliTheme {
     static let recording = Color(hex: 0x69A1FF)
     static let transcribing = Color(hex: 0x6BA3F7)
     static let success = syncGreen
+    static let destructive = Color.adaptive(dark: 0xFF453A, light: 0xD70015)
+    static var destructiveSubtle: Color { destructive.opacity(0.16) }
 
     static func title1() -> Font { .system(size: 28, weight: .bold) }
     static func title2() -> Font { .system(size: 22, weight: .semibold) }

--- a/Shared/MuesliTheme.swift
+++ b/Shared/MuesliTheme.swift
@@ -89,9 +89,9 @@ enum MuesliTheme {
     }
 
     private static var selectedAccentTheme: MuesliAccentTheme {
-        MuesliAccentTheme(
+        MuesliAccentTheme.resolved(
             rawValue: UserDefaults.standard.string(forKey: "muesli.appearance.accent") ?? ""
-        ) ?? .blue
+        )
     }
 }
 
@@ -320,6 +320,21 @@ enum MuesliAccentTheme: String, CaseIterable, Identifiable {
     case slate
 
     var id: String { rawValue }
+
+    static func resolved(rawValue: String) -> MuesliAccentTheme {
+        if let theme = MuesliAccentTheme(rawValue: rawValue) {
+            return theme
+        }
+
+        switch rawValue {
+        case "orange":
+            return .green
+        case "purple", "pink":
+            return .slate
+        default:
+            return .blue
+        }
+    }
 
     var label: String {
         switch self {

--- a/Shared/MuesliTheme.swift
+++ b/Shared/MuesliTheme.swift
@@ -179,6 +179,7 @@ struct MuesliGlassGroup<Content: View>: View {
     }
 
     var body: some View {
+        #if compiler(>=6.2)
         if #available(iOS 26.0, *) {
             GlassEffectContainer(spacing: spacing) {
                 content
@@ -186,6 +187,9 @@ struct MuesliGlassGroup<Content: View>: View {
         } else {
             content
         }
+        #else
+        content
+        #endif
     }
 }
 
@@ -220,31 +224,41 @@ private struct MuesliGlassSurfaceModifier: ViewModifier {
     func body(content: Content) -> some View {
         let shape = RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
 
+        #if compiler(>=6.2)
         if #available(iOS 26.0, *) {
             content
                 .background(tintBackground, in: shape)
-                .glassEffect(glassEffect, in: .rect(cornerRadius: cornerRadius))
+                .glassEffect(glassEffect(), in: .rect(cornerRadius: cornerRadius))
                 .overlay(shape.strokeBorder(MuesliTheme.glassHighlight, lineWidth: 0.7))
                 .shadow(color: MuesliTheme.glassShadow, radius: 10, x: 0, y: 5)
         } else {
-            content
-                .background {
-                    shape.fill(.regularMaterial)
-                    shape.fill(tintBackground)
-                }
-                .overlay(shape.strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1))
-                .shadow(color: MuesliTheme.glassShadow, radius: 8, x: 0, y: 4)
+            fallback(content: content, shape: shape)
         }
+        #else
+        fallback(content: content, shape: shape)
+        #endif
     }
 
     private var tintBackground: Color {
         tint?.opacity(0.08) ?? MuesliTheme.backgroundRaised.opacity(0.74)
     }
 
+    #if compiler(>=6.2)
     @available(iOS 26.0, *)
-    private var glassEffect: Glass {
+    private func glassEffect() -> Glass {
         let base = Glass.regular.tint(tint?.opacity(0.18) ?? .clear)
         return isInteractive ? base.interactive() : base
+    }
+    #endif
+
+    private func fallback(content: Content, shape: RoundedRectangle) -> some View {
+        content
+            .background {
+                shape.fill(.regularMaterial)
+                shape.fill(tintBackground)
+            }
+            .overlay(shape.strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1))
+            .shadow(color: MuesliTheme.glassShadow, radius: 8, x: 0, y: 4)
     }
 }
 
@@ -255,6 +269,7 @@ private struct MuesliGlassButtonModifier: ViewModifier {
     func body(content: Content) -> some View {
         let shape = RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
 
+        #if compiler(>=6.2)
         if #available(iOS 26.0, *) {
             content
                 .background((tint ?? MuesliTheme.accent).opacity(0.10), in: shape)
@@ -262,14 +277,21 @@ private struct MuesliGlassButtonModifier: ViewModifier {
                 .overlay(shape.strokeBorder((tint ?? MuesliTheme.accent).opacity(0.24), lineWidth: 1))
                 .contentShape(shape)
         } else {
-            content
-                .background {
-                    shape.fill(.ultraThinMaterial)
-                    shape.fill((tint ?? MuesliTheme.accent).opacity(0.12))
-                }
-                .overlay(shape.strokeBorder((tint ?? MuesliTheme.accent).opacity(0.24), lineWidth: 1))
-                .contentShape(shape)
+            fallback(content: content, shape: shape)
         }
+        #else
+        fallback(content: content, shape: shape)
+        #endif
+    }
+
+    private func fallback(content: Content, shape: RoundedRectangle) -> some View {
+        content
+            .background {
+                shape.fill(.ultraThinMaterial)
+                shape.fill((tint ?? MuesliTheme.accent).opacity(0.12))
+            }
+            .overlay(shape.strokeBorder((tint ?? MuesliTheme.accent).opacity(0.24), lineWidth: 1))
+            .contentShape(shape)
     }
 }
 

--- a/Shared/MuesliWaveformView.swift
+++ b/Shared/MuesliWaveformView.swift
@@ -68,7 +68,10 @@ struct MuesliInlineWaveformView: View {
     var color: Color
     var level: Double? = nil
     var barCount: Int = 24
-    var spacing: CGFloat = 5
+    var spacing: CGFloat = 3
+
+    @State private var liveSamples: [CGFloat] = []
+    @State private var sampleSequence = 0
 
     private let basePattern: [CGFloat] = [
         0.18, 0.26, 0.42, 0.58, 0.76, 0.92,
@@ -82,22 +85,32 @@ struct MuesliInlineWaveformView: View {
             let elapsed = timeline.date.timeIntervalSinceReferenceDate
             waveformBars(elapsed: elapsed)
         }
+        .onAppear {
+            seedLiveSamplesIfNeeded()
+        }
+        .onChange(of: level ?? 0) { _, newValue in
+            appendLiveSample(newValue)
+        }
+        .onChange(of: mode) { _, _ in
+            seedLiveSamplesIfNeeded(force: true)
+        }
     }
 
     private func waveformBars(elapsed: TimeInterval) -> some View {
         GeometryReader { geometry in
-            let count = max(12, barCount)
+            let count = max(48, barCount * 2)
             let totalSpacing = spacing * CGFloat(count - 1)
-            let barWidth = max(3, min(8, (geometry.size.width - totalSpacing) / CGFloat(count)))
+            let barWidth = max(2, min(5, (geometry.size.width - totalSpacing) / CGFloat(count)))
+            let samples = samplesForRender(count: count, elapsed: elapsed)
             HStack(alignment: .center, spacing: spacing) {
                 ForEach(0..<count, id: \.self) { index in
+                    let sample = samples[index]
                     RoundedRectangle(cornerRadius: barWidth / 2, style: .continuous)
-                        .fill(color.opacity(mode == .waiting ? waitingOpacity(index: index, elapsed: elapsed) : 0.92))
+                        .fill(color.opacity(mode == .waiting ? waitingOpacity(index: index, elapsed: elapsed) : 0.94))
                         .frame(
                             width: barWidth,
                             height: barHeight(
-                                index: index,
-                                elapsed: elapsed,
+                                sample: sample,
                                 maxHeight: geometry.size.height
                             )
                         )
@@ -107,30 +120,71 @@ struct MuesliInlineWaveformView: View {
         }
     }
 
-    private func barHeight(
-        index: Int,
-        elapsed: TimeInterval,
-        maxHeight: CGFloat
-    ) -> CGFloat {
+    private func barHeight(sample: CGFloat, maxHeight: CGFloat) -> CGFloat {
         let minHeight: CGFloat = 4
         let maxBarHeight = max(minHeight, maxHeight)
-        let base = basePattern[index % basePattern.count]
-        let amplitude: CGFloat
+        return min(maxBarHeight, max(minHeight, minHeight + (maxBarHeight - minHeight) * sample))
+    }
 
+    private func samplesForRender(count: Int, elapsed: TimeInterval) -> [CGFloat] {
         switch mode {
         case .level:
-            let normalized = CGFloat(min(max(level ?? 0.28, 0), 1))
-            amplitude = max(0.12, base * (0.24 + normalized * 0.88))
+            let samples = paddedLiveSamples(count: count)
+            return samples
         case .waiting:
-            let phase = CGFloat(elapsed) * 5.8 + CGFloat(index) * 0.72
-            amplitude = 0.18 + (sin(phase) + 1) * 0.18 + base * 0.48
+            return waitingSamples(count: count, elapsed: elapsed)
+        }
+    }
+
+    private func paddedLiveSamples(count: Int) -> [CGFloat] {
+        guard !liveSamples.isEmpty else {
+            return Array(repeating: 0.08, count: count)
         }
 
-        return min(maxBarHeight, max(minHeight, minHeight + (maxBarHeight - minHeight) * amplitude))
+        let suffix = liveSamples.suffix(count)
+        if suffix.count == count {
+            return Array(suffix)
+        }
+
+        return Array(repeating: 0.08, count: count - suffix.count) + suffix
+    }
+
+    private func waitingSamples(count: Int, elapsed: TimeInterval) -> [CGFloat] {
+        (0..<count).map { index in
+            let base = basePattern[index % basePattern.count]
+            let phase = CGFloat(elapsed) * 5.8 + CGFloat(index) * 0.72
+            return min(0.86, 0.12 + (sin(phase) + 1) * 0.13 + base * 0.34)
+        }
     }
 
     private func waitingOpacity(index: Int, elapsed: TimeInterval) -> Double {
         let phase = CGFloat(elapsed) * 5.8 + CGFloat(index) * 0.72
         return Double(0.48 + (sin(phase) + 1) * 0.16)
+    }
+
+    private func seedLiveSamplesIfNeeded(force: Bool = false) {
+        guard force || liveSamples.isEmpty else { return }
+
+        let count = max(48, barCount * 2)
+        liveSamples = (0..<count).map { index in
+            let base = basePattern[index % basePattern.count]
+            return 0.07 + base * 0.08
+        }
+    }
+
+    private func appendLiveSample(_ rawLevel: Double) {
+        guard mode == .level else { return }
+
+        let normalized = CGFloat(min(max(rawLevel, 0), 1))
+        let shaped = pow(normalized, 0.72)
+        let texture = CGFloat(0.90 + 0.16 * sin(Double(sampleSequence) * 1.73))
+        let sample = min(0.98, max(0.06, (0.07 + shaped * 0.88) * texture))
+        let maxSamples = max(48, barCount * 2) * 3
+
+        sampleSequence += 1
+        liveSamples.append(sample)
+        if liveSamples.count > maxSamples {
+            liveSamples.removeFirst(liveSamples.count - maxSamples)
+        }
     }
 }

--- a/Shared/MuesliWaveformView.swift
+++ b/Shared/MuesliWaveformView.swift
@@ -73,6 +73,8 @@ struct MuesliInlineWaveformView: View {
     @State private var liveSamples: [CGFloat] = []
     @State private var sampleSequence = 0
 
+    private let sampleTimer = Timer.publish(every: 1.0 / 18.0, on: .main, in: .common).autoconnect()
+
     private let basePattern: [CGFloat] = [
         0.18, 0.26, 0.42, 0.58, 0.76, 0.92,
         0.72, 0.46, 0.28, 0.36, 0.62, 0.86,
@@ -93,6 +95,9 @@ struct MuesliInlineWaveformView: View {
         }
         .onChange(of: mode) { _, _ in
             seedLiveSamplesIfNeeded(force: true)
+        }
+        .onReceive(sampleTimer) { _ in
+            appendLiveSample(level ?? 0)
         }
     }
 
@@ -186,4 +191,5 @@ struct MuesliInlineWaveformView: View {
             liveSamples.removeFirst(liveSamples.count - maxSamples)
         }
     }
+
 }

--- a/Shared/MuesliWaveformView.swift
+++ b/Shared/MuesliWaveformView.swift
@@ -121,7 +121,7 @@ struct MuesliInlineWaveformView: View {
     }
 
     private func barHeight(sample: CGFloat, maxHeight: CGFloat) -> CGFloat {
-        let minHeight: CGFloat = 4
+        let minHeight: CGFloat = 1.5
         let maxBarHeight = max(minHeight, maxHeight)
         return min(maxBarHeight, max(minHeight, minHeight + (maxBarHeight - minHeight) * sample))
     }
@@ -166,19 +166,18 @@ struct MuesliInlineWaveformView: View {
         guard force || liveSamples.isEmpty else { return }
 
         let count = max(48, barCount * 2)
-        liveSamples = (0..<count).map { index in
-            let base = basePattern[index % basePattern.count]
-            return 0.07 + base * 0.08
-        }
+        liveSamples = Array(repeating: 0, count: count)
     }
 
     private func appendLiveSample(_ rawLevel: Double) {
         guard mode == .level else { return }
 
         let normalized = CGFloat(min(max(rawLevel, 0), 1))
-        let shaped = pow(normalized, 0.72)
+        let noiseFloor: CGFloat = 0.26
+        let gatedLevel = max(0, (normalized - noiseFloor) / (1 - noiseFloor))
+        let shaped = pow(gatedLevel, 0.72)
         let texture = CGFloat(0.90 + 0.16 * sin(Double(sampleSequence) * 1.73))
-        let sample = min(0.98, max(0.06, (0.07 + shaped * 0.88) * texture))
+        let sample = gatedLevel <= 0.02 ? 0 : min(0.98, max(0.01, shaped * 0.92 * texture))
         let maxSamples = max(48, barCount * 2) * 3
 
         sampleSequence += 1


### PR DESCRIPTION
## Summary
- refreshes the iOS UI palette and surfaces around a blue/black/white/green Liquid Glass direction
- reworks the voice notes landing screen with a fixed recorder area, list-only scrolling, focused dictation cards, and a rolling live waveform
- adds onboarding background model download flow, skip/retry affordances, model-ready cue, and improved button hit areas
- adds audio-only deletion for retained voice note recordings while preserving transcripts

## Verification
- built and launched on iOS Simulator with mock dictations and waveform preview
- scrolled the inner voice-note list in simulator to verify fixed recorder behavior
- ran simulator tests: 39 passed, 0 failed
- built for physical iOS and installed/launched on picophone

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli-ios/pr/9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785457377&installation_id=136549638&pr_number=9&repository=Muesli-HQ%2Fmuesli-ios&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli-ios%2Fpull%2F9&signature=77dee7fd103ade99c1dd9139fb6db7fc25e2f05a5d966a4026509683d7545bf6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/muesli-hq/muesli-ios/pull/9" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Background transcription model preparation with per-model “ready” cues, allowing onboarding and voice-note tests to continue while setup runs.
  * Added **Delete Audio Only** for dictations with confirmation and clear success/error feedback.

* **Bug Fixes**
  * Improved background model download progress reporting and completion/failure handling during preparation.

* **UI/UX Improvements**
  * Refreshed dictation, meetings, models, onboarding, keyboard, sidebar, and selectors with new glass surfaces and better touch targets.
  * Enhanced waveform preview/liveness and updated status/accent colors (including live activity color mapping).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->