### PR TITLE
Add route-aware microphone selection

### DIFF
--- a/Muesli/AudioInputRouteManager.swift
+++ b/Muesli/AudioInputRouteManager.swift
@@ -103,6 +103,10 @@ enum AudioInputRouteManager {
         return options
     }
 
+    static func normalizedPreference(_ preference: RecordingMicrophonePreference) -> RecordingMicrophonePreference {
+        availablePreferenceOptions().contains(preference) ? preference : .automatic
+    }
+
     private static func preferredInput(
         for preference: RecordingMicrophonePreference,
         in inputs: [AVAudioSessionPortDescription]

--- a/Muesli/AudioInputRouteManager.swift
+++ b/Muesli/AudioInputRouteManager.swift
@@ -80,6 +80,28 @@ enum AudioInputRouteManager {
         return snapshot
     }
 
+    static func configureForKeyboardKeepAlive(stage: String) throws -> AudioInputRouteSnapshot {
+        let session = AVAudioSession.sharedInstance()
+        do {
+            try session.setCategory(
+                .playAndRecord,
+                mode: .spokenAudio,
+                options: [.mixWithOthers]
+            )
+            try session.setActive(true)
+        } catch {
+            throw AudioRecorder.RecordingError.audioSessionFailed(stage: stage, underlying: error)
+        }
+
+        let builtInInput = (session.availableInputs ?? []).first(where: isBuiltInInput)
+        try? session.setPreferredInput(builtInInput)
+
+        #if DEBUG
+        print("Muesli audio route configured [\(stage)]: preference=\(RecordingMicrophonePreference.builtIn.rawValue)")
+        #endif
+        return currentSnapshot(preference: .builtIn)
+    }
+
     static func currentSnapshot(
         preference: RecordingMicrophonePreference = MuesliPreferences.recordingMicrophonePreference
     ) -> AudioInputRouteSnapshot {
@@ -101,10 +123,6 @@ enum AudioInputRouteManager {
             options.append(.external)
         }
         return options
-    }
-
-    static func normalizedPreference(_ preference: RecordingMicrophonePreference) -> RecordingMicrophonePreference {
-        availablePreferenceOptions().contains(preference) ? preference : .automatic
     }
 
     private static func preferredInput(

--- a/Muesli/AudioInputRouteManager.swift
+++ b/Muesli/AudioInputRouteManager.swift
@@ -1,0 +1,161 @@
+import AVFoundation
+import Foundation
+
+enum RecordingMicrophonePreference: String, CaseIterable, Identifiable {
+    case automatic
+    case builtIn
+    case bluetooth
+    case external
+
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .automatic:
+            "Automatic"
+        case .builtIn:
+            "iPhone Microphone"
+        case .bluetooth:
+            "AirPods / Bluetooth"
+        case .external:
+            "External Microphone"
+        }
+    }
+
+    var detail: String {
+        switch self {
+        case .automatic:
+            "Uses AirPods or Bluetooth when connected, otherwise falls back to iPhone."
+        case .builtIn:
+            "Records from this iPhone even when headphones are connected."
+        case .bluetooth:
+            "Uses a connected headset mic. Music may pause or switch quality."
+        case .external:
+            "Uses a connected USB or wired microphone when available."
+        }
+    }
+}
+
+struct AudioInputRouteSnapshot: Equatable {
+    let preference: RecordingMicrophonePreference
+    let inputName: String
+    let inputDetail: String
+    let outputName: String
+
+    var displayText: String {
+        if inputName.isEmpty {
+            preference.label
+        } else if preference == .bluetooth, inputDetail == "Built-in" {
+            preference.label
+        } else if preference == .external, inputDetail == "Built-in" {
+            preference.label
+        } else {
+            inputName
+        }
+    }
+}
+
+enum AudioInputRouteManager {
+    static func configureForRecording(
+        stage: String,
+        preference: RecordingMicrophonePreference = MuesliPreferences.recordingMicrophonePreference
+    ) throws -> AudioInputRouteSnapshot {
+        let session = AVAudioSession.sharedInstance()
+        do {
+            try session.setCategory(
+                .playAndRecord,
+                mode: .spokenAudio,
+                options: [.mixWithOthers, .allowBluetoothHFP, .allowBluetoothA2DP, .defaultToSpeaker]
+            )
+            try session.setActive(true)
+            let preferredInput = preferredInput(for: preference, in: session.availableInputs ?? [])
+            try session.setPreferredInput(preferredInput)
+        } catch {
+            throw AudioRecorder.RecordingError.audioSessionFailed(stage: stage, underlying: error)
+        }
+
+        let snapshot = currentSnapshot(preference: preference)
+        print(
+            "Muesli audio route [\(stage)]: preference=\(preference.rawValue), input=\(snapshot.inputName), output=\(snapshot.outputName)"
+        )
+        return snapshot
+    }
+
+    static func currentSnapshot(
+        preference: RecordingMicrophonePreference = MuesliPreferences.recordingMicrophonePreference
+    ) -> AudioInputRouteSnapshot {
+        let session = AVAudioSession.sharedInstance()
+        let input = session.currentRoute.inputs.first
+        let output = session.currentRoute.outputs.first
+        return AudioInputRouteSnapshot(
+            preference: preference,
+            inputName: input?.portName ?? fallbackInputName(for: preference, availableInputs: session.availableInputs ?? []),
+            inputDetail: detail(for: input?.portType),
+            outputName: output?.portName ?? "Default Output"
+        )
+    }
+
+    static func availablePreferenceOptions() -> [RecordingMicrophonePreference] {
+        let inputs = AVAudioSession.sharedInstance().availableInputs ?? []
+        var options: [RecordingMicrophonePreference] = [.automatic, .builtIn, .bluetooth]
+        if inputs.contains(where: isExternalInput) {
+            options.append(.external)
+        }
+        return options
+    }
+
+    private static func preferredInput(
+        for preference: RecordingMicrophonePreference,
+        in inputs: [AVAudioSessionPortDescription]
+    ) -> AVAudioSessionPortDescription? {
+        switch preference {
+        case .automatic:
+            return inputs.first(where: isBluetoothInput)
+                ?? inputs.first(where: isExternalInput)
+                ?? inputs.first(where: isBuiltInInput)
+                ?? inputs.first
+        case .builtIn:
+            return inputs.first(where: isBuiltInInput)
+        case .bluetooth:
+            return inputs.first(where: isBluetoothInput)
+        case .external:
+            return inputs.first(where: isExternalInput)
+        }
+    }
+
+    private static func fallbackInputName(
+        for preference: RecordingMicrophonePreference,
+        availableInputs: [AVAudioSessionPortDescription]
+    ) -> String {
+        preferredInput(for: preference, in: availableInputs)?.portName ?? preference.label
+    }
+
+    private static func isBuiltInInput(_ input: AVAudioSessionPortDescription) -> Bool {
+        input.portType == .builtInMic
+    }
+
+    private static func isBluetoothInput(_ input: AVAudioSessionPortDescription) -> Bool {
+        input.portType == .bluetoothHFP || input.portType == .bluetoothLE
+    }
+
+    private static func isExternalInput(_ input: AVAudioSessionPortDescription) -> Bool {
+        !isBuiltInInput(input) && !isBluetoothInput(input)
+    }
+
+    private static func detail(for portType: AVAudioSession.Port?) -> String {
+        switch portType {
+        case .builtInMic:
+            "Built-in"
+        case .bluetoothHFP, .bluetoothLE:
+            "Bluetooth headset mic"
+        case .headsetMic:
+            "Wired headset mic"
+        case .usbAudio:
+            "USB audio"
+        case .none:
+            "Inactive"
+        default:
+            "External"
+        }
+    }
+}

