### PR TITLE
Add landing stats dashboard

### DIFF
--- a/Muesli/AudioInputRouteManager.swift
+++ b/Muesli/AudioInputRouteManager.swift
@@ -110,7 +110,7 @@ enum AudioInputRouteManager {
         let output = session.currentRoute.outputs.first
         return AudioInputRouteSnapshot(
             preference: preference,
-            inputName: input?.portName ?? fallbackInputName(for: preference, availableInputs: session.availableInputs ?? []),
+            inputName: displayName(for: input) ?? fallbackInputName(for: preference, availableInputs: session.availableInputs ?? []),
             inputDetail: detail(for: input?.portType),
             outputName: output?.portName ?? "Default Output"
         )
@@ -160,7 +160,15 @@ enum AudioInputRouteManager {
         for preference: RecordingMicrophonePreference,
         availableInputs: [AVAudioSessionPortDescription]
     ) -> String {
-        preferredInput(for: preference, in: availableInputs)?.portName ?? preference.label
+        preferredInput(for: preference, in: availableInputs).flatMap(displayName(for:)) ?? preference.label
+    }
+
+    private static func displayName(for input: AVAudioSessionPortDescription?) -> String? {
+        guard let input else { return nil }
+        if isBuiltInInput(input) {
+            return RecordingMicrophonePreference.builtIn.label
+        }
+        return input.portName
     }
 
     private static func isBuiltInInput(_ input: AVAudioSessionPortDescription) -> Bool {

--- a/Muesli/DictationCoordinator.swift
+++ b/Muesli/DictationCoordinator.swift
@@ -537,6 +537,30 @@ final class DictationCoordinator {
         }
     }
 
+    func updateMeetingTitle(sessionID: UUID, title: String) {
+        do {
+            guard var session = try store.recordingSession(id: sessionID),
+                  session.kind == .meeting
+            else { return }
+
+            let trimmedTitle = title.trimmingCharacters(in: .whitespacesAndNewlines)
+            session.title = trimmedTitle.isEmpty ? session.kind.title : trimmedTitle
+            try store.saveSession(session)
+            if let index = recordingSessions.firstIndex(where: { $0.id == session.id }) {
+                recordingSessions[index] = session
+            } else {
+                refreshHistory()
+            }
+            clipboardStatusText = "Title updated"
+            clearClipboardStatusSoon()
+            scheduleICloudSyncAfterLocalChange(reason: "meeting_title_updated")
+            AppTelemetry.signal("meeting_title_updated")
+        } catch {
+            clipboardStatusText = "Title update failed"
+            clearClipboardStatusSoon()
+        }
+    }
+
     func copyTranscript(_ transcript: Transcript) {
         UIPasteboard.general.string = transcript.text
         clipboardStatusText = "Copied"
@@ -1761,6 +1785,40 @@ final class DictationCoordinator {
         transcribeSession(session)
     }
 
+    func cancelCurrentMeetingRecording() {
+        guard isMeetingRecording || meetingRecorder != nil || persistedRecordingMeetingSession != nil else { return }
+        guard let session = activeSession ?? persistedRecordingMeetingSession, session.kind == .meeting else { return }
+
+        MuesliHaptics.dictationStop()
+        isMeetingRecording = false
+        isMeetingTranscribing = false
+        stopMetering()
+        meetingStatusText = "Ready"
+
+        meetingVadController?.stop()
+        meetingRecorder?.cancel()
+        meetingRecorder = nil
+        meetingVadController = nil
+        activeSession = nil
+        cleanupMeetingChunks(cancelTasks: true)
+
+        if let audioFileName = session.audioFileName {
+            try? store.deleteAudioFile(fileName: audioFileName)
+        }
+        try? store.deleteTranscript(for: session.id)
+        try? store.deleteRecordingSession(id: session.id)
+        recordingSessions.removeAll { $0.id == session.id }
+        refreshHistory()
+        Task {
+            await liveActivityController.end(
+                phase: "Discarded",
+                detail: "Meeting recording discarded",
+                session: session
+            )
+        }
+        AppTelemetry.signal("meeting_recording_discarded")
+    }
+
     func stopMeetingRecording(queueForTranscription _: Bool = false) {
         guard isMeetingRecording || meetingRecorder != nil else { return }
         guard var session = activeSession ?? persistedRecordingMeetingSession, session.kind == .meeting else { return }
@@ -1843,6 +1901,10 @@ final class DictationCoordinator {
         let merged = MeetingChunkTranscriptMerger.merge(meetingChunkTranscriptions)
         let text = postProcessTranscript(merged.text)
         guard !text.isEmpty else { return }
+        guard var session = try? store.recordingSession(id: sessionID),
+              session.kind == .meeting,
+              session.phase != .cancelled
+        else { return }
 
         let transcript = Transcript(
             sessionID: sessionID,
@@ -1854,11 +1916,9 @@ final class DictationCoordinator {
             summaryState: MuesliPreferences.meetingSummariesEnabled ? .processing : .notStarted
         )
         try? store.saveTranscript(transcript)
-        if var session = try? store.recordingSession(id: sessionID) {
-            session.transcriptID = transcript.id
-            session.engineIdentifier = engine.identifier
-            try? store.saveSession(session)
-        }
+        session.transcriptID = transcript.id
+        session.engineIdentifier = engine.identifier
+        try? store.saveSession(session)
         refreshHistory()
     }
 
@@ -2119,7 +2179,10 @@ final class DictationCoordinator {
         return directory
     }
 
-    private func cleanupMeetingChunks() {
+    private func cleanupMeetingChunks(cancelTasks: Bool = false) {
+        if cancelTasks {
+            meetingChunkTasks.forEach { $0.cancel() }
+        }
         if let meetingChunksDirectory {
             try? FileManager.default.removeItem(at: meetingChunksDirectory)
         }

--- a/Muesli/DictationCoordinator.swift
+++ b/Muesli/DictationCoordinator.swift
@@ -1746,6 +1746,13 @@ final class DictationCoordinator {
                     )
                 }
             } catch {
+                guard shouldContinueMeetingFinalization(sessionID: session.id) else {
+                    cleanupMeetingChunks()
+                    meetingStatusText = "Ready"
+                    refreshHistory()
+                    return
+                }
+
                 session.phase = .failed
                 session.errorMessage = error.localizedDescription
                 try? store.saveSession(session)

--- a/Muesli/DictationCoordinator.swift
+++ b/Muesli/DictationCoordinator.swift
@@ -1746,7 +1746,7 @@ final class DictationCoordinator {
                     )
                 }
             } catch {
-                guard shouldContinueMeetingFinalization(sessionID: session.id) else {
+                guard !discardedMeetingSessionIDs.contains(session.id) else {
                     cleanupMeetingChunks()
                     meetingStatusText = "Ready"
                     refreshHistory()
@@ -2000,6 +2000,13 @@ final class DictationCoordinator {
                     "chunked": "true"
                 ])
             } catch {
+                guard shouldContinueMeetingFinalization(sessionID: session.id) else {
+                    cleanupMeetingChunks()
+                    meetingStatusText = "Ready"
+                    refreshHistory()
+                    return
+                }
+
                 session.phase = .failed
                 session.errorMessage = error.localizedDescription
                 try? store.saveSession(session)

--- a/Muesli/DictationCoordinator.swift
+++ b/Muesli/DictationCoordinator.swift
@@ -110,7 +110,7 @@ final class DictationCoordinator {
     var clipboardStatusText: String?
 
     var hasMeetingRecordingInProgress: Bool {
-        isMeetingRecording || persistedRecordingMeetingSession != nil
+        isMeetingRecording || activeSession?.kind == .meeting || persistedRecordingMeetingSession != nil
     }
 
     var effectiveMeetingStatusText: String {
@@ -1685,7 +1685,7 @@ final class DictationCoordinator {
     }
 
     func startMeetingRecording(title: String = "Untitled Meeting") {
-        guard !isRecording, !isMeetingRecording, !isMeetingTranscribing, statusText != "Transcribing" else { return }
+        guard !isRecording, !isMeetingRecording, !isMeetingTranscribing, activeSession?.kind != .meeting, statusText != "Transcribing" else { return }
         MuesliHaptics.dictationStart()
         activeMeetingTitle = title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
             ? "Untitled Meeting"

--- a/Muesli/DictationCoordinator.swift
+++ b/Muesli/DictationCoordinator.swift
@@ -552,9 +552,13 @@ final class DictationCoordinator {
     }
 
     func recordingSession(for result: DictationResult) -> RecordingSession? {
-        if let sessionID = result.sessionID,
-           let session = try? store.recordingSession(id: sessionID) {
-            return session
+        if let sessionID = result.sessionID {
+            if let cachedSession = recordingSessions.first(where: { $0.id == sessionID }) {
+                return cachedSession
+            }
+            if let storedSession = try? store.recordingSession(id: sessionID) {
+                return storedSession
+            }
         }
         return nil
     }

--- a/Muesli/DictationCoordinator.swift
+++ b/Muesli/DictationCoordinator.swift
@@ -434,6 +434,13 @@ final class DictationCoordinator {
         }
     }
 
+    func cancelActiveRecording() {
+        guard let request = activeRequest else { return }
+        MuesliHaptics.dictationStop()
+        cancelRecording(requestID: request.id)
+        AppTelemetry.signal("dictation_cancelled", parameters: ["source": isKeyboardHandoffActive ? "keyboard" : "app"])
+    }
+
     func refreshHistory() {
         do {
             dictationHistory = try store.resultsHistory()
@@ -2164,6 +2171,13 @@ final class DictationCoordinator {
         session.audioFileName = nil
     }
 
+    private func discardAudio(for session: inout RecordingSession) {
+        guard let audioFileName = session.audioFileName else { return }
+        try? store.deleteAudioFile(fileName: audioFileName)
+        session.audioFileName = nil
+        session.keepsAudioRecording = false
+    }
+
     private func exportRetainedAudioIfNeeded(for session: RecordingSession) {
         guard session.keepsAudioRecording,
               let audioFileName = session.audioFileName
@@ -2487,8 +2501,11 @@ final class DictationCoordinator {
         if var session = activeSession {
             session.phase = .cancelled
             session.endedAt = .now
-            cleanupNonRetainedAudio(for: &session)
+            discardAudio(for: &session)
             try? store.saveSession(session)
+            if let index = recordingSessions.firstIndex(where: { $0.id == session.id }) {
+                recordingSessions[index] = session
+            }
             Task {
                 await liveActivityController.end(
                     phase: "Cancelled",

--- a/Muesli/DictationCoordinator.swift
+++ b/Muesli/DictationCoordinator.swift
@@ -38,6 +38,7 @@ final class DictationCoordinator {
     private var meetingChunkTasks: [Task<MeetingChunkTranscription?, Never>] = []
     private var meetingChunkTranscriptions: [MeetingChunkTranscription] = []
     private var meetingChunksDirectory: URL?
+    private var discardedMeetingSessionIDs = Set<UUID>()
     private let meetingVadQueue = DispatchQueue(label: "com.phequals7.muesli.meeting-vad")
     private var transcriptionBackgroundTask: UIBackgroundTaskIdentifier = .invalid
     nonisolated(unsafe) private var audioRouteObserver: NSObjectProtocol?
@@ -436,9 +437,10 @@ final class DictationCoordinator {
 
     func cancelActiveRecording() {
         guard let request = activeRequest else { return }
+        let source = isKeyboardHandoffActive ? "keyboard" : "app"
         MuesliHaptics.dictationStop()
         cancelRecording(requestID: request.id)
-        AppTelemetry.signal("dictation_cancelled", parameters: ["source": isKeyboardHandoffActive ? "keyboard" : "app"])
+        AppTelemetry.signal("dictation_cancelled", parameters: ["source": source])
     }
 
     func refreshHistory() {
@@ -539,7 +541,7 @@ final class DictationCoordinator {
 
     func updateMeetingTitle(sessionID: UUID, title: String) {
         do {
-            guard var session = try store.recordingSession(id: sessionID),
+            guard var session = try store.activeRecordingSession(id: sessionID),
                   session.kind == .meeting
             else { return }
 
@@ -587,7 +589,7 @@ final class DictationCoordinator {
             if let cachedSession = recordingSessions.first(where: { $0.id == sessionID }) {
                 return cachedSession
             }
-            if let storedSession = try? store.recordingSession(id: sessionID) {
+            if let storedSession = try? store.activeRecordingSession(id: sessionID) {
                 return storedSession
             }
         }
@@ -1800,6 +1802,7 @@ final class DictationCoordinator {
         meetingRecorder = nil
         meetingVadController = nil
         activeSession = nil
+        discardedMeetingSessionIDs.insert(session.id)
         cleanupMeetingChunks(cancelTasks: true)
 
         if let audioFileName = session.audioFileName {
@@ -1901,7 +1904,8 @@ final class DictationCoordinator {
         let merged = MeetingChunkTranscriptMerger.merge(meetingChunkTranscriptions)
         let text = postProcessTranscript(merged.text)
         guard !text.isEmpty else { return }
-        guard var session = try? store.recordingSession(id: sessionID),
+        guard !discardedMeetingSessionIDs.contains(sessionID),
+              var session = try? store.activeRecordingSession(id: sessionID),
               session.kind == .meeting,
               session.phase != .cancelled
         else { return }
@@ -1940,6 +1944,11 @@ final class DictationCoordinator {
                     }
                 }
                 meetingChunkTasks.removeAll(keepingCapacity: false)
+                guard shouldContinueMeetingFinalization(sessionID: session.id) else {
+                    meetingStatusText = "Ready"
+                    cleanupMeetingChunks()
+                    return
+                }
 
                 let mergedTranscription = MeetingChunkTranscriptMerger.merge(meetingChunkTranscriptions)
                 let text = postProcessTranscript(mergedTranscription.text)
@@ -1954,6 +1963,12 @@ final class DictationCoordinator {
                     ),
                     audioURL: audioURL
                 )
+                guard shouldContinueMeetingFinalization(sessionID: session.id) else {
+                    try? store.deleteTranscript(for: session.id)
+                    meetingStatusText = "Ready"
+                    cleanupMeetingChunks()
+                    return
+                }
 
                 session.phase = .completed
                 session.title = finalTranscript.resolvedTitle
@@ -2189,6 +2204,13 @@ final class DictationCoordinator {
         meetingChunksDirectory = nil
         meetingChunkTasks.removeAll(keepingCapacity: false)
         meetingChunkTranscriptions.removeAll(keepingCapacity: false)
+    }
+
+    private func shouldContinueMeetingFinalization(sessionID: UUID) -> Bool {
+        guard !discardedMeetingSessionIDs.contains(sessionID),
+              (try? store.activeRecordingSession(id: sessionID)) != nil
+        else { return false }
+        return true
     }
 
     private func startMetering(update: @escaping @MainActor (Double) -> Void) {

--- a/Muesli/DictationCoordinator.swift
+++ b/Muesli/DictationCoordinator.swift
@@ -1692,16 +1692,34 @@ final class DictationCoordinator {
             : title.trimmingCharacters(in: .whitespacesAndNewlines)
         var session = RecordingSession(kind: .meeting, title: activeMeetingTitle)
         session.keepsAudioRecording = true
+        activeSession = session
+        meetingStatusText = "Preparing"
 
         Task {
             do {
+                guard !discardedMeetingSessionIDs.contains(session.id) else {
+                    abortDiscardedMeetingStartup(session)
+                    return
+                }
+
                 let audioURL = try store.newAudioFileURL(sessionID: session.id)
                 let chunksDirectory = try meetingChunkDirectory(for: session.id)
                 try? FileManager.default.removeItem(at: chunksDirectory)
                 session.audioFileName = audioURL.lastPathComponent
                 session.startedAt = .now
                 try store.saveSession(session)
+
+                guard !discardedMeetingSessionIDs.contains(session.id) else {
+                    abortDiscardedMeetingStartup(session)
+                    return
+                }
+
                 try await recorder.requestPermission()
+
+                guard !discardedMeetingSessionIDs.contains(session.id) else {
+                    abortDiscardedMeetingStartup(session)
+                    return
+                }
 
                 let vadManager = try await VadManager()
                 let vadController = StreamingVadController(vadManager: vadManager)
@@ -1795,7 +1813,7 @@ final class DictationCoordinator {
     }
 
     func cancelCurrentMeetingRecording() {
-        guard isMeetingRecording || meetingRecorder != nil || persistedRecordingMeetingSession != nil else { return }
+        guard isMeetingRecording || meetingRecorder != nil || activeSession?.kind == .meeting || persistedRecordingMeetingSession != nil else { return }
         guard let session = activeSession ?? persistedRecordingMeetingSession, session.kind == .meeting else { return }
 
         MuesliHaptics.dictationStop()
@@ -1929,7 +1947,7 @@ final class DictationCoordinator {
         try? store.saveTranscript(transcript)
         session.transcriptID = transcript.id
         session.engineIdentifier = engine.identifier
-        try? store.saveSession(session)
+        _ = try? saveActiveMeetingSession(session)
         refreshHistory()
     }
 
@@ -1982,7 +2000,11 @@ final class DictationCoordinator {
                 session.transcriptID = finalTranscript.transcript.id
                 session.engineIdentifier = engine.identifier
                 session.errorMessage = nil
-                try store.saveSession(session)
+                guard try saveActiveMeetingSession(session) else {
+                    meetingStatusText = "Ready"
+                    cleanupMeetingChunks()
+                    return
+                }
                 scheduleICloudSyncAfterLocalChange(reason: "meeting_completed")
                 cleanupMeetingChunks()
                 meetingStatusText = "Ready"
@@ -2009,7 +2031,7 @@ final class DictationCoordinator {
 
                 session.phase = .failed
                 session.errorMessage = error.localizedDescription
-                try? store.saveSession(session)
+                _ = try? saveActiveMeetingSession(session)
                 cleanupMeetingChunks()
                 meetingStatusText = error.localizedDescription
                 refreshHistory()
@@ -2218,6 +2240,29 @@ final class DictationCoordinator {
         meetingChunksDirectory = nil
         meetingChunkTasks.removeAll(keepingCapacity: false)
         meetingChunkTranscriptions.removeAll(keepingCapacity: false)
+    }
+
+    private func abortDiscardedMeetingStartup(_ session: RecordingSession) {
+        cleanupMeetingChunks(cancelTasks: true)
+        if let audioFileName = session.audioFileName {
+            try? store.deleteAudioFile(fileName: audioFileName)
+        }
+        try? store.deleteTranscript(for: session.id)
+        try? store.deleteRecordingSession(id: session.id)
+        activeSession = nil
+        meetingRecorder = nil
+        meetingVadController = nil
+        isMeetingRecording = false
+        isMeetingTranscribing = false
+        meetingStatusText = "Ready"
+        refreshHistory()
+    }
+
+    @discardableResult
+    private func saveActiveMeetingSession(_ session: RecordingSession) throws -> Bool {
+        guard shouldContinueMeetingFinalization(sessionID: session.id) else { return false }
+        try store.saveSession(session)
+        return true
     }
 
     private func shouldContinueMeetingFinalization(sessionID: UUID) -> Bool {

--- a/Muesli/DictationView.swift
+++ b/Muesli/DictationView.swift
@@ -14,6 +14,7 @@ struct DictationView: View {
     @State private var isSyncSetupPromptPresented = false
     @State private var shouldShowKeyboardSetupRow = false
     @State private var previewInputLevel = 0.0
+    @State private var dashboardStats = DictationDashboardStats.empty
 
     var body: some View {
         NavigationStack {
@@ -49,11 +50,19 @@ struct DictationView: View {
                 coordinator.refreshHistory()
                 coordinator.refreshAudioInputRoute()
                 refreshKeyboardSetupPromptVisibility()
+                updateDashboardStats()
+            }
+            .onChange(of: coordinator.dictationHistory.count) { _, _ in
+                updateDashboardStats()
+            }
+            .onChange(of: coordinator.recordingSessions.count) { _, _ in
+                updateDashboardStats()
             }
             .onChange(of: scenePhase) { _, phase in
                 guard phase == .active else { return }
                 coordinator.refreshAudioInputRoute()
                 refreshKeyboardSetupPromptVisibility()
+                updateDashboardStats()
             }
             .onChange(of: microphonePreference) { _, _ in
                 coordinator.refreshAudioInputRoute()
@@ -74,28 +83,30 @@ struct DictationView: View {
         }
     }
 
+    @ViewBuilder
     private var homeStatsRow: some View {
+        let stats = dashboardStats
         HStack(spacing: MuesliTheme.spacing8) {
             DictationHomeStatTile(
-                value: dashboardStats.streak,
+                value: stats.streak,
                 label: "streak",
                 systemImage: "flame.fill",
                 tint: Color(hex: 0xFF9F2D)
             )
             DictationHomeStatTile(
-                value: dashboardStats.words,
+                value: stats.words,
                 label: "words",
                 systemImage: "waveform",
                 tint: MuesliTheme.accent
             )
             DictationHomeStatTile(
-                value: dashboardStats.wpm,
+                value: stats.wpm,
                 label: "WPM",
                 systemImage: "speedometer",
                 tint: MuesliTheme.success
             )
             DictationHomeStatTile(
-                value: dashboardStats.meetings,
+                value: stats.meetings,
                 label: "meetings",
                 systemImage: "person.2",
                 tint: MuesliTheme.accent
@@ -103,7 +114,7 @@ struct DictationView: View {
         }
         .accessibilityElement(children: .combine)
         .accessibilityLabel(
-            "Stats: \(dashboardStats.streak) day streak, \(dashboardStats.words) words, \(dashboardStats.wpm) words per minute, \(dashboardStats.meetings) meetings"
+            "Stats: \(stats.streak) day streak, \(stats.words) words, \(stats.wpm) words per minute, \(stats.meetings) meetings"
         )
     }
 
@@ -122,34 +133,39 @@ struct DictationView: View {
         }
     }
 
-    private var dashboardStats: DictationDashboardStats {
+    private func updateDashboardStats() {
         #if DEBUG
         if shouldUseMockDictations {
-            return DictationDashboardStats(words: "61.0k", wpm: "152", meetings: "135", streak: "3")
+            dashboardStats = DictationDashboardStats(words: "61.0k", wpm: "152", meetings: "135", streak: "3")
+            return
         }
         #endif
 
-        return DictationDashboardStats(
-            words: formattedCompactCount(totalDictationWords),
-            wpm: formattedAverageWPM,
-            meetings: formattedCompactCount(totalMeetingCount),
-            streak: "\(currentActivityStreak)"
+        let history = displayHistory
+        let sessions = coordinator.recordingSessions
+        dashboardStats = DictationDashboardStats(
+            words: formattedCompactCount(totalDictationWords(in: history)),
+            wpm: formattedAverageWPM(history: history, sessions: sessions),
+            meetings: formattedCompactCount(totalMeetingCount(in: sessions)),
+            streak: "\(currentActivityStreak(history: history, sessions: sessions))"
         )
     }
 
-    private var totalDictationWords: Int {
-        displayHistory.reduce(0) { total, result in
+    private func totalDictationWords(in history: [DictationResult]) -> Int {
+        history.reduce(0) { total, result in
             total + result.text.split { $0.isWhitespace || $0.isNewline }.count
         }
     }
 
-    private var totalMeetingCount: Int {
-        coordinator.recordingSessions.filter { $0.kind == .meeting }.count
+    private func totalMeetingCount(in sessions: [RecordingSession]) -> Int {
+        sessions.filter { $0.kind == .meeting }.count
     }
 
-    private var formattedAverageWPM: String {
-        let completedDictationSessions = displayHistory.compactMap { result -> (words: Int, duration: TimeInterval)? in
-            guard let session = coordinator.recordingSession(for: result),
+    private func formattedAverageWPM(history: [DictationResult], sessions: [RecordingSession]) -> String {
+        let sessionsByID = Dictionary(uniqueKeysWithValues: sessions.map { ($0.id, $0) })
+        let completedDictationSessions = history.compactMap { result -> (words: Int, duration: TimeInterval)? in
+            guard let sessionID = result.sessionID,
+                  let session = sessionsByID[sessionID],
                   let duration = session.duration,
                   duration >= 10 else {
                 return nil
@@ -168,11 +184,11 @@ struct DictationView: View {
         return "\(Int(wpm.rounded()))"
     }
 
-    private var currentActivityStreak: Int {
+    private func currentActivityStreak(history: [DictationResult], sessions: [RecordingSession]) -> Int {
         let calendar = Calendar.current
         let activeDays = Set(
-            displayHistory.map { calendar.startOfDay(for: $0.createdAt) }
-                + coordinator.recordingSessions.map { calendar.startOfDay(for: $0.createdAt) }
+            history.map { calendar.startOfDay(for: $0.createdAt) }
+                + sessions.map { calendar.startOfDay(for: $0.createdAt) }
         )
 
         guard !activeDays.isEmpty else { return 0 }
@@ -676,6 +692,8 @@ struct DictationView: View {
 }
 
 private struct DictationDashboardStats {
+    static let empty = DictationDashboardStats(words: "0", wpm: "0", meetings: "0", streak: "0")
+
     let words: String
     let wpm: String
     let meetings: String

--- a/Muesli/DictationView.swift
+++ b/Muesli/DictationView.swift
@@ -20,6 +20,7 @@ struct DictationView: View {
             VStack(alignment: .leading, spacing: MuesliTheme.spacing16) {
                 VStack(alignment: .leading, spacing: MuesliTheme.spacing16) {
                     header
+                    homeStatsRow
                     recorderPanel
                     historyHeader
                 }
@@ -73,13 +74,43 @@ struct DictationView: View {
         }
     }
 
+    private var homeStatsRow: some View {
+        HStack(spacing: MuesliTheme.spacing8) {
+            DictationHomeStatTile(
+                value: dashboardStats.streak,
+                label: "streak",
+                systemImage: "flame.fill",
+                tint: Color(hex: 0xFF9F2D)
+            )
+            DictationHomeStatTile(
+                value: dashboardStats.words,
+                label: "words",
+                systemImage: "waveform",
+                tint: MuesliTheme.accent
+            )
+            DictationHomeStatTile(
+                value: dashboardStats.wpm,
+                label: "WPM",
+                systemImage: "speedometer",
+                tint: MuesliTheme.success
+            )
+            DictationHomeStatTile(
+                value: dashboardStats.meetings,
+                label: "meetings",
+                systemImage: "person.2",
+                tint: MuesliTheme.accent
+            )
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(
+            "Stats: \(dashboardStats.streak) day streak, \(dashboardStats.words) words, \(dashboardStats.wpm) words per minute, \(dashboardStats.meetings) meetings"
+        )
+    }
+
     private var header: some View {
         VStack(alignment: .leading, spacing: MuesliTheme.spacing4) {
             HStack(spacing: MuesliTheme.spacing12) {
-                Image("MuesliAppIcon")
-                    .resizable()
-                    .scaledToFit()
-                    .frame(width: 42, height: 42)
+                MuesliHeaderWaveformMark()
                 Text("muesli")
                     .font(MuesliTheme.title2())
                     .foregroundStyle(MuesliTheme.textPrimary)
@@ -89,6 +120,90 @@ struct DictationView: View {
                 .font(MuesliTheme.callout())
                 .foregroundStyle(MuesliTheme.textSecondary)
         }
+    }
+
+    private var dashboardStats: DictationDashboardStats {
+        #if DEBUG
+        if shouldUseMockDictations {
+            return DictationDashboardStats(words: "61.0k", wpm: "152", meetings: "135", streak: "3")
+        }
+        #endif
+
+        return DictationDashboardStats(
+            words: formattedCompactCount(totalDictationWords),
+            wpm: formattedAverageWPM,
+            meetings: formattedCompactCount(totalMeetingCount),
+            streak: "\(currentActivityStreak)"
+        )
+    }
+
+    private var totalDictationWords: Int {
+        displayHistory.reduce(0) { total, result in
+            total + result.text.split { $0.isWhitespace || $0.isNewline }.count
+        }
+    }
+
+    private var totalMeetingCount: Int {
+        coordinator.recordingSessions.filter { $0.kind == .meeting }.count
+    }
+
+    private var formattedAverageWPM: String {
+        let completedDictationSessions = displayHistory.compactMap { result -> (words: Int, duration: TimeInterval)? in
+            guard let session = coordinator.recordingSession(for: result),
+                  let duration = session.duration,
+                  duration >= 10 else {
+                return nil
+            }
+
+            let words = result.text.split { $0.isWhitespace || $0.isNewline }.count
+            guard words > 0 else { return nil }
+            return (words, duration)
+        }
+
+        let totalWords = completedDictationSessions.reduce(0) { $0 + $1.words }
+        let totalSeconds = completedDictationSessions.reduce(0) { $0 + $1.duration }
+        guard totalWords > 0, totalSeconds > 0 else { return "0" }
+
+        let wpm = Double(totalWords) / max(totalSeconds / 60, 1 / 60)
+        return "\(Int(wpm.rounded()))"
+    }
+
+    private var currentActivityStreak: Int {
+        let calendar = Calendar.current
+        let activeDays = Set(
+            displayHistory.map { calendar.startOfDay(for: $0.createdAt) }
+                + coordinator.recordingSessions.map { calendar.startOfDay(for: $0.createdAt) }
+        )
+
+        guard !activeDays.isEmpty else { return 0 }
+
+        var streak = 0
+        var day = calendar.startOfDay(for: .now)
+        if !activeDays.contains(day),
+           let yesterday = calendar.date(byAdding: .day, value: -1, to: day) {
+            day = yesterday
+        }
+
+        while activeDays.contains(day) {
+            streak += 1
+            guard let previousDay = calendar.date(byAdding: .day, value: -1, to: day) else { break }
+            day = previousDay
+        }
+
+        return streak
+    }
+
+    private func formattedCompactCount(_ value: Int) -> String {
+        if value >= 1_000_000 {
+            return String(format: "%.1fM", Double(value) / 1_000_000)
+        }
+        if value >= 10_000 {
+            return String(format: "%.1fk", Double(value) / 1_000)
+        }
+        if value >= 1_000 {
+            return "\(value.formatted())"
+        }
+        return "\(value)"
     }
 
     private var recorderPanel: some View {
@@ -560,6 +675,91 @@ struct DictationView: View {
     #endif
 }
 
+private struct DictationDashboardStats {
+    let words: String
+    let wpm: String
+    let meetings: String
+    let streak: String
+}
+
+private struct MuesliHeaderWaveformMark: View {
+    private let bars: [CGFloat] = [0.34, 0.58, 0.82, 1.0, 0.74, 0.5, 0.68, 0.96, 0.78, 0.54]
+
+    var body: some View {
+        HStack(spacing: 2.2) {
+            ForEach(bars.indices, id: \.self) { index in
+                Capsule()
+                    .fill(MuesliTheme.accent)
+                    .frame(width: 3.2, height: 32 * bars[index])
+            }
+        }
+        .frame(width: 42, height: 42)
+        .shadow(color: MuesliTheme.accent.opacity(0.28), radius: 8, x: 0, y: 3)
+        .accessibilityHidden(true)
+    }
+}
+
+private struct DictationHomeStatTile: View {
+    let value: String
+    let label: String
+    let systemImage: String
+    let tint: Color
+
+    var body: some View {
+        VStack(spacing: MuesliTheme.spacing8) {
+            Image(systemName: systemImage)
+                .font(.system(size: 18, weight: .semibold))
+                .symbolRenderingMode(.hierarchical)
+                .foregroundStyle(tint)
+                .frame(height: 20)
+
+            VStack(spacing: 1) {
+                Text(value)
+                    .font(.system(size: 20, weight: .semibold, design: .rounded))
+                    .monospacedDigit()
+                    .minimumScaleFactor(0.76)
+                    .lineLimit(1)
+                    .foregroundStyle(MuesliTheme.textPrimary)
+
+                Text(label)
+                    .font(MuesliTheme.caption())
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.78)
+                    .foregroundStyle(MuesliTheme.textSecondary)
+            }
+        }
+        .frame(maxWidth: .infinity)
+        .frame(height: 76)
+        .padding(.horizontal, MuesliTheme.spacing8)
+        .background {
+            RoundedRectangle(cornerRadius: MuesliTheme.cornerLarge, style: .continuous)
+                .fill(
+                    LinearGradient(
+                        colors: [
+                            MuesliTheme.backgroundRaised.opacity(0.88),
+                            MuesliTheme.backgroundDeep.opacity(0.76)
+                        ],
+                        startPoint: .topLeading,
+                        endPoint: .bottomTrailing
+                    )
+                )
+        }
+        .overlay(alignment: .top) {
+            RoundedRectangle(cornerRadius: MuesliTheme.cornerLarge, style: .continuous)
+                .strokeBorder(MuesliTheme.glassHighlight.opacity(0.72), lineWidth: 0.7)
+                .blendMode(.screen)
+        }
+        .overlay {
+            RoundedRectangle(cornerRadius: MuesliTheme.cornerLarge, style: .continuous)
+                .strokeBorder(MuesliTheme.accent.opacity(0.34), lineWidth: 1)
+        }
+        .shadow(color: MuesliTheme.accent.opacity(0.10), radius: 12, x: 0, y: 7)
+        .shadow(color: .black.opacity(0.18), radius: 8, x: 0, y: 4)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("\(value) \(label)")
+    }
+}
+
 private struct VoiceNoteRecordButtonLabel: View {
     let title: String
     let systemImage: String
@@ -571,13 +771,48 @@ private struct VoiceNoteRecordButtonLabel: View {
         VStack(spacing: MuesliTheme.spacing8) {
             ZStack {
                 Circle()
-                    .fill(circleFill)
-                    .frame(width: 74, height: 74)
+                    .fill(color.opacity(isStopState ? 0.18 : 0.16))
+                    .frame(width: 96, height: 96)
+                    .blur(radius: 0.5)
+
+                Circle()
+                    .fill(outerRingFill)
+                    .frame(width: 88, height: 88)
                     .overlay(
                         Circle()
-                            .strokeBorder(circleBorder, lineWidth: 1)
+                            .strokeBorder(outerRingBorder, lineWidth: 1.2)
                     )
-                    .shadow(color: circleShadow, radius: isStopState ? 10 : 0, x: 0, y: 5)
+                    .shadow(color: outerShadow, radius: 14, x: 0, y: 9)
+                    .shadow(color: color.opacity(isStopState ? 0.10 : 0.22), radius: 18, x: 0, y: 7)
+
+                Circle()
+                    .fill(
+                        LinearGradient(
+                            colors: circleGradient,
+                            startPoint: .topLeading,
+                            endPoint: .bottomTrailing
+                        )
+                    )
+                    .frame(width: 74, height: 74)
+                    .overlay(alignment: .topLeading) {
+                        Circle()
+                            .strokeBorder(.white.opacity(isDisabled ? 0.08 : 0.42), lineWidth: 2)
+                            .padding(4)
+                            .blur(radius: 0.2)
+                            .mask(
+                                LinearGradient(
+                                    colors: [.white, .clear],
+                                    startPoint: .topLeading,
+                                    endPoint: .center
+                                )
+                            )
+                    }
+                    .overlay {
+                        Circle()
+                            .strokeBorder(circleBorder, lineWidth: 1)
+                    }
+                    .shadow(color: .white.opacity(isDisabled ? 0 : 0.10), radius: 2, x: -1, y: -1)
+                    .shadow(color: .black.opacity(0.20), radius: 7, x: 0, y: 5)
 
                 Image(systemName: systemImage)
                     .font(.system(size: 26, weight: .semibold))
@@ -593,14 +828,43 @@ private struct VoiceNoteRecordButtonLabel: View {
         .contentShape(Rectangle())
     }
 
-    private var circleFill: Color {
+    private var outerRingFill: Color {
         if isDisabled {
-            MuesliTheme.surfacePrimary
-        } else if isStopState {
-            MuesliTheme.destructive.opacity(0.32)
-        } else {
-            color
+            return MuesliTheme.surfacePrimary.opacity(0.72)
         }
+        if isStopState {
+            return MuesliTheme.destructive.opacity(0.20)
+        }
+        return color.opacity(0.18)
+    }
+
+    private var outerRingBorder: Color {
+        if isDisabled {
+            return MuesliTheme.surfaceBorder
+        }
+        if isStopState {
+            return MuesliTheme.destructive.opacity(0.42)
+        }
+        return color.opacity(0.54)
+    }
+
+    private var circleGradient: [Color] {
+        if isDisabled {
+            return [
+                MuesliTheme.surfacePrimary.opacity(0.72),
+                MuesliTheme.surfacePrimary.opacity(0.52)
+            ]
+        }
+        if isStopState {
+            return [
+                MuesliTheme.destructive.opacity(0.88),
+                MuesliTheme.destructive.opacity(0.52)
+            ]
+        }
+        return [
+            color.opacity(0.96),
+            Color(hex: 0x1B56D8).opacity(0.95)
+        ]
     }
 
     private var circleBorder: Color {
@@ -613,8 +877,14 @@ private struct VoiceNoteRecordButtonLabel: View {
         }
     }
 
-    private var circleShadow: Color {
-        isStopState && !isDisabled ? MuesliTheme.destructive.opacity(0.16) : .clear
+    private var outerShadow: Color {
+        if isDisabled {
+            return .clear
+        }
+        if isStopState {
+            return MuesliTheme.destructive.opacity(0.16)
+        }
+        return MuesliTheme.accent.opacity(0.18)
     }
 
     private var iconColor: Color {

--- a/Muesli/DictationView.swift
+++ b/Muesli/DictationView.swift
@@ -124,7 +124,13 @@ struct DictationView: View {
     private var header: some View {
         VStack(alignment: .leading, spacing: MuesliTheme.spacing4) {
             HStack(spacing: MuesliTheme.spacing12) {
-                MuesliHeaderWaveformMark()
+                Image("MuesliAppIcon")
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: 42, height: 42)
+                    .clipShape(RoundedRectangle(cornerRadius: 9, style: .continuous))
+                    .shadow(color: MuesliTheme.accent.opacity(0.24), radius: 8, x: 0, y: 3)
+                    .accessibilityHidden(true)
                 Text("muesli")
                     .font(MuesliTheme.title2())
                     .foregroundStyle(MuesliTheme.textPrimary)
@@ -714,23 +720,6 @@ private struct DictationDashboardStats {
     let wpm: String
     let meetings: String
     let streak: String
-}
-
-private struct MuesliHeaderWaveformMark: View {
-    private let bars: [CGFloat] = [0.34, 0.58, 0.82, 1.0, 0.74, 0.5, 0.68, 0.96, 0.78, 0.54]
-
-    var body: some View {
-        HStack(spacing: 2.2) {
-            ForEach(bars.indices, id: \.self) { index in
-                Capsule()
-                    .fill(MuesliTheme.accent)
-                    .frame(width: 3.2, height: 32 * bars[index])
-            }
-        }
-        .frame(width: 42, height: 42)
-        .shadow(color: MuesliTheme.accent.opacity(0.28), radius: 8, x: 0, y: 3)
-        .accessibilityHidden(true)
-    }
 }
 
 private struct DictationHomeStatTile: View {

--- a/Muesli/DictationView.swift
+++ b/Muesli/DictationView.swift
@@ -18,17 +18,20 @@ struct DictationView: View {
 
     var body: some View {
         NavigationStack {
-            VStack(alignment: .leading, spacing: MuesliTheme.spacing16) {
-                VStack(alignment: .leading, spacing: MuesliTheme.spacing16) {
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: MuesliTheme.spacing16) {
                     header
                     homeStatsRow
                     recorderPanel
                     historyHeader
+                    historyRows
                 }
                 .padding(.horizontal, MuesliTheme.spacing20)
                 .padding(.top, MuesliTheme.spacing24)
-
-                historyList
+                .padding(.bottom, 112)
+            }
+            .refreshable {
+                triggerHomeSync()
             }
             .background(MuesliTheme.backgroundBase)
             .toolbar(.hidden, for: .navigationBar)
@@ -442,9 +445,8 @@ struct DictationView: View {
     }
 
     @ViewBuilder
-    private var historyList: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: MuesliTheme.spacing12) {
+    private var historyRows: some View {
+        Group {
             if filteredHistory.isEmpty {
                 emptyHistory
             } else {
@@ -473,12 +475,6 @@ struct DictationView: View {
                     }
                 }
             }
-            }
-            .padding(.horizontal, MuesliTheme.spacing20)
-            .padding(.bottom, 112)
-        }
-        .refreshable {
-            triggerHomeSync()
         }
     }
 

--- a/Muesli/DictationView.swift
+++ b/Muesli/DictationView.swift
@@ -171,7 +171,7 @@ struct DictationView: View {
     }
 
     private func formattedAverageWPM(history: [DictationResult], sessions: [RecordingSession]) -> String {
-        let sessionsByID = Dictionary(uniqueKeysWithValues: sessions.map { ($0.id, $0) })
+        let sessionsByID = Dictionary(sessions.map { ($0.id, $0) }, uniquingKeysWith: { _, latest in latest })
         let completedDictationSessions = history.compactMap { result -> (words: Int, duration: TimeInterval)? in
             guard let sessionID = result.sessionID,
                   let session = sessionsByID[sessionID],

--- a/Muesli/DictationView.swift
+++ b/Muesli/DictationView.swift
@@ -189,9 +189,10 @@ struct DictationView: View {
 
     private func currentActivityStreak(history: [DictationResult], sessions: [RecordingSession]) -> Int {
         let calendar = Calendar.current
+        let countedSessions = sessions.filter { $0.phase != .cancelled && $0.phase != .failed }
         let activeDays = Set(
             history.map { calendar.startOfDay(for: $0.createdAt) }
-                + sessions.map { calendar.startOfDay(for: $0.createdAt) }
+                + countedSessions.map { calendar.startOfDay(for: $0.createdAt) }
         )
 
         guard !activeDays.isEmpty else { return 0 }
@@ -304,24 +305,43 @@ struct DictationView: View {
                     .muesliGlassSurface(cornerRadius: MuesliTheme.cornerMedium, tint: MuesliTheme.accent)
                 }
 
-                Button {
-                    coordinator.toggleRecording()
-                } label: {
-                    VoiceNoteRecordButtonLabel(
-                        title: dictationButtonTitle,
-                        systemImage: dictationButtonIcon,
-                        color: statusColor,
-                        isStopState: coordinator.isRecording,
-                        isDisabled: isDictationButtonDisabled
-                    )
+                VStack(spacing: MuesliTheme.spacing8) {
+                    Button {
+                        coordinator.toggleRecording()
+                    } label: {
+                        VoiceNoteRecordButtonLabel(
+                            title: dictationButtonTitle,
+                            systemImage: dictationButtonIcon,
+                            color: statusColor,
+                            isStopState: coordinator.isRecording,
+                            isDisabled: isDictationButtonDisabled
+                        )
+                    }
+                    .buttonStyle(.plain)
+                    .disabled(isDictationButtonDisabled)
+                    .sensoryFeedback(.impact, trigger: coordinator.isRecording)
+                    .accessibilityElement(children: .ignore)
+                    .accessibilityLabel(dictationButtonTitle)
+                    .accessibilityAddTraits(.isButton)
+                    .accessibilityIdentifier("dictation.primaryButton")
+
+                    if coordinator.isRecording {
+                        Button(role: .destructive) {
+                            coordinator.cancelActiveRecording()
+                        } label: {
+                            Label("Cancel Recording", systemImage: "xmark")
+                                .font(MuesliTheme.captionMedium())
+                                .foregroundStyle(MuesliTheme.destructive)
+                                .frame(maxWidth: .infinity)
+                                .frame(minHeight: 44)
+                                .background(MuesliTheme.destructiveSubtle)
+                                .clipShape(Capsule())
+                                .contentShape(Capsule())
+                        }
+                        .buttonStyle(.plain)
+                        .accessibilityIdentifier("dictation.cancelButton")
+                    }
                 }
-                .buttonStyle(.plain)
-                .disabled(isDictationButtonDisabled)
-                .sensoryFeedback(.impact, trigger: coordinator.isRecording)
-                .accessibilityElement(children: .ignore)
-                .accessibilityLabel(dictationButtonTitle)
-                .accessibilityAddTraits(.isButton)
-                .accessibilityIdentifier("dictation.primaryButton")
                 .padding(.top, isWaveformActive || shouldShowRealtimeTranscript ? 0 : MuesliTheme.spacing4)
 
                 if shouldShowKeyboardSetupRow && !shouldHideKeyboardSetupRowForMockPreview {

--- a/Muesli/MeetingsView.swift
+++ b/Muesli/MeetingsView.swift
@@ -48,6 +48,9 @@ struct MeetingsView: View {
                         },
                         onDelete: {
                             coordinator.deleteMeeting(session)
+                        },
+                        onRename: { title in
+                            coordinator.updateMeetingTitle(sessionID: session.id, title: title)
                         }
                     )
                 } else {
@@ -143,30 +146,49 @@ struct MeetingsView: View {
                     .muesliGlassSurface(cornerRadius: MuesliTheme.cornerMedium, tint: statusColor)
                 }
 
-                Button {
-                    if coordinator.hasMeetingRecordingInProgress {
-                        coordinator.stopCurrentMeetingRecording()
-                    } else {
-                        coordinator.startMeetingRecording(title: meetingTitle)
+                VStack(spacing: MuesliTheme.spacing8) {
+                    Button {
+                        if coordinator.hasMeetingRecordingInProgress {
+                            coordinator.stopCurrentMeetingRecording()
+                        } else {
+                            coordinator.startMeetingRecording(title: meetingTitle)
+                        }
+                    } label: {
+                        Label(
+                            coordinator.hasMeetingRecordingInProgress ? "Stop Meeting" : "Start Meeting",
+                            systemImage: coordinator.hasMeetingRecordingInProgress ? "stop.fill" : "mic.fill"
+                        )
+                        .font(MuesliTheme.headline())
+                        .frame(maxWidth: .infinity)
+                        .frame(height: 48)
+                        .foregroundStyle(meetingPrimaryButtonTextColor)
+                        .background(meetingPrimaryButtonBackground)
+                        .overlay(meetingPrimaryButtonBorder)
+                        .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+                        .contentShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
                     }
-                } label: {
-                    Label(
-                        coordinator.hasMeetingRecordingInProgress ? "Stop Meeting" : "Start Meeting",
-                        systemImage: coordinator.hasMeetingRecordingInProgress ? "stop.fill" : "mic.fill"
-                    )
-                    .font(MuesliTheme.headline())
-                    .frame(maxWidth: .infinity)
-                    .frame(height: 48)
-                    .foregroundStyle(meetingPrimaryButtonTextColor)
-                    .background(meetingPrimaryButtonBackground)
-                    .overlay(meetingPrimaryButtonBorder)
-                    .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
-                    .contentShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+                    .buttonStyle(.plain)
+                    .disabled(coordinator.isMeetingTranscribing)
+                    .sensoryFeedback(.impact, trigger: coordinator.hasMeetingRecordingInProgress)
+                    .accessibilityIdentifier("meetings.primaryButton")
+
+                    if coordinator.hasMeetingRecordingInProgress {
+                        Button(role: .destructive) {
+                            coordinator.cancelCurrentMeetingRecording()
+                        } label: {
+                            Label("Discard Meeting", systemImage: "xmark")
+                                .font(MuesliTheme.captionMedium())
+                                .foregroundStyle(MuesliTheme.destructive)
+                                .frame(maxWidth: .infinity)
+                                .frame(minHeight: 44)
+                                .background(MuesliTheme.destructiveSubtle)
+                                .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+                                .contentShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+                        }
+                        .buttonStyle(.plain)
+                        .accessibilityIdentifier("meetings.discardButton")
+                    }
                 }
-                .buttonStyle(.plain)
-                .disabled(coordinator.isMeetingTranscribing)
-                .sensoryFeedback(.impact, trigger: coordinator.hasMeetingRecordingInProgress)
-                .accessibilityIdentifier("meetings.primaryButton")
             }
             .padding(MuesliTheme.spacing16)
         }
@@ -424,10 +446,14 @@ private struct MeetingSessionDetailView: View {
     let onTranscribe: () -> Void
     let onCopy: (String, MeetingContentTab) -> Void
     let onDelete: () -> Void
+    let onRename: (String) -> Void
     @Environment(\.dismiss) private var dismiss
     @State private var selectedContent: MeetingContentTab = .notes
     @State private var sharePayload: MeetingSharePayload?
     @State private var isConfirmingDelete = false
+    @State private var editedTitle: String?
+    @State private var titleDraft = ""
+    @State private var isEditingTitle = false
 
     var body: some View {
         ScrollView {
@@ -446,6 +472,17 @@ private struct MeetingSessionDetailView: View {
         .navigationBarTitleDisplayMode(.inline)
         .sheet(item: $sharePayload) { payload in
             MeetingShareSheet(items: payload.items)
+        }
+        .alert("Edit Meeting Title", isPresented: $isEditingTitle) {
+            TextField("Meeting title", text: $titleDraft)
+            Button("Save") {
+                let title = resolvedTitle(titleDraft)
+                editedTitle = title
+                onRename(title)
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("This updates the saved meeting title without changing the transcript or notes.")
         }
         .confirmationDialog(
             "Delete this meeting?",
@@ -472,10 +509,27 @@ private struct MeetingSessionDetailView: View {
                         .frame(width: 28)
 
                     VStack(alignment: .leading, spacing: MuesliTheme.spacing4) {
-                        Text(session.title ?? session.kind.title)
-                            .font(MuesliTheme.title3())
-                            .foregroundStyle(MuesliTheme.textPrimary)
-                            .fixedSize(horizontal: false, vertical: true)
+                        HStack(alignment: .firstTextBaseline, spacing: MuesliTheme.spacing8) {
+                            Text(displayTitle)
+                                .font(MuesliTheme.title3())
+                                .foregroundStyle(MuesliTheme.textPrimary)
+                                .fixedSize(horizontal: false, vertical: true)
+
+                            Button {
+                                titleDraft = displayTitle
+                                isEditingTitle = true
+                            } label: {
+                                Image(systemName: "pencil")
+                                    .font(.system(size: 14, weight: .semibold))
+                                    .foregroundStyle(MuesliTheme.accent)
+                                    .frame(width: 32, height: 32)
+                                    .background(MuesliTheme.accentSubtle)
+                                    .clipShape(Circle())
+                                    .contentShape(Circle())
+                            }
+                            .buttonStyle(.plain)
+                            .accessibilityLabel("Edit meeting title")
+                        }
                         Text(session.createdAt, formatter: MeetingSessionRow.dateFormatter)
                             .font(MuesliTheme.captionMedium())
                             .foregroundStyle(MuesliTheme.textSecondary)
@@ -676,9 +730,23 @@ private struct MeetingSessionDetailView: View {
 
     private func share(_ kind: MeetingShareKind, transcript: Transcript) {
         sharePayload = MeetingSharePayload(
-            items: [MeetingExportFormatter.text(for: kind, session: session, transcript: transcript)]
+            items: [MeetingExportFormatter.text(
+                for: kind,
+                session: session,
+                transcript: transcript,
+                titleOverride: displayTitle
+            )]
         )
         AppTelemetry.signal("meeting_\(kind.telemetryName)_shared")
+    }
+
+    private var displayTitle: String {
+        resolvedTitle(editedTitle ?? session.title ?? session.kind.title)
+    }
+
+    private func resolvedTitle(_ title: String) -> String {
+        let trimmedTitle = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmedTitle.isEmpty ? session.kind.title : trimmedTitle
     }
 }
 
@@ -793,20 +861,25 @@ private struct MeetingShareSheet: UIViewControllerRepresentable {
 }
 
 private enum MeetingExportFormatter {
-    static func text(for kind: MeetingShareKind, session: RecordingSession, transcript: Transcript) -> String {
+    static func text(
+        for kind: MeetingShareKind,
+        session: RecordingSession,
+        transcript: Transcript,
+        titleOverride: String? = nil
+    ) -> String {
         switch kind {
         case .notes:
-            notes(session: session, transcript: transcript)
+            notes(session: session, transcript: transcript, titleOverride: titleOverride)
         case .transcript:
-            transcriptText(session: session, transcript: transcript)
+            transcriptText(session: session, transcript: transcript, titleOverride: titleOverride)
         case .full:
-            fullMeeting(session: session, transcript: transcript)
+            fullMeeting(session: session, transcript: transcript, titleOverride: titleOverride)
         }
     }
 
-    private static func notes(session: RecordingSession, transcript: Transcript) -> String {
+    private static func notes(session: RecordingSession, transcript: Transcript, titleOverride: String?) -> String {
         """
-        # \(title(for: session))
+        # \(titleOverride ?? title(for: session))
 
         \(dateString(for: session))
 
@@ -814,12 +887,12 @@ private enum MeetingExportFormatter {
         """
     }
 
-    private static func transcriptText(session: RecordingSession, transcript: Transcript) -> String {
+    private static func transcriptText(session: RecordingSession, transcript: Transcript, titleOverride: String?) -> String {
         let body = transcript.speakerTranscript?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
             ? transcript.speakerTranscript!
             : transcript.text
         return """
-        # \(title(for: session)) Transcript
+        # \(titleOverride ?? title(for: session)) Transcript
 
         \(dateString(for: session))
 
@@ -827,11 +900,11 @@ private enum MeetingExportFormatter {
         """
     }
 
-    private static func fullMeeting(session: RecordingSession, transcript: Transcript) -> String {
+    private static func fullMeeting(session: RecordingSession, transcript: Transcript, titleOverride: String?) -> String {
         let notes = transcript.summaryText?.trimmingCharacters(in: .whitespacesAndNewlines)
         let speakers = transcript.speakerTranscript?.trimmingCharacters(in: .whitespacesAndNewlines)
         return """
-        # \(title(for: session))
+        # \(titleOverride ?? title(for: session))
 
         \(dateString(for: session))
 

--- a/Muesli/RootView.swift
+++ b/Muesli/RootView.swift
@@ -71,6 +71,8 @@ struct RootView: View {
                 VStack(spacing: 0) {
                     sectionContent
                         .frame(maxWidth: .infinity, maxHeight: .infinity)
+                        .contentShape(Rectangle())
+                        .simultaneousGesture(sectionSwipeGesture)
 
                     MuesliTabSwitcher(
                         selectedSection: $selectedSection,
@@ -162,6 +164,32 @@ struct RootView: View {
             pins.append(section)
         }
         pinnedSectionsStorage = AppSection.storageString(for: pins)
+    }
+
+    private var sectionSwipeGesture: some Gesture {
+        DragGesture(minimumDistance: 32, coordinateSpace: .local)
+            .onEnded { value in
+                guard !isDrawerOpen else { return }
+
+                let translation = value.translation
+                let horizontalDistance = abs(translation.width)
+                let verticalDistance = abs(translation.height)
+                guard horizontalDistance >= 76, horizontalDistance > verticalDistance * 1.35 else { return }
+
+                navigateSections(by: translation.width < 0 ? 1 : -1)
+            }
+    }
+
+    private func navigateSections(by offset: Int) {
+        let sections = AppSection.defaultPinnedSections
+        guard let currentIndex = sections.firstIndex(of: selectedSection) else { return }
+
+        let nextIndex = currentIndex + offset
+        guard sections.indices.contains(nextIndex) else { return }
+
+        withAnimation(.snappy(duration: 0.2)) {
+            selectedSection = sections[nextIndex]
+        }
     }
 }
 

--- a/Muesli/RootView.swift
+++ b/Muesli/RootView.swift
@@ -31,6 +31,12 @@ struct RootView: View {
         .onChange(of: coordinator.settingsNavigationRequestID) { _, requestID in
             navigateToSettingsIfNeeded(requestID)
         }
+        .onChange(of: selectedSection) { _, section in
+            ensureSectionPinned(section)
+        }
+        .onChange(of: pinnedSectionsStorage) { _, _ in
+            clampSelectedSectionToPinnedSections()
+        }
     }
 
     private var currentAccent: Color {
@@ -115,7 +121,12 @@ struct RootView: View {
 
     @ViewBuilder
     private var sectionContent: some View {
-        switch selectedSection {
+        sectionView(for: selectedSection)
+    }
+
+    @ViewBuilder
+    private func sectionView(for section: AppSection) -> some View {
+        switch section {
         case .dictations:
             DictationView(coordinator: coordinator)
         case .meetings:
@@ -132,22 +143,12 @@ struct RootView: View {
 
     private var pagedSectionContent: some View {
         TabView(selection: $selectedSection) {
-            DictationView(coordinator: coordinator)
-                .tag(AppSection.dictations)
-
-            MeetingsView(coordinator: coordinator)
-                .tag(AppSection.meetings)
-
-            SettingsView(
-                coordinator: coordinator,
-                openSyncPrivacyRequest: coordinator.syncSetupRequestID
-            ) { section in
-                selectedSection = section
+            ForEach(pinnedSections, id: \.self) { section in
+                sectionView(for: section)
+                    .tag(section)
             }
-            .tag(AppSection.settings)
         }
         .tabViewStyle(.page(indexDisplayMode: .never))
-        .animation(.snappy(duration: 0.22), value: selectedSection)
     }
 
     private func openDrawer() {
@@ -165,6 +166,7 @@ struct RootView: View {
     private func navigateToSettingsIfNeeded(_ requestID: UUID?) {
         guard requestID != nil else { return }
         if coordinator.hasCompletedOnboarding {
+            ensureSectionPinned(.settings)
             selectedSection = .settings
         }
         isDrawerOpen = false
@@ -181,6 +183,26 @@ struct RootView: View {
             }
             pins.append(section)
         }
+        pinnedSectionsStorage = AppSection.storageString(for: pins)
+        if !pins.contains(selectedSection), let nextSection = pins.first {
+            selectedSection = nextSection
+        }
+    }
+
+    private func clampSelectedSectionToPinnedSections() {
+        let pins = pinnedSections
+        if !pins.contains(selectedSection), let nextSection = pins.first {
+            selectedSection = nextSection
+        }
+    }
+
+    private func ensureSectionPinned(_ section: AppSection) {
+        var pins = pinnedSections
+        guard !pins.contains(section) else { return }
+        if pins.count >= AppSection.maxPinnedSections {
+            pins.removeFirst()
+        }
+        pins.append(section)
         pinnedSectionsStorage = AppSection.storageString(for: pins)
     }
 

--- a/Muesli/RootView.swift
+++ b/Muesli/RootView.swift
@@ -69,10 +69,8 @@ struct RootView: View {
                 .background(MuesliTheme.backgroundBase)
             } else {
                 VStack(spacing: 0) {
-                    sectionContent
+                    pagedSectionContent
                         .frame(maxWidth: .infinity, maxHeight: .infinity)
-                        .contentShape(Rectangle())
-                        .simultaneousGesture(sectionSwipeGesture)
 
                     MuesliTabSwitcher(
                         selectedSection: $selectedSection,
@@ -132,6 +130,26 @@ struct RootView: View {
         }
     }
 
+    private var pagedSectionContent: some View {
+        TabView(selection: $selectedSection) {
+            DictationView(coordinator: coordinator)
+                .tag(AppSection.dictations)
+
+            MeetingsView(coordinator: coordinator)
+                .tag(AppSection.meetings)
+
+            SettingsView(
+                coordinator: coordinator,
+                openSyncPrivacyRequest: coordinator.syncSetupRequestID
+            ) { section in
+                selectedSection = section
+            }
+            .tag(AppSection.settings)
+        }
+        .tabViewStyle(.page(indexDisplayMode: .never))
+        .animation(.snappy(duration: 0.22), value: selectedSection)
+    }
+
     private func openDrawer() {
         withAnimation(.snappy(duration: 0.24)) {
             isDrawerOpen = true
@@ -166,31 +184,6 @@ struct RootView: View {
         pinnedSectionsStorage = AppSection.storageString(for: pins)
     }
 
-    private var sectionSwipeGesture: some Gesture {
-        DragGesture(minimumDistance: 32, coordinateSpace: .local)
-            .onEnded { value in
-                guard !isDrawerOpen else { return }
-
-                let translation = value.translation
-                let horizontalDistance = abs(translation.width)
-                let verticalDistance = abs(translation.height)
-                guard horizontalDistance >= 76, horizontalDistance > verticalDistance * 1.35 else { return }
-
-                navigateSections(by: translation.width < 0 ? 1 : -1)
-            }
-    }
-
-    private func navigateSections(by offset: Int) {
-        let sections = AppSection.defaultPinnedSections
-        guard let currentIndex = sections.firstIndex(of: selectedSection) else { return }
-
-        let nextIndex = currentIndex + offset
-        guard sections.indices.contains(nextIndex) else { return }
-
-        withAnimation(.snappy(duration: 0.2)) {
-            selectedSection = sections[nextIndex]
-        }
-    }
 }
 
 private struct KeyboardHandoffOverlay: View {

--- a/Muesli/RootView.swift
+++ b/Muesli/RootView.swift
@@ -31,9 +31,6 @@ struct RootView: View {
         .onChange(of: coordinator.settingsNavigationRequestID) { _, requestID in
             navigateToSettingsIfNeeded(requestID)
         }
-        .onChange(of: selectedSection) { _, section in
-            ensureSectionPinned(section)
-        }
         .onChange(of: pinnedSectionsStorage) { _, _ in
             clampSelectedSectionToPinnedSections()
         }
@@ -143,27 +140,35 @@ struct RootView: View {
 
     private var pagedSectionContent: some View {
         TabView(selection: $selectedSection) {
-            ForEach(compactPageSections, id: \.self) { section in
-                sectionView(for: section)
-                    .tag(section)
+            ForEach(pageSections, id: \.self) { section in
+                Group {
+                    if shouldRenderPage(section) {
+                        sectionView(for: section)
+                    } else {
+                        Color.clear
+                    }
+                }
+                .tag(section)
             }
         }
         .tabViewStyle(.page(indexDisplayMode: .never))
     }
 
-    private var compactPageSections: [AppSection] {
-        let sections = pinnedSections
-        guard let selectedIndex = sections.firstIndex(of: selectedSection) else {
-            return sections.first.map { [$0] } ?? []
+    private var pageSections: [AppSection] {
+        var sections = pinnedSections
+        if !sections.contains(selectedSection) {
+            sections.append(selectedSection)
         }
+        return sections
+    }
 
-        let nearbyIndices = [
-            selectedIndex - 1,
-            selectedIndex,
-            selectedIndex + 1
-        ].filter { sections.indices.contains($0) }
-
-        return nearbyIndices.map { sections[$0] }
+    private func shouldRenderPage(_ section: AppSection) -> Bool {
+        let sections = pageSections
+        guard let selectedIndex = sections.firstIndex(of: selectedSection),
+              let sectionIndex = sections.firstIndex(of: section) else {
+            return section == selectedSection
+        }
+        return abs(sectionIndex - selectedIndex) <= 1
     }
 
     private func openDrawer() {
@@ -181,7 +186,6 @@ struct RootView: View {
     private func navigateToSettingsIfNeeded(_ requestID: UUID?) {
         guard requestID != nil else { return }
         if coordinator.hasCompletedOnboarding {
-            ensureSectionPinned(.settings)
             selectedSection = .settings
         }
         isDrawerOpen = false
@@ -209,16 +213,6 @@ struct RootView: View {
         if !pins.contains(selectedSection), let nextSection = pins.first {
             selectedSection = nextSection
         }
-    }
-
-    private func ensureSectionPinned(_ section: AppSection) {
-        var pins = pinnedSections
-        guard !pins.contains(section) else { return }
-        if pins.count >= AppSection.maxPinnedSections {
-            pins.removeFirst()
-        }
-        pins.append(section)
-        pinnedSectionsStorage = AppSection.storageString(for: pins)
     }
 
 }

--- a/Muesli/RootView.swift
+++ b/Muesli/RootView.swift
@@ -143,12 +143,27 @@ struct RootView: View {
 
     private var pagedSectionContent: some View {
         TabView(selection: $selectedSection) {
-            ForEach(pinnedSections, id: \.self) { section in
+            ForEach(compactPageSections, id: \.self) { section in
                 sectionView(for: section)
                     .tag(section)
             }
         }
         .tabViewStyle(.page(indexDisplayMode: .never))
+    }
+
+    private var compactPageSections: [AppSection] {
+        let sections = pinnedSections
+        guard let selectedIndex = sections.firstIndex(of: selectedSection) else {
+            return sections.first.map { [$0] } ?? []
+        }
+
+        let nearbyIndices = [
+            selectedIndex - 1,
+            selectedIndex,
+            selectedIndex + 1
+        ].filter { sections.indices.contains($0) }
+
+        return nearbyIndices.map { sections[$0] }
     }
 
     private func openDrawer() {

--- a/MuesliKeyboard/KeyboardController.swift
+++ b/MuesliKeyboard/KeyboardController.swift
@@ -350,9 +350,20 @@ final class KeyboardController {
         prepareLaunchRequestIfNeeded()
         pollingTask?.cancel()
         pollingTask = Task { @MainActor [weak self] in
+            var lastFullRefresh = Date.distantPast
             while !Task.isCancelled {
-                self?.refreshLatestDictation()
-                try? await Task.sleep(for: .milliseconds(500))
+                guard let self else { return }
+
+                if self.dictationPhase == .recording,
+                   Date().timeIntervalSince(lastFullRefresh) < 0.45
+                {
+                    self.refreshRuntimeLevelOnly()
+                    try? await Task.sleep(for: .milliseconds(100))
+                } else {
+                    self.refreshLatestDictation()
+                    lastFullRefresh = Date()
+                    try? await Task.sleep(for: self.dictationPhase == .recording ? .milliseconds(100) : .milliseconds(500))
+                }
             }
         }
     }
@@ -368,6 +379,16 @@ final class KeyboardController {
     func stopPolling() {
         pollingTask?.cancel()
         pollingTask = nil
+    }
+
+    private func refreshRuntimeLevelOnly() {
+        do {
+            let runtimeStatus = try store.keyboardRuntimeStatus()
+            latestRuntimeStatus = runtimeStatus
+            apply(runtimeStatus: runtimeStatus)
+        } catch {
+            inputLevel = 0
+        }
     }
 
     private func refreshLatestDictation() {

--- a/Shared/MuesliWaveformView.swift
+++ b/Shared/MuesliWaveformView.swift
@@ -129,11 +129,37 @@ struct MuesliInlineWaveformView: View {
     private func samplesForRender(count: Int, elapsed: TimeInterval) -> [CGFloat] {
         switch mode {
         case .level:
-            let samples = paddedLiveSamples(count: count)
-            return samples
+            return liveLevelSamples(count: count, elapsed: elapsed)
         case .waiting:
             return waitingSamples(count: count, elapsed: elapsed)
         }
+    }
+
+    private func liveLevelSamples(count: Int, elapsed: TimeInterval) -> [CGFloat] {
+        var samples = paddedLiveSamples(count: count)
+        guard let level else { return samples }
+
+        let normalized = CGFloat(min(max(level, 0), 1))
+        let gatedLevel = gatedLevel(for: normalized)
+        guard gatedLevel > 0.02 else {
+            return samples.map { min($0, 0.02) }
+        }
+
+        let shaped = pow(gatedLevel, 0.72)
+        let dynamicCount = max(10, min(count, count / 2))
+        let startIndex = count - dynamicCount
+
+        for offset in 0..<dynamicCount {
+            let index = startIndex + offset
+            let localPhase = CGFloat(elapsed) * 8.6 + CGFloat(offset) * 0.58
+            let broadPhase = CGFloat(elapsed) * 2.1 + CGFloat(offset) * 0.13
+            let motion = 0.62 + 0.24 * sin(localPhase) + 0.14 * sin(broadPhase)
+            let texture = 0.90 + 0.12 * sin(localPhase * 1.47)
+            let sample = shaped * motion * texture
+            samples[index] = min(0.98, max(0.01, sample))
+        }
+
+        return samples
     }
 
     private func paddedLiveSamples(count: Int) -> [CGFloat] {
@@ -173,8 +199,7 @@ struct MuesliInlineWaveformView: View {
         guard mode == .level else { return }
 
         let normalized = CGFloat(min(max(rawLevel, 0), 1))
-        let noiseFloor: CGFloat = 0.26
-        let gatedLevel = max(0, (normalized - noiseFloor) / (1 - noiseFloor))
+        let gatedLevel = gatedLevel(for: normalized)
         let shaped = pow(gatedLevel, 0.72)
         let texture = CGFloat(0.90 + 0.16 * sin(Double(sampleSequence) * 1.73))
         let sample = gatedLevel <= 0.02 ? 0 : min(0.98, max(0.01, shaped * 0.92 * texture))
@@ -185,6 +210,11 @@ struct MuesliInlineWaveformView: View {
         if liveSamples.count > maxSamples {
             liveSamples.removeFirst(liveSamples.count - maxSamples)
         }
+    }
+
+    private func gatedLevel(for normalized: CGFloat) -> CGFloat {
+        let noiseFloor: CGFloat = 0.26
+        return max(0, (normalized - noiseFloor) / (1 - noiseFloor))
     }
 
 }

--- a/Shared/MuesliWaveformView.swift
+++ b/Shared/MuesliWaveformView.swift
@@ -73,8 +73,6 @@ struct MuesliInlineWaveformView: View {
     @State private var liveSamples: [CGFloat] = []
     @State private var sampleSequence = 0
 
-    private let sampleTimer = Timer.publish(every: 1.0 / 18.0, on: .main, in: .common).autoconnect()
-
     private let basePattern: [CGFloat] = [
         0.18, 0.26, 0.42, 0.58, 0.76, 0.92,
         0.72, 0.46, 0.28, 0.36, 0.62, 0.86,
@@ -95,9 +93,6 @@ struct MuesliInlineWaveformView: View {
         }
         .onChange(of: mode) { _, _ in
             seedLiveSamplesIfNeeded(force: true)
-        }
-        .onReceive(sampleTimer) { _ in
-            appendLiveSample(level ?? 0)
         }
     }
 

--- a/Shared/MuesliWaveformView.swift
+++ b/Shared/MuesliWaveformView.swift
@@ -146,14 +146,12 @@ struct MuesliInlineWaveformView: View {
         }
 
         let shaped = pow(gatedLevel, 0.72)
-        let dynamicCount = max(10, min(count, count / 2))
-        let startIndex = count - dynamicCount
 
-        for offset in 0..<dynamicCount {
-            let index = startIndex + offset
-            let localPhase = CGFloat(elapsed) * 8.6 + CGFloat(offset) * 0.58
-            let broadPhase = CGFloat(elapsed) * 2.1 + CGFloat(offset) * 0.13
-            let motion = 0.62 + 0.24 * sin(localPhase) + 0.14 * sin(broadPhase)
+        for index in 0..<count {
+            let base = basePattern[index % basePattern.count]
+            let localPhase = CGFloat(elapsed) * 8.6 + CGFloat(index) * 0.58
+            let broadPhase = CGFloat(elapsed) * 2.1 + CGFloat(index) * 0.13
+            let motion = 0.54 + 0.22 * sin(localPhase) + 0.12 * sin(broadPhase) + base * 0.22
             let texture = 0.90 + 0.12 * sin(localPhase * 1.47)
             let sample = shaped * motion * texture
             samples[index] = min(0.98, max(0.01, sample))

--- a/Shared/SharedStore.swift
+++ b/Shared/SharedStore.swift
@@ -136,6 +136,10 @@ struct SharedStore: Sendable {
         try database().recordingSession(id: id)
     }
 
+    func activeRecordingSession(id: UUID) throws -> RecordingSession? {
+        try database().activeRecordingSession(id: id)
+    }
+
     func recordingSession(requestID: UUID) throws -> RecordingSession? {
         try database().recordingSession(requestID: requestID)
     }
@@ -464,6 +468,17 @@ private struct SharedStoreDatabase {
         try withDatabase { db in
             try querySingleBlob(
                 "SELECT payload FROM recording_sessions WHERE id = ? LIMIT 1",
+                db: db
+            ) { statement in
+                try bind(id.uuidString, to: statement, at: 1)
+            }.map { try decoder.decode(RecordingSession.self, from: $0) }
+        }
+    }
+
+    func activeRecordingSession(id: UUID) throws -> RecordingSession? {
+        try withDatabase { db in
+            try querySingleBlob(
+                "SELECT payload FROM recording_sessions WHERE id = ? AND deleted_at IS NULL LIMIT 1",
                 db: db
             ) { statement in
                 try bind(id.uuidString, to: statement, at: 1)


### PR DESCRIPTION
## Summary
- add a compact landing stats dashboard with streak, words, WPM, and meetings
- update the home header mark to a standalone waveform and make the record CTA more tactile
- normalize the built-in mic route label to show iPhone Microphone

## Verification
- xcodebuild -project MuesliiOS.xcodeproj -scheme Muesli -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=26.5' -derivedDataPath build/landing-stats-sim build
- installed and launched on iPhone 17 Pro simulator with --muesli-mock-dictations
- captured diagnostics/ui/landing-stats-dashboard-sim-dark.png

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli-ios/pr/12"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785527763&installation_id=136549638&pr_number=12&repository=Muesli-HQ%2Fmuesli-ios&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli-ios%2Fpull%2F12&signature=764aee3e36e5248b0f3d1b88fd2578c3f5f193af3e80a79fb948df624c4326af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/muesli-hq/muesli-ios/pull/12" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a home stats row in the dictation header with streak, words, WPM, and meetings tiles, including a combined accessibility label and updated waveform-style branding.
  * Enabled swipe navigation between sections in compact layouts with smooth paging and updated header/section presentation.
  * Added support for cancelling the currently active recording, including UI/behavior updates during recording.
  * Refreshed record button visuals for a clearer stop/disabled experience.
* **Bug Fixes**
  * Improved audio input labeling so built-in microphones use consistent, user-friendly names (including improved fallback labeling).
  * Improved waveform responsiveness by updating live samples only when the input level changes.
* **Chores**
  * Improved dictation session lookup performance by preferring cached session data when available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->