--- a/Muesli/AudioInputRouteManager.swift
+++ b/Muesli/AudioInputRouteManager.swift
@@ -43,15 +43,7 @@ struct AudioInputRouteSnapshot: Equatable {
     let outputName: String
 
     var displayText: String {
-        if inputName.isEmpty {
-            preference.label
-        } else if preference == .bluetooth, inputDetail == "Built-in" {
-            preference.label
-        } else if preference == .external, inputDetail == "Built-in" {
-            preference.label
-        } else {
-            inputName
-        }
+        inputName.isEmpty ? preference.label : inputName
     }
 }
 
@@ -65,19 +57,26 @@ enum AudioInputRouteManager {
             try session.setCategory(
                 .playAndRecord,
                 mode: .spokenAudio,
-                options: [.mixWithOthers, .allowBluetoothHFP, .allowBluetoothA2DP, .defaultToSpeaker]
+                options: recordingCategoryOptions
             )
             try session.setActive(true)
-            let preferredInput = preferredInput(for: preference, in: session.availableInputs ?? [])
-            try session.setPreferredInput(preferredInput)
         } catch {
             throw AudioRecorder.RecordingError.audioSessionFailed(stage: stage, underlying: error)
         }
 
+        let preferredInput = preferredInput(for: preference, in: session.availableInputs ?? [])
+        do {
+            try session.setPreferredInput(preferredInput)
+        } catch {
+            #if DEBUG
+            print("Muesli audio route preference was ignored [\(stage)]: \(preference.rawValue)")
+            #endif
+        }
+
         let snapshot = currentSnapshot(preference: preference)
-        print(
-            "Muesli audio route [\(stage)]: preference=\(preference.rawValue), input=\(snapshot.inputName), output=\(snapshot.outputName)"
-        )
+        #if DEBUG
+        print("Muesli audio route configured [\(stage)]: preference=\(preference.rawValue)")
+        #endif
         return snapshot
     }
 
@@ -121,6 +120,18 @@ enum AudioInputRouteManager {
         case .external:
             return inputs.first(where: isExternalInput)
         }
+    }
+
+    private static var recordingCategoryOptions: AVAudioSession.CategoryOptions {
+        [.mixWithOthers, bluetoothRecordingOption, .allowBluetoothA2DP, .defaultToSpeaker]
+    }
+
+    private static var bluetoothRecordingOption: AVAudioSession.CategoryOptions {
+        #if compiler(>=6.2)
+        .allowBluetoothHFP
+        #else
+        .allowBluetooth
+        #endif
     }
 
     private static func fallbackInputName(

--- a/Muesli/AudioRecorder.swift
+++ b/Muesli/AudioRecorder.swift
@@ -18,18 +18,7 @@ final class AudioRecorder {
             try stop()
         }
 
-        let session = AVAudioSession.sharedInstance()
-        do {
-            try session.setCategory(.playAndRecord, mode: .spokenAudio, options: [])
-        } catch {
-            throw RecordingError.audioSessionFailed(stage: "category", underlying: error)
-        }
-
-        do {
-            try session.setActive(true)
-        } catch {
-            throw RecordingError.audioSessionFailed(stage: "activation", underlying: error)
-        }
+        _ = try AudioInputRouteManager.configureForRecording(stage: "quick dictation")
 
         let url = preferredOutputURL ?? FileManager.default.temporaryDirectory
             .appendingPathComponent("muesli-\(UUID().uuidString)")

--- a/Muesli/DictationCoordinator.swift
+++ b/Muesli/DictationCoordinator.swift
@@ -94,6 +94,7 @@ final class DictationCoordinator {
     var inputLevel = 0.0
     var recordingElapsedTime: TimeInterval = 0
     var statusText = "Ready"
+    var audioInputRouteText = AudioInputRouteManager.currentSnapshot().displayText
     var meetingStatusText = "Ready"
     var lastTranscript = ""
     var liveDictationTranscript = ""
@@ -133,6 +134,7 @@ final class DictationCoordinator {
         }
         #endif
 
+        refreshAudioInputRoute()
         refreshHistory()
         Task {
             await liveActivityController.endAllActivities(
@@ -145,6 +147,10 @@ final class DictationCoordinator {
                 await startKeyboardSessionMode()
             }
         }
+    }
+
+    func refreshAudioInputRoute() {
+        audioInputRouteText = AudioInputRouteManager.currentSnapshot().displayText
     }
 
     func handleOpenURL(_ url: URL) {
@@ -1185,6 +1191,7 @@ final class DictationCoordinator {
                 } else {
                     try recorder.start(outputURL: audioURL)
                 }
+                refreshAudioInputRoute()
                 activeSession = session
                 isRecording = true
                 startRecordingTimer(startedAt: session.startedAt ?? .now)
@@ -1619,6 +1626,7 @@ final class DictationCoordinator {
                 }
 
                 try streamingRecorder.start(chunksDirectory: chunksDirectory, retainedAudioURL: audioURL)
+                refreshAudioInputRoute()
                 vadController.start()
 
                 meetingRecorder = streamingRecorder

--- a/Muesli/DictationCoordinator.swift
+++ b/Muesli/DictationCoordinator.swift
@@ -39,6 +39,7 @@ final class DictationCoordinator {
     private var meetingChunksDirectory: URL?
     private let meetingVadQueue = DispatchQueue(label: "com.phequals7.muesli.meeting-vad")
     private var transcriptionBackgroundTask: UIBackgroundTaskIdentifier = .invalid
+    private var audioRouteObserver: NSObjectProtocol?
 
     private var activeRequest: DictationRequest?
     private var activeSession: RecordingSession?
@@ -134,6 +135,16 @@ final class DictationCoordinator {
         }
         #endif
 
+        audioRouteObserver = NotificationCenter.default.addObserver(
+            forName: AVAudioSession.routeChangeNotification,
+            object: AVAudioSession.sharedInstance(),
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor in
+                self?.refreshAudioInputRoute()
+            }
+        }
+
         refreshAudioInputRoute()
         refreshHistory()
         Task {
@@ -145,6 +156,14 @@ final class DictationCoordinator {
         if MuesliPreferences.keyboardSessionModeEnabled {
             Task { @MainActor in
                 await startKeyboardSessionMode()
+            }
+        }
+    }
+
+    deinit {
+        MainActor.assumeIsolated {
+            if let audioRouteObserver {
+                NotificationCenter.default.removeObserver(audioRouteObserver)
             }
         }
     }
@@ -1101,7 +1120,11 @@ final class DictationCoordinator {
             }
         }
 
-        try streamingRecorder.start(chunksDirectory: chunksDirectory, retainedAudioURL: audioURL)
+        try streamingRecorder.start(
+            chunksDirectory: chunksDirectory,
+            retainedAudioURL: audioURL,
+            routeStage: "realtime dictation"
+        )
         realtimeDictationRecorder = streamingRecorder
         realtimeDictationBufferPipe = pipe
         realtimeDictationChunksDirectory = chunksDirectory
@@ -1625,7 +1648,11 @@ final class DictationCoordinator {
                     }
                 }
 
-                try streamingRecorder.start(chunksDirectory: chunksDirectory, retainedAudioURL: audioURL)
+                try streamingRecorder.start(
+                    chunksDirectory: chunksDirectory,
+                    retainedAudioURL: audioURL,
+                    routeStage: "meeting recording"
+                )
                 refreshAudioInputRoute()
                 vadController.start()
 

--- a/Muesli/DictationCoordinator.swift
+++ b/Muesli/DictationCoordinator.swift
@@ -160,11 +160,9 @@ final class DictationCoordinator {
         }
     }
 
-    deinit {
-        MainActor.assumeIsolated {
-            if let audioRouteObserver {
-                NotificationCenter.default.removeObserver(audioRouteObserver)
-            }
+    isolated deinit {
+        if let audioRouteObserver {
+            NotificationCenter.default.removeObserver(audioRouteObserver)
         }
     }
 

--- a/Muesli/DictationCoordinator.swift
+++ b/Muesli/DictationCoordinator.swift
@@ -39,7 +39,7 @@ final class DictationCoordinator {
     private var meetingChunksDirectory: URL?
     private let meetingVadQueue = DispatchQueue(label: "com.phequals7.muesli.meeting-vad")
     private var transcriptionBackgroundTask: UIBackgroundTaskIdentifier = .invalid
-    private var audioRouteObserver: NSObjectProtocol?
+    nonisolated(unsafe) private var audioRouteObserver: NSObjectProtocol?
 
     private var activeRequest: DictationRequest?
     private var activeSession: RecordingSession?
@@ -160,7 +160,7 @@ final class DictationCoordinator {
         }
     }
 
-    isolated deinit {
+    deinit {
         if let audioRouteObserver {
             NotificationCenter.default.removeObserver(audioRouteObserver)
         }

--- a/Muesli/DictationView.swift
+++ b/Muesli/DictationView.swift
@@ -125,6 +125,7 @@ struct DictationView: View {
                         }
 
                         microphoneMenu
+                            .disabled(coordinator.isRecording)
                     }
                 }
 
@@ -232,6 +233,7 @@ struct DictationView: View {
         }
         .buttonStyle(.plain)
         .menuOrder(.fixed)
+        .disabled(coordinator.isRecording)
         .accessibilityLabel("Recording microphone")
         .accessibilityValue(coordinator.audioInputRouteText)
     }

--- a/Muesli/DictationView.swift
+++ b/Muesli/DictationView.swift
@@ -205,7 +205,7 @@ struct DictationView: View {
     private var microphoneMenu: some View {
         Menu {
             Section("Recording Microphone") {
-                ForEach(AudioInputRouteManager.availablePreferenceOptions()) { option in
+                ForEach(microphonePreferenceOptions) { option in
                     Button {
                         microphonePreference = option.rawValue
                         coordinator.refreshAudioInputRoute()
@@ -236,6 +236,13 @@ struct DictationView: View {
         .disabled(coordinator.isRecording)
         .accessibilityLabel("Recording microphone")
         .accessibilityValue(coordinator.audioInputRouteText)
+    }
+
+    private var microphonePreferenceOptions: [RecordingMicrophonePreference] {
+        let options = AudioInputRouteManager.availablePreferenceOptions()
+        let currentPreference = RecordingMicrophonePreference(rawValue: microphonePreference) ?? .automatic
+        guard !options.contains(currentPreference) else { return options }
+        return options + [currentPreference]
     }
 
     private var keyboardShortcutRow: some View {

--- a/Muesli/DictationView.swift
+++ b/Muesli/DictationView.swift
@@ -9,6 +9,7 @@ struct DictationView: View {
     @Environment(\.openURL) private var openURL
     @Environment(\.scenePhase) private var scenePhase
     @AppStorage(MuesliPreferences.iCloudSyncEnabledKey) private var iCloudSyncEnabled = false
+    @AppStorage(MuesliPreferences.recordingMicrophonePreferenceKey) private var microphonePreference = RecordingMicrophonePreference.automatic.rawValue
     @State private var sourceFilter: DictationSourceFilter = .all
     @State private var isSyncSetupPromptPresented = false
     @State private var shouldShowKeyboardSetupRow = false
@@ -45,11 +46,16 @@ struct DictationView: View {
             }
             .onAppear {
                 coordinator.refreshHistory()
+                coordinator.refreshAudioInputRoute()
                 refreshKeyboardSetupPromptVisibility()
             }
             .onChange(of: scenePhase) { _, phase in
                 guard phase == .active else { return }
+                coordinator.refreshAudioInputRoute()
                 refreshKeyboardSetupPromptVisibility()
+            }
+            .onChange(of: microphonePreference) { _, _ in
+                coordinator.refreshAudioInputRoute()
             }
             .navigationDestination(for: UUID.self) { resultID in
                 if let result = coordinator.dictationHistory.first(where: { $0.id == resultID }),
@@ -91,7 +97,7 @@ struct DictationView: View {
             tint: statusColor,
             isInteractive: true
         ) {
-            VStack(spacing: MuesliTheme.spacing16) {
+            VStack(spacing: MuesliTheme.spacing12) {
                 HStack(alignment: .top) {
                     VStack(alignment: .leading, spacing: MuesliTheme.spacing4) {
                         Text("Voice Note")
@@ -104,17 +110,21 @@ struct DictationView: View {
 
                     Spacer()
 
-                    if coordinator.isRecording {
-                        Text(formatElapsedTime(coordinator.recordingElapsedTime))
-                            .font(MuesliTheme.captionMedium())
-                            .monospacedDigit()
-                            .foregroundStyle(statusColor)
-                            .padding(.horizontal, MuesliTheme.spacing8)
-                            .padding(.vertical, MuesliTheme.spacing4)
-                            .background(statusColor.opacity(0.13))
-                            .clipShape(Capsule())
-                            .accessibilityLabel("Recording elapsed time")
-                            .accessibilityValue(formatElapsedTime(coordinator.recordingElapsedTime))
+                    VStack(alignment: .trailing, spacing: MuesliTheme.spacing8) {
+                        if coordinator.isRecording {
+                            Text(formatElapsedTime(coordinator.recordingElapsedTime))
+                                .font(MuesliTheme.captionMedium())
+                                .monospacedDigit()
+                                .foregroundStyle(statusColor)
+                                .padding(.horizontal, MuesliTheme.spacing8)
+                                .padding(.vertical, MuesliTheme.spacing4)
+                                .background(statusColor.opacity(0.13))
+                                .clipShape(Capsule())
+                                .accessibilityLabel("Recording elapsed time")
+                                .accessibilityValue(formatElapsedTime(coordinator.recordingElapsedTime))
+                        }
+
+                        microphoneMenu
                     }
                 }
 
@@ -177,6 +187,7 @@ struct DictationView: View {
                 .accessibilityLabel(dictationButtonTitle)
                 .accessibilityAddTraits(.isButton)
                 .accessibilityIdentifier("dictation.primaryButton")
+                .padding(.top, isWaveformActive || shouldShowRealtimeTranscript ? 0 : MuesliTheme.spacing4)
 
                 if shouldShowKeyboardSetupRow && !shouldHideKeyboardSetupRowForMockPreview {
                     keyboardShortcutRow
@@ -188,6 +199,41 @@ struct DictationView: View {
         .task {
             await runPreviewWaveformIfNeeded()
         }
+    }
+
+    private var microphoneMenu: some View {
+        Menu {
+            Section("Recording Microphone") {
+                ForEach(AudioInputRouteManager.availablePreferenceOptions()) { option in
+                    Button {
+                        microphonePreference = option.rawValue
+                        coordinator.refreshAudioInputRoute()
+                    } label: {
+                        Label(
+                            option.label,
+                            systemImage: option.rawValue == microphonePreference ? "checkmark" : "mic"
+                        )
+                    }
+                }
+            }
+        } label: {
+            HStack(spacing: 6) {
+                Image(systemName: "mic")
+                Text(coordinator.audioInputRouteText)
+                    .lineLimit(1)
+            }
+            .font(MuesliTheme.captionMedium())
+            .foregroundStyle(MuesliTheme.textSecondary)
+            .padding(.horizontal, MuesliTheme.spacing8)
+            .frame(minHeight: 32)
+            .background(MuesliTheme.surfacePrimary)
+            .clipShape(Capsule())
+            .contentShape(Capsule())
+        }
+        .buttonStyle(.plain)
+        .menuOrder(.fixed)
+        .accessibilityLabel("Recording microphone")
+        .accessibilityValue(coordinator.audioInputRouteText)
     }
 
     private var keyboardShortcutRow: some View {

--- a/Muesli/KeyboardSessionKeeper.swift
+++ b/Muesli/KeyboardSessionKeeper.swift
@@ -17,10 +17,7 @@ final class KeyboardSessionKeeper {
             throw AudioRecorder.RecordingError.microphonePermissionDenied
         }
 
-        _ = try AudioInputRouteManager.configureForRecording(
-            stage: "keyboard session",
-            preference: .builtIn
-        )
+        _ = try AudioInputRouteManager.configureForKeyboardKeepAlive(stage: "keyboard session")
 
         let engine = AVAudioEngine()
         let inputNode = engine.inputNode

--- a/Muesli/KeyboardSessionKeeper.swift
+++ b/Muesli/KeyboardSessionKeeper.swift
@@ -17,13 +17,7 @@ final class KeyboardSessionKeeper {
             throw AudioRecorder.RecordingError.microphonePermissionDenied
         }
 
-        let session = AVAudioSession.sharedInstance()
-        do {
-            try session.setCategory(.playAndRecord, mode: .spokenAudio, options: [.mixWithOthers])
-            try session.setActive(true)
-        } catch {
-            throw AudioRecorder.RecordingError.audioSessionFailed(stage: "keyboard session", underlying: error)
-        }
+        _ = try AudioInputRouteManager.configureForRecording(stage: "keyboard session")
 
         let engine = AVAudioEngine()
         let inputNode = engine.inputNode
@@ -35,7 +29,7 @@ final class KeyboardSessionKeeper {
             try engine.start()
         } catch {
             inputNode.removeTap(onBus: 0)
-            try? session.setActive(false, options: .notifyOthersOnDeactivation)
+            try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
             throw AudioRecorder.RecordingError.startFailed(stage: "keyboard session")
         }
 

--- a/Muesli/KeyboardSessionKeeper.swift
+++ b/Muesli/KeyboardSessionKeeper.swift
@@ -17,7 +17,10 @@ final class KeyboardSessionKeeper {
             throw AudioRecorder.RecordingError.microphonePermissionDenied
         }
 
-        _ = try AudioInputRouteManager.configureForRecording(stage: "keyboard session")
+        _ = try AudioInputRouteManager.configureForRecording(
+            stage: "keyboard session",
+            preference: .builtIn
+        )
 
         let engine = AVAudioEngine()
         let inputNode = engine.inputNode

--- a/Muesli/MuesliPreferences.swift
+++ b/Muesli/MuesliPreferences.swift
@@ -73,14 +73,9 @@ enum MuesliPreferences {
     }
 
     static var recordingMicrophonePreference: RecordingMicrophonePreference {
-        let storedPreference = RecordingMicrophonePreference(
+        RecordingMicrophonePreference(
             rawValue: UserDefaults.standard.string(forKey: recordingMicrophonePreferenceKey) ?? ""
         ) ?? .automatic
-        let normalizedPreference = AudioInputRouteManager.normalizedPreference(storedPreference)
-        if normalizedPreference != storedPreference {
-            UserDefaults.standard.set(normalizedPreference.rawValue, forKey: recordingMicrophonePreferenceKey)
-        }
-        return normalizedPreference
     }
 
     static var meetingSummariesEnabled: Bool {

--- a/Muesli/MuesliPreferences.swift
+++ b/Muesli/MuesliPreferences.swift
@@ -12,6 +12,7 @@ enum MuesliPreferences {
     static let transcriptionModelKey = "muesli.transcription.localModel"
     static let keepDictationAudioRecordingsKey = "muesli.dictations.keepAudioRecordings"
     static let keepMeetingAudioRecordingsKey = "muesli.meetings.keepAudioRecordings"
+    static let recordingMicrophonePreferenceKey = "muesli.recording.microphonePreference"
     static let meetingSummariesEnabledKey = "muesli.meetings.summaries.enabled"
     static let meetingSummaryBackendKey = "muesli.meetings.summary.backend"
     static let openRouterModelKey = "muesli.meetings.summary.openRouter.model"
@@ -69,6 +70,12 @@ enum MuesliPreferences {
 
     static var keepMeetingAudioRecordingsEnabled: Bool {
         bool(for: keepMeetingAudioRecordingsKey, defaultValue: false)
+    }
+
+    static var recordingMicrophonePreference: RecordingMicrophonePreference {
+        RecordingMicrophonePreference(
+            rawValue: UserDefaults.standard.string(forKey: recordingMicrophonePreferenceKey) ?? ""
+        ) ?? .automatic
     }
 
     static var meetingSummariesEnabled: Bool {

--- a/Muesli/MuesliPreferences.swift
+++ b/Muesli/MuesliPreferences.swift
@@ -73,9 +73,14 @@ enum MuesliPreferences {
     }
 
     static var recordingMicrophonePreference: RecordingMicrophonePreference {
-        RecordingMicrophonePreference(
+        let storedPreference = RecordingMicrophonePreference(
             rawValue: UserDefaults.standard.string(forKey: recordingMicrophonePreferenceKey) ?? ""
         ) ?? .automatic
+        let normalizedPreference = AudioInputRouteManager.normalizedPreference(storedPreference)
+        if normalizedPreference != storedPreference {
+            UserDefaults.standard.set(normalizedPreference.rawValue, forKey: recordingMicrophonePreferenceKey)
+        }
+        return normalizedPreference
     }
 
     static var meetingSummariesEnabled: Bool {

--- a/Muesli/SettingsView.swift
+++ b/Muesli/SettingsView.swift
@@ -889,8 +889,31 @@ private struct SettingsToggleRow: View {
 private struct SettingsMicrophonePicker: View {
     @Binding var selection: String
 
+    private var availableOptions: [RecordingMicrophonePreference] {
+        AudioInputRouteManager.availablePreferenceOptions()
+    }
+
+    private var normalizedSelection: Binding<String> {
+        Binding(
+            get: {
+                let selectedPreference = RecordingMicrophonePreference(rawValue: selection) ?? .automatic
+                let normalizedPreference = AudioInputRouteManager.normalizedPreference(selectedPreference)
+                return normalizedPreference.rawValue
+            },
+            set: { selection = $0 }
+        )
+    }
+
     private var preference: RecordingMicrophonePreference {
-        RecordingMicrophonePreference(rawValue: selection) ?? .automatic
+        RecordingMicrophonePreference(rawValue: normalizedSelection.wrappedValue) ?? .automatic
+    }
+
+    private func normalizeStoredSelection() {
+        let selectedPreference = RecordingMicrophonePreference(rawValue: selection) ?? .automatic
+        let normalizedPreference = AudioInputRouteManager.normalizedPreference(selectedPreference)
+        if normalizedPreference.rawValue != selection {
+            selection = normalizedPreference.rawValue
+        }
     }
 
     var body: some View {
@@ -912,14 +935,18 @@ private struct SettingsMicrophonePicker: View {
 
             Spacer(minLength: MuesliTheme.spacing12)
 
-            Picker("Microphone", selection: $selection) {
-                ForEach(AudioInputRouteManager.availablePreferenceOptions()) { option in
+            Picker("Microphone", selection: normalizedSelection) {
+                ForEach(availableOptions) { option in
                     Text(option.label).tag(option.rawValue)
                 }
             }
             .labelsHidden()
             .pickerStyle(.menu)
             .tint(MuesliTheme.accent)
+        }
+        .onAppear(perform: normalizeStoredSelection)
+        .onChange(of: selection) { _, _ in
+            normalizeStoredSelection()
         }
     }
 }

--- a/Muesli/SettingsView.swift
+++ b/Muesli/SettingsView.swift
@@ -890,30 +890,13 @@ private struct SettingsMicrophonePicker: View {
     @Binding var selection: String
 
     private var availableOptions: [RecordingMicrophonePreference] {
-        AudioInputRouteManager.availablePreferenceOptions()
-    }
-
-    private var normalizedSelection: Binding<String> {
-        Binding(
-            get: {
-                let selectedPreference = RecordingMicrophonePreference(rawValue: selection) ?? .automatic
-                let normalizedPreference = AudioInputRouteManager.normalizedPreference(selectedPreference)
-                return normalizedPreference.rawValue
-            },
-            set: { selection = $0 }
-        )
+        let options = AudioInputRouteManager.availablePreferenceOptions()
+        guard !options.contains(preference) else { return options }
+        return options + [preference]
     }
 
     private var preference: RecordingMicrophonePreference {
-        RecordingMicrophonePreference(rawValue: normalizedSelection.wrappedValue) ?? .automatic
-    }
-
-    private func normalizeStoredSelection() {
-        let selectedPreference = RecordingMicrophonePreference(rawValue: selection) ?? .automatic
-        let normalizedPreference = AudioInputRouteManager.normalizedPreference(selectedPreference)
-        if normalizedPreference.rawValue != selection {
-            selection = normalizedPreference.rawValue
-        }
+        RecordingMicrophonePreference(rawValue: selection) ?? .automatic
     }
 
     var body: some View {
@@ -935,7 +918,7 @@ private struct SettingsMicrophonePicker: View {
 
             Spacer(minLength: MuesliTheme.spacing12)
 
-            Picker("Microphone", selection: normalizedSelection) {
+            Picker("Microphone", selection: $selection) {
                 ForEach(availableOptions) { option in
                     Text(option.label).tag(option.rawValue)
                 }
@@ -943,10 +926,6 @@ private struct SettingsMicrophonePicker: View {
             .labelsHidden()
             .pickerStyle(.menu)
             .tint(MuesliTheme.accent)
-        }
-        .onAppear(perform: normalizeStoredSelection)
-        .onChange(of: selection) { _, _ in
-            normalizeStoredSelection()
         }
     }
 }

--- a/Muesli/SettingsView.swift
+++ b/Muesli/SettingsView.swift
@@ -12,6 +12,7 @@ struct SettingsView: View {
     @AppStorage(MuesliPreferences.liveActivitiesForMeetingsKey) private var liveActivitiesForMeetings = true
     @AppStorage(MuesliPreferences.keyboardSessionModeKey) private var keyboardSessionMode = false
     @AppStorage(MuesliPreferences.keyboardSessionTimeoutMinutesKey) private var keyboardSessionTimeoutMinutes = 10
+    @AppStorage(MuesliPreferences.recordingMicrophonePreferenceKey) private var microphonePreference = RecordingMicrophonePreference.automatic.rawValue
     @AppStorage(MuesliPreferences.keepDictationAudioRecordingsKey) private var keepDictationAudioRecordings = false
     @AppStorage(MuesliPreferences.keepMeetingAudioRecordingsKey) private var keepMeetingAudioRecordings = false
     @AppStorage(MuesliPreferences.meetingSummariesEnabledKey) private var meetingSummariesEnabled = false
@@ -67,6 +68,10 @@ struct SettingsView: View {
             }
             .onChange(of: keyboardSessionTimeoutMinutes) { _, _ in
                 coordinator.refreshKeyboardSessionTimeout()
+            }
+            .onChange(of: microphonePreference) { _, newValue in
+                coordinator.refreshAudioInputRoute()
+                AppTelemetry.signal("recording_microphone_preference_changed", parameters: ["preference": newValue])
             }
             .onChange(of: openRouterAPIKey) { _, newValue in
                 saveOpenRouterAPIKey(newValue)
@@ -275,6 +280,8 @@ struct SettingsView: View {
                         title: "Session",
                         value: coordinator.keyboardSessionStatusText
                     )
+                    Divider().overlay(MuesliTheme.surfaceBorder)
+                    SettingsMicrophonePicker(selection: $microphonePreference)
                     Divider().overlay(MuesliTheme.surfaceBorder)
                     Stepper(value: $keyboardSessionTimeoutMinutes, in: 1...30, step: 1) {
                         SettingsRow(
@@ -875,6 +882,44 @@ private struct SettingsToggleRow: View {
             Toggle(title, isOn: $isOn)
                 .labelsHidden()
                 .tint(MuesliTheme.accent)
+        }
+    }
+}
+
+private struct SettingsMicrophonePicker: View {
+    @Binding var selection: String
+
+    private var preference: RecordingMicrophonePreference {
+        RecordingMicrophonePreference(rawValue: selection) ?? .automatic
+    }
+
+    var body: some View {
+        HStack(alignment: .top, spacing: MuesliTheme.spacing12) {
+            Image(systemName: "mic")
+                .font(.system(size: 15, weight: .medium))
+                .foregroundStyle(MuesliTheme.accent)
+                .frame(width: 22)
+
+            VStack(alignment: .leading, spacing: MuesliTheme.spacing4) {
+                Text("Microphone")
+                    .font(MuesliTheme.headline())
+                    .foregroundStyle(MuesliTheme.textPrimary)
+                Text(preference.detail)
+                    .font(MuesliTheme.caption())
+                    .foregroundStyle(MuesliTheme.textSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Spacer(minLength: MuesliTheme.spacing12)
+
+            Picker("Microphone", selection: $selection) {
+                ForEach(AudioInputRouteManager.availablePreferenceOptions()) { option in
+                    Text(option.label).tag(option.rawValue)
+                }
+            }
+            .labelsHidden()
+            .pickerStyle(.menu)
+            .tint(MuesliTheme.accent)
         }
     }
 }

--- a/Muesli/StreamingMeetingRecorder.swift
+++ b/Muesli/StreamingMeetingRecorder.swift
@@ -1,5 +1,6 @@
 import AVFoundation
 import Foundation
+import os
 
 struct MeetingAudioChunk: Sendable, Equatable {
     let index: Int
@@ -35,12 +36,16 @@ final class StreamingMeetingRecorder: @unchecked Sendable {
     private static let sampleRate: Double = 16_000
     private static let bufferSize: AVAudioFrameCount = 4_096
 
-    func start(chunksDirectory: URL, retainedAudioURL: URL?) throws {
+    func start(
+        chunksDirectory: URL,
+        retainedAudioURL: URL?,
+        routeStage: String = "streaming recorder"
+    ) throws {
         guard !isRunning else { return }
         self.chunksDirectory = chunksDirectory
         try FileManager.default.createDirectory(at: chunksDirectory, withIntermediateDirectories: true)
 
-        _ = try AudioInputRouteManager.configureForRecording(stage: "streaming recorder")
+        _ = try AudioInputRouteManager.configureForRecording(stage: routeStage)
 
         guard let targetFormat = AVAudioFormat(
             commonFormat: .pcmFormatFloat32,
@@ -207,14 +212,18 @@ final class StreamingMeetingRecorder: @unchecked Sendable {
             let ratio = targetFormat.sampleRate / buffer.format.sampleRate
             let frameCapacity = max(1, AVAudioFrameCount(Double(buffer.frameLength) * ratio) + 1)
             guard let converted = AVAudioPCMBuffer(pcmFormat: targetFormat, frameCapacity: frameCapacity) else { return }
-            var didProvideInput = false
+            let didProvideInput = OSAllocatedUnfairLock(initialState: false)
             var error: NSError?
             converter.convert(to: converted, error: &error) { _, outStatus in
-                guard !didProvideInput else {
+                let shouldProvideInput = didProvideInput.withLock { hasProvidedInput in
+                    guard !hasProvidedInput else { return false }
+                    hasProvidedInput = true
+                    return true
+                }
+                guard shouldProvideInput else {
                     outStatus.pointee = .noDataNow
                     return nil
                 }
-                didProvideInput = true
                 outStatus.pointee = .haveData
                 return buffer
             }

--- a/Muesli/StreamingMeetingRecorder.swift
+++ b/Muesli/StreamingMeetingRecorder.swift
@@ -47,49 +47,51 @@ final class StreamingMeetingRecorder: @unchecked Sendable {
 
         _ = try AudioInputRouteManager.configureForRecording(stage: routeStage)
 
-        guard let targetFormat = AVAudioFormat(
-            commonFormat: .pcmFormatFloat32,
-            sampleRate: Self.sampleRate,
-            channels: 1,
-            interleaved: false
-        ) else {
-            throw AudioRecorder.RecordingError.startFailed(stage: "streaming format")
-        }
-
-        let inputNode = engine.inputNode
-        let inputFormat = inputNode.outputFormat(forBus: 0)
-        converter = inputFormat.sampleRate != targetFormat.sampleRate || inputFormat.channelCount != targetFormat.channelCount
-            ? AVAudioConverter(from: inputFormat, to: targetFormat)
-            : nil
-
-        let firstChunkURL = chunkURL(directory: chunksDirectory, index: 0)
-        let firstChunkFile = try AVAudioFile(forWriting: firstChunkURL, settings: targetFormat.settings)
-        let retainedFile = try retainedAudioURL.map { url in
-            try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
-            return try AVAudioFile(forWriting: url, settings: targetFormat.settings)
-        }
-
-        lock.lock()
-        state = FileState(
-            chunkFile: firstChunkFile,
-            chunkURL: firstChunkURL,
-            retainedFile: retainedFile,
-            retainedURL: retainedAudioURL
-        )
-        lock.unlock()
-
-        inputNode.installTap(onBus: 0, bufferSize: Self.bufferSize, format: nil) { [weak self] buffer, _ in
-            self?.handle(buffer: buffer, targetFormat: targetFormat)
-        }
-        tapInstalled = true
-        engine.prepare()
-
         do {
+            guard let targetFormat = AVAudioFormat(
+                commonFormat: .pcmFormatFloat32,
+                sampleRate: Self.sampleRate,
+                channels: 1,
+                interleaved: false
+            ) else {
+                throw AudioRecorder.RecordingError.startFailed(stage: "streaming format")
+            }
+
+            let inputNode = engine.inputNode
+            let inputFormat = inputNode.outputFormat(forBus: 0)
+            converter = inputFormat.sampleRate != targetFormat.sampleRate || inputFormat.channelCount != targetFormat.channelCount
+                ? AVAudioConverter(from: inputFormat, to: targetFormat)
+                : nil
+
+            let firstChunkURL = chunkURL(directory: chunksDirectory, index: 0)
+            let firstChunkFile = try AVAudioFile(forWriting: firstChunkURL, settings: targetFormat.settings)
+            let retainedFile = try retainedAudioURL.map { url in
+                try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+                return try AVAudioFile(forWriting: url, settings: targetFormat.settings)
+            }
+
+            lock.lock()
+            state = FileState(
+                chunkFile: firstChunkFile,
+                chunkURL: firstChunkURL,
+                retainedFile: retainedFile,
+                retainedURL: retainedAudioURL
+            )
+            lock.unlock()
+
+            inputNode.installTap(onBus: 0, bufferSize: Self.bufferSize, format: nil) { [weak self] buffer, _ in
+                self?.handle(buffer: buffer, targetFormat: targetFormat)
+            }
+            tapInstalled = true
+            engine.prepare()
             try engine.start()
             isRunning = true
         } catch {
             cleanupAfterFailedStart()
-            throw AudioRecorder.RecordingError.startFailed(stage: "streaming meeting")
+            if error is AudioRecorder.RecordingError {
+                throw error
+            }
+            throw AudioRecorder.RecordingError.startFailed(stage: routeStage)
         }
     }
 
@@ -296,6 +298,7 @@ final class StreamingMeetingRecorder: @unchecked Sendable {
         state = FileState()
         lock.unlock()
         isRunning = false
+        try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
     }
 
     private func chunkURL(directory: URL, index: Int) -> URL {

--- a/Muesli/StreamingMeetingRecorder.swift
+++ b/Muesli/StreamingMeetingRecorder.swift
@@ -40,13 +40,7 @@ final class StreamingMeetingRecorder: @unchecked Sendable {
         self.chunksDirectory = chunksDirectory
         try FileManager.default.createDirectory(at: chunksDirectory, withIntermediateDirectories: true)
 
-        let session = AVAudioSession.sharedInstance()
-        do {
-            try session.setCategory(.playAndRecord, mode: .spokenAudio, options: [.mixWithOthers])
-            try session.setActive(true)
-        } catch {
-            throw AudioRecorder.RecordingError.audioSessionFailed(stage: "streaming meeting", underlying: error)
-        }
+        _ = try AudioInputRouteManager.configureForRecording(stage: "streaming recorder")
 
         guard let targetFormat = AVAudioFormat(
             commonFormat: .pcmFormatFloat32,


### PR DESCRIPTION
## Summary
- Add a shared audio route manager for recording sessions
- Add a mic route chip and Settings picker for Automatic, iPhone mic, AirPods/Bluetooth, and detected external inputs
- Route quick dictation, realtime dictation, meetings, and keyboard session setup through the shared policy

## Testing
- Built for picophone with xcodebuild
- Installed and manually tested AirPods / Bluetooth route selection on picophone

## Notes
- AirPods / Bluetooth is intentionally a policy option because iOS may not expose AirPods as a concrete input until the play-and-record Bluetooth session is active.
- External Microphone is only shown when iOS reports a non-built-in, non-Bluetooth input.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli-ios/pr/11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785478020&installation_id=136549638&pr_number=11&repository=Muesli-HQ%2Fmuesli-ios&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli-ios%2Fpull%2F11&signature=2e7416bd12c540664b889037f7b47b499331a48533d9448c1aab1776442e12c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/muesli-hq/muesli-ios/pull/11" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added recording microphone routing controls (automatic, built-in, Bluetooth, external) across dictation, meeting, and keyboard session recording.
  * Persisted your microphone routing preference and introduced microphone pickers that display the currently active input route.
  * The active input route display now refreshes automatically on app focus and system route changes.
* **Bug Fixes**
  * Improved recording audio session setup consistency across recording modes.
  * Improved meeting audio streaming reliability, including safer handling during failed starts and more reliable conversion behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->