### PR TITLE
[codex] Fix swipe tab blank state

### DIFF
--- a/Muesli/AudioRecorder.swift
+++ b/Muesli/AudioRecorder.swift
@@ -72,6 +72,18 @@ final class AudioRecorder {
         return outputURL
     }
 
+    func cancel() {
+        recorder?.stop()
+        recorder = nil
+
+        if let outputURL {
+            try? FileManager.default.removeItem(at: outputURL)
+        }
+        outputURL = nil
+
+        try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
+    }
+
     enum RecordingError: LocalizedError {
         case microphonePermissionDenied
         case noRecording

--- a/Muesli/DictationCoordinator.swift
+++ b/Muesli/DictationCoordinator.swift
@@ -1032,6 +1032,18 @@ final class DictationCoordinator {
         }
     }
 
+    func cancelOnboardingTestDictation() {
+        guard isOnboardingTestRecording else { return }
+        MuesliHaptics.dictationStop()
+        isOnboardingTestRecording = false
+        isOnboardingTestTranscribing = false
+        onboardingTestInputLevel = 0
+        onboardingTestError = nil
+        stopMetering()
+        recorder.cancel()
+        AppTelemetry.signal("onboarding_test_cancelled")
+    }
+
     func completeOnboarding() {
         hasCompletedOnboarding = true
         UserDefaults.standard.set(true, forKey: Self.onboardingCompletedKey)

--- a/Muesli/DictationView.swift
+++ b/Muesli/DictationView.swift
@@ -276,7 +276,7 @@ struct DictationView: View {
                             mode: isListeningWaveformActive ? .level : .waiting,
                             color: statusColor,
                             level: waveformLevel,
-                            barCount: 24
+                            barCount: 32
                         )
                         .frame(maxWidth: .infinity)
                         .frame(height: 54)
@@ -335,12 +335,16 @@ struct DictationView: View {
                         Button(role: .destructive) {
                             coordinator.cancelActiveRecording()
                         } label: {
-                            Label("Cancel Recording", systemImage: "xmark")
+                            Label("Discard Recording", systemImage: "xmark")
                                 .font(MuesliTheme.captionMedium())
                                 .foregroundStyle(MuesliTheme.destructive)
                                 .frame(maxWidth: .infinity)
                                 .frame(minHeight: 44)
-                                .background(MuesliTheme.destructiveSubtle)
+                                .background(MuesliTheme.destructive.opacity(0.07))
+                                .overlay(
+                                    Capsule()
+                                        .strokeBorder(MuesliTheme.destructive.opacity(0.22), lineWidth: 1)
+                                )
                                 .clipShape(Capsule())
                                 .contentShape(Capsule())
                         }
@@ -350,7 +354,7 @@ struct DictationView: View {
                 }
                 .padding(.top, isWaveformActive || shouldShowRealtimeTranscript ? 0 : MuesliTheme.spacing4)
 
-                if shouldShowKeyboardSetupRow && !shouldHideKeyboardSetupRowForMockPreview {
+                if shouldShowKeyboardSetupRow && !shouldHideKeyboardSetupRowForMockPreview && !coordinator.isRecording {
                     keyboardShortcutRow
                 }
             }
@@ -386,7 +390,7 @@ struct DictationView: View {
             .font(MuesliTheme.captionMedium())
             .foregroundStyle(MuesliTheme.textSecondary)
             .padding(.horizontal, MuesliTheme.spacing8)
-            .frame(minHeight: 32)
+            .frame(minHeight: 44)
             .background(MuesliTheme.surfacePrimary)
             .clipShape(Capsule())
             .contentShape(Capsule())
@@ -752,15 +756,15 @@ private struct DictationHomeStatTile: View {
             }
         }
         .frame(maxWidth: .infinity)
-        .frame(height: 76)
+        .frame(height: 72)
         .padding(.horizontal, MuesliTheme.spacing8)
         .background {
             RoundedRectangle(cornerRadius: MuesliTheme.cornerLarge, style: .continuous)
                 .fill(
                     LinearGradient(
                         colors: [
-                            MuesliTheme.backgroundRaised.opacity(0.88),
-                            MuesliTheme.backgroundDeep.opacity(0.76)
+                            MuesliTheme.backgroundRaised.opacity(0.80),
+                            MuesliTheme.backgroundDeep.opacity(0.68)
                         ],
                         startPoint: .topLeading,
                         endPoint: .bottomTrailing
@@ -776,8 +780,8 @@ private struct DictationHomeStatTile: View {
             RoundedRectangle(cornerRadius: MuesliTheme.cornerLarge, style: .continuous)
                 .strokeBorder(MuesliTheme.accent.opacity(0.34), lineWidth: 1)
         }
-        .shadow(color: MuesliTheme.accent.opacity(0.10), radius: 12, x: 0, y: 7)
-        .shadow(color: .black.opacity(0.18), radius: 8, x: 0, y: 4)
+        .shadow(color: MuesliTheme.accent.opacity(0.07), radius: 9, x: 0, y: 5)
+        .shadow(color: .black.opacity(0.12), radius: 6, x: 0, y: 3)
         .accessibilityElement(children: .ignore)
         .accessibilityLabel("\(value) \(label)")
     }
@@ -795,12 +799,12 @@ private struct VoiceNoteRecordButtonLabel: View {
             ZStack {
                 Circle()
                     .fill(color.opacity(isStopState ? 0.18 : 0.16))
-                    .frame(width: 96, height: 96)
+                    .frame(width: haloSize, height: haloSize)
                     .blur(radius: 0.5)
 
                 Circle()
                     .fill(outerRingFill)
-                    .frame(width: 88, height: 88)
+                    .frame(width: outerRingSize, height: outerRingSize)
                     .overlay(
                         Circle()
                             .strokeBorder(outerRingBorder, lineWidth: 1.2)
@@ -816,7 +820,7 @@ private struct VoiceNoteRecordButtonLabel: View {
                             endPoint: .bottomTrailing
                         )
                     )
-                    .frame(width: 74, height: 74)
+                    .frame(width: innerCircleSize, height: innerCircleSize)
                     .overlay(alignment: .topLeading) {
                         Circle()
                             .strokeBorder(.white.opacity(isDisabled ? 0.08 : 0.42), lineWidth: 2)
@@ -838,7 +842,7 @@ private struct VoiceNoteRecordButtonLabel: View {
                     .shadow(color: .black.opacity(0.20), radius: 7, x: 0, y: 5)
 
                 Image(systemName: systemImage)
-                    .font(.system(size: 26, weight: .semibold))
+                    .font(.system(size: isStopState ? 26 : 24, weight: .semibold))
                     .foregroundStyle(iconColor)
             }
 
@@ -847,8 +851,20 @@ private struct VoiceNoteRecordButtonLabel: View {
                 .foregroundStyle(titleColor)
         }
         .frame(maxWidth: .infinity)
-        .frame(minHeight: 112)
+        .frame(minHeight: isStopState ? 112 : 98)
         .contentShape(Rectangle())
+    }
+
+    private var haloSize: CGFloat {
+        isStopState ? 96 : 84
+    }
+
+    private var outerRingSize: CGFloat {
+        isStopState ? 88 : 76
+    }
+
+    private var innerCircleSize: CGFloat {
+        isStopState ? 74 : 64
     }
 
     private var outerRingFill: Color {
@@ -1215,7 +1231,7 @@ private struct DictationHistoryRow: View {
             }
 
             Text(result.text)
-                .font(.system(size: 17, weight: .regular))
+                .font(MuesliTheme.transcript())
                 .foregroundStyle(MuesliTheme.textPrimary)
                 .lineSpacing(2)
                 .textSelection(.enabled)

--- a/Muesli/DictationView.swift
+++ b/Muesli/DictationView.swift
@@ -6,6 +6,7 @@ import UIKit
 
 struct DictationView: View {
     @Bindable var coordinator: DictationCoordinator
+    var isActive = true
     @Environment(\.openURL) private var openURL
     @Environment(\.scenePhase) private var scenePhase
     @AppStorage(MuesliPreferences.iCloudSyncEnabledKey) private var iCloudSyncEnabled = false
@@ -50,24 +51,26 @@ struct DictationView: View {
                 Text("Muesli will sync voice note text, meeting transcripts, notes, and summaries with your Mac through your private iCloud account. Audio stays local.")
             }
             .onAppear {
-                coordinator.refreshHistory()
-                coordinator.refreshAudioInputRoute()
-                refreshKeyboardSetupPromptVisibility()
-                updateDashboardStats()
+                refreshVisibleStateIfNeeded()
+            }
+            .onChange(of: isActive) { _, active in
+                guard active else { return }
+                refreshVisibleStateIfNeeded()
             }
             .onChange(of: coordinator.dictationHistory.count) { _, _ in
+                guard isActive else { return }
                 updateDashboardStats()
             }
             .onChange(of: coordinator.recordingSessions.count) { _, _ in
+                guard isActive else { return }
                 updateDashboardStats()
             }
             .onChange(of: scenePhase) { _, phase in
-                guard phase == .active else { return }
-                coordinator.refreshAudioInputRoute()
-                refreshKeyboardSetupPromptVisibility()
-                updateDashboardStats()
+                guard phase == .active, isActive else { return }
+                refreshVisibleStateIfNeeded()
             }
             .onChange(of: microphonePreference) { _, _ in
+                guard isActive else { return }
                 coordinator.refreshAudioInputRoute()
             }
             .navigationDestination(for: UUID.self) { resultID in
@@ -276,6 +279,7 @@ struct DictationView: View {
                             mode: isListeningWaveformActive ? .level : .waiting,
                             color: statusColor,
                             level: waveformLevel,
+                            isActive: isActive,
                             barCount: 32
                         )
                         .frame(maxWidth: .infinity)
@@ -361,7 +365,8 @@ struct DictationView: View {
             .padding(MuesliTheme.spacing16)
         }
         .accessibilityIdentifier("dictation.recorderPanel")
-        .task {
+        .task(id: isActive) {
+            guard isActive else { return }
             await runPreviewWaveformIfNeeded()
         }
     }
@@ -636,6 +641,14 @@ struct DictationView: View {
             return
         }
         coordinator.syncICloudTextIfEnabled(reason: "home_manual")
+    }
+
+    private func refreshVisibleStateIfNeeded() {
+        guard isActive else { return }
+        coordinator.refreshHistory()
+        coordinator.refreshAudioInputRoute()
+        refreshKeyboardSetupPromptVisibility()
+        updateDashboardStats()
     }
 
     private func openKeyboardSettings() {

--- a/Muesli/MeetingsView.swift
+++ b/Muesli/MeetingsView.swift
@@ -4,6 +4,7 @@ import UIKit
 
 struct MeetingsView: View {
     @Bindable var coordinator: DictationCoordinator
+    var isActive = true
     @State private var meetingTitle = ""
     @State private var sessionPendingDelete: RecordingSession?
     @AppStorage(MuesliPreferences.meetingTemplateKey) private var selectedMeetingTemplate = MeetingTemplatePreset.general.rawValue
@@ -31,7 +32,11 @@ struct MeetingsView: View {
             .background(MuesliTheme.backgroundBase)
             .toolbar(.hidden, for: .navigationBar)
             .onAppear {
-                coordinator.refreshHistory()
+                refreshVisibleStateIfNeeded()
+            }
+            .onChange(of: isActive) { _, active in
+                guard active else { return }
+                refreshVisibleStateIfNeeded()
             }
             .navigationDestination(for: UUID.self) { sessionID in
                 if let session = coordinator.recordingSessions.first(where: { $0.id == sessionID }) {
@@ -131,6 +136,7 @@ struct MeetingsView: View {
                             mode: coordinator.isMeetingRecording ? .level : .waiting,
                             color: statusColor,
                             level: coordinator.isMeetingRecording ? coordinator.inputLevel : nil,
+                            isActive: isActive,
                             barCount: 32
                         )
                         .frame(maxWidth: .infinity)
@@ -302,6 +308,11 @@ struct MeetingsView: View {
                 }
             }
         }
+    }
+
+    private func refreshVisibleStateIfNeeded() {
+        guard isActive else { return }
+        coordinator.refreshHistory()
     }
 
     private var emptyState: some View {

--- a/Muesli/MeetingsView.swift
+++ b/Muesli/MeetingsView.swift
@@ -131,7 +131,7 @@ struct MeetingsView: View {
                             mode: coordinator.isMeetingRecording ? .level : .waiting,
                             color: statusColor,
                             level: coordinator.isMeetingRecording ? coordinator.inputLevel : nil,
-                            barCount: 24
+                            barCount: 32
                         )
                         .frame(maxWidth: .infinity)
                         .frame(height: 54)
@@ -181,7 +181,11 @@ struct MeetingsView: View {
                                 .foregroundStyle(MuesliTheme.destructive)
                                 .frame(maxWidth: .infinity)
                                 .frame(minHeight: 44)
-                                .background(MuesliTheme.destructiveSubtle)
+                                .background(MuesliTheme.destructive.opacity(0.07))
+                                .overlay(
+                                    RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall)
+                                        .strokeBorder(MuesliTheme.destructive.opacity(0.22), lineWidth: 1)
+                                )
                                 .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
                                 .contentShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
                         }
@@ -522,7 +526,7 @@ private struct MeetingSessionDetailView: View {
                                 Image(systemName: "pencil")
                                     .font(.system(size: 14, weight: .semibold))
                                     .foregroundStyle(MuesliTheme.accent)
-                                    .frame(width: 32, height: 32)
+                                    .frame(width: 44, height: 44)
                                     .background(MuesliTheme.accentSubtle)
                                     .clipShape(Circle())
                                     .contentShape(Circle())

--- a/Muesli/OnboardingView.swift
+++ b/Muesli/OnboardingView.swift
@@ -404,14 +404,14 @@ struct OnboardingView: View {
                 Spacer()
 
                 Button(action: action) {
-                    Text(buttonTitle)
-                        .font(MuesliTheme.captionMedium())
-                        .foregroundStyle(isComplete ? MuesliTheme.success : .white)
-                        .padding(.horizontal, MuesliTheme.spacing12)
-                        .frame(height: 34)
-                        .background(
-                            Capsule()
-                                .fill(isComplete ? MuesliTheme.success.opacity(0.13) : MuesliTheme.accent)
+                        Text(buttonTitle)
+                            .font(MuesliTheme.captionMedium())
+                            .foregroundStyle(isComplete ? MuesliTheme.success : .white)
+                            .padding(.horizontal, MuesliTheme.spacing12)
+                            .frame(minHeight: 44)
+                            .background(
+                                Capsule()
+                                    .fill(isComplete ? MuesliTheme.success.opacity(0.13) : MuesliTheme.accent)
                         )
                         .overlay(
                             Capsule()
@@ -748,7 +748,7 @@ struct OnboardingView: View {
                                 mode: coordinator.isOnboardingTestRecording ? .level : .waiting,
                                 color: onboardingTestColor,
                                 level: coordinator.isOnboardingTestRecording ? coordinator.onboardingTestInputLevel : nil,
-                                barCount: 24
+                                barCount: 32
                             )
                             .frame(maxWidth: .infinity)
                             .frame(height: 54)
@@ -780,28 +780,50 @@ struct OnboardingView: View {
                     }
 
                     if coordinator.modelPreparation.isReady {
-                        Button {
-                            if coordinator.isOnboardingTestRecording {
-                                coordinator.stopOnboardingTestDictation()
-                            } else {
-                                coordinator.startOnboardingTestDictation()
+                        VStack(spacing: MuesliTheme.spacing8) {
+                            Button {
+                                if coordinator.isOnboardingTestRecording {
+                                    coordinator.stopOnboardingTestDictation()
+                                } else {
+                                    coordinator.startOnboardingTestDictation()
+                                }
+                            } label: {
+                                Label(
+                                    onboardingTestButtonTitle,
+                                    systemImage: onboardingTestButtonIcon
+                                )
+                                .font(MuesliTheme.headline())
+                                .frame(maxWidth: .infinity)
+                                .frame(height: 48)
+                                .foregroundStyle(onboardingTestButtonTextColor)
+                                .background(onboardingTestButtonBackground)
+                                .overlay(onboardingTestButtonBorder)
+                                .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+                                .contentShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
                             }
-                        } label: {
-                            Label(
-                                onboardingTestButtonTitle,
-                                systemImage: onboardingTestButtonIcon
-                            )
-                            .font(MuesliTheme.headline())
-                            .frame(maxWidth: .infinity)
-                            .frame(height: 48)
-                            .foregroundStyle(onboardingTestButtonTextColor)
-                            .background(onboardingTestButtonBackground)
-                            .overlay(onboardingTestButtonBorder)
-                            .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
-                            .contentShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+                            .buttonStyle(.plain)
+                            .disabled(coordinator.isOnboardingTestTranscribing)
+
+                            if coordinator.isOnboardingTestRecording {
+                                Button(role: .destructive) {
+                                    coordinator.cancelOnboardingTestDictation()
+                                } label: {
+                                    Label("Discard Test", systemImage: "xmark")
+                                        .font(MuesliTheme.captionMedium())
+                                        .frame(maxWidth: .infinity)
+                                        .frame(minHeight: 44)
+                                        .foregroundStyle(MuesliTheme.destructive)
+                                        .background(MuesliTheme.destructive.opacity(0.07))
+                                        .overlay(
+                                            RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall)
+                                                .strokeBorder(MuesliTheme.destructive.opacity(0.22), lineWidth: 1)
+                                        )
+                                        .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+                                        .contentShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+                                }
+                                .buttonStyle(.plain)
+                            }
                         }
-                        .buttonStyle(.plain)
-                        .disabled(coordinator.isOnboardingTestTranscribing)
                     } else if coordinator.modelPreparation.phase == .failed || coordinator.modelPreparation.phase == .idle {
                         Button {
                             coordinator.prepareModelForOnboarding()

--- a/Muesli/OnboardingView.swift
+++ b/Muesli/OnboardingView.swift
@@ -1278,10 +1278,6 @@ struct OnboardingView: View {
     private func refreshAppleSyncStatus() {
         Task {
             appleSyncSnapshot = await AppleSyncAccountManager.shared.snapshot()
-            AppTelemetry.signal(
-                "onboarding_icloud_sync_status_checked",
-                parameters: ["icloud_available": appleSyncSnapshot.isICloudAvailable ? "true" : "false"]
-            )
             if iCloudSyncEnabled && !appleSyncSnapshot.isICloudAvailable {
                 pinnedSyncSetupStatusText = nil
                 appleSyncStatusText = "Sign in to iCloud on this iPhone before enabling Muesli sync."

--- a/Muesli/RootView.swift
+++ b/Muesli/RootView.swift
@@ -118,20 +118,21 @@ struct RootView: View {
 
     @ViewBuilder
     private var sectionContent: some View {
-        sectionView(for: selectedSection)
+        sectionView(for: selectedSection, isActive: true)
     }
 
     @ViewBuilder
-    private func sectionView(for section: AppSection) -> some View {
+    private func sectionView(for section: AppSection, isActive: Bool) -> some View {
         switch section {
         case .dictations:
-            DictationView(coordinator: coordinator)
+            DictationView(coordinator: coordinator, isActive: isActive)
         case .meetings:
-            MeetingsView(coordinator: coordinator)
+            MeetingsView(coordinator: coordinator, isActive: isActive)
         case .settings:
             SettingsView(
                 coordinator: coordinator,
-                openSyncPrivacyRequest: coordinator.syncSetupRequestID
+                openSyncPrivacyRequest: coordinator.syncSetupRequestID,
+                isActive: isActive
             ) { section in
                 selectedSection = section
             }
@@ -141,9 +142,9 @@ struct RootView: View {
     private var pagedSectionContent: some View {
         TabView(selection: $selectedSection) {
             ForEach(pageSections, id: \.self) { section in
-                sectionView(for: section)
+                sectionView(for: section, isActive: selectedSection == section)
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .tag(section)
+                    .tag(section)
             }
         }
         .tabViewStyle(.page(indexDisplayMode: .never))

--- a/Muesli/RootView.swift
+++ b/Muesli/RootView.swift
@@ -141,13 +141,8 @@ struct RootView: View {
     private var pagedSectionContent: some View {
         TabView(selection: $selectedSection) {
             ForEach(pageSections, id: \.self) { section in
-                Group {
-                    if shouldRenderPage(section) {
-                        sectionView(for: section)
-                    } else {
-                        Color.clear
-                    }
-                }
+                sectionView(for: section)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .tag(section)
             }
         }
@@ -160,15 +155,6 @@ struct RootView: View {
             sections.append(selectedSection)
         }
         return sections
-    }
-
-    private func shouldRenderPage(_ section: AppSection) -> Bool {
-        let sections = pageSections
-        guard let selectedIndex = sections.firstIndex(of: selectedSection),
-              let sectionIndex = sections.firstIndex(of: section) else {
-            return section == selectedSection
-        }
-        return abs(sectionIndex - selectedIndex) <= 1
     }
 
     private func openDrawer() {

--- a/Muesli/RootView.swift
+++ b/Muesli/RootView.swift
@@ -233,7 +233,7 @@ private struct KeyboardHandoffOverlay: View {
                         mode: coordinator.isRecording ? .level : .waiting,
                         color: coordinator.isRecording ? MuesliTheme.recording : MuesliTheme.transcribing,
                         level: coordinator.isRecording ? coordinator.inputLevel : nil,
-                        barCount: 24
+                        barCount: 32
                     )
                     .frame(width: 220, height: 56)
 
@@ -471,12 +471,12 @@ private struct MuesliDrawer: View {
                 Spacer()
 
                 Button(action: onClose) {
-                    Image(systemName: "xmark")
-                        .font(.system(size: 14, weight: .bold))
-                        .foregroundStyle(MuesliTheme.textSecondary)
-                        .frame(width: 34, height: 34)
-                        .muesliGlassButton(cornerRadius: 17)
-                        .contentShape(Circle())
+                        Image(systemName: "xmark")
+                            .font(.system(size: 14, weight: .bold))
+                            .foregroundStyle(MuesliTheme.textSecondary)
+                            .frame(width: 44, height: 44)
+                            .muesliGlassButton(cornerRadius: 22)
+                            .contentShape(Circle())
                 }
                 .buttonStyle(.plain)
             }
@@ -551,7 +551,7 @@ private struct SidebarSectionRow: View {
                 Image(systemName: isPinned ? "pin.fill" : "pin")
                     .font(.system(size: 13, weight: .semibold))
                     .foregroundStyle(isPinned ? accent : MuesliTheme.textTertiary)
-                    .frame(width: 36, height: 36)
+                    .frame(width: 44, height: 44)
                     .background(isPinned ? accent.opacity(0.15) : Color.clear)
                     .clipShape(Circle())
                     .contentShape(Circle())

--- a/Muesli/SettingsView.swift
+++ b/Muesli/SettingsView.swift
@@ -4,6 +4,7 @@ import SwiftUI
 struct SettingsView: View {
     @Bindable var coordinator: DictationCoordinator
     var openSyncPrivacyRequest: UUID?
+    var isActive = true
     var onSelectSection: ((AppSection) -> Void)?
 
     @AppStorage(MuesliPreferences.liveActivitiesForDictationsKey) private var liveActivitiesForDictations = true
@@ -35,10 +36,12 @@ struct SettingsView: View {
             .background(MuesliTheme.backgroundBase)
             .toolbar(.hidden, for: .navigationBar)
             .onAppear {
-                refreshKeyboardStatus()
-                refreshSummarySettings()
-                AppTelemetry.signal("settings_viewed")
-                refreshAppleSyncSettings()
+                refreshVisibleSettingsIfNeeded()
+                openRequestedSyncPrivacySection()
+            }
+            .onChange(of: isActive) { _, active in
+                guard active else { return }
+                refreshVisibleSettingsIfNeeded()
                 openRequestedSyncPrivacySection()
             }
             .onChange(of: openSyncPrivacyRequest) { _, _ in
@@ -68,6 +71,7 @@ struct SettingsView: View {
                 coordinator.refreshKeyboardSessionTimeout()
             }
             .onChange(of: microphonePreference) { _, newValue in
+                guard isActive else { return }
                 coordinator.refreshAudioInputRoute()
                 AppTelemetry.signal("recording_microphone_preference_changed", parameters: ["preference": newValue])
             }
@@ -550,6 +554,14 @@ struct SettingsView: View {
         chatGPTSignedIn = ChatGPTAuthManager.shared.isAuthenticated
     }
 
+    private func refreshVisibleSettingsIfNeeded() {
+        guard isActive else { return }
+        refreshKeyboardStatus()
+        refreshSummarySettings()
+        AppTelemetry.signal("settings_viewed")
+        refreshAppleSyncSettings()
+    }
+
     private func saveOpenRouterAPIKey(_ apiKey: String) {
         do {
             try MeetingSummaryClient.saveOpenRouterAPIKey(apiKey)
@@ -583,7 +595,9 @@ struct SettingsView: View {
 
     private func refreshAppleSyncSettings() {
         Task {
+            guard isActive else { return }
             appleSyncSnapshot = await AppleSyncAccountManager.shared.snapshot()
+            guard isActive else { return }
             AppTelemetry.signal(
                 "icloud_sync_status_checked",
                 parameters: ["icloud_available": appleSyncSnapshot.isICloudAvailable ? "true" : "false"]

--- a/Muesli/SettingsView.swift
+++ b/Muesli/SettingsView.swift
@@ -558,7 +558,6 @@ struct SettingsView: View {
         guard isActive else { return }
         refreshKeyboardStatus()
         refreshSummarySettings()
-        AppTelemetry.signal("settings_viewed")
         refreshAppleSyncSettings()
     }
 
@@ -598,10 +597,6 @@ struct SettingsView: View {
             guard isActive else { return }
             appleSyncSnapshot = await AppleSyncAccountManager.shared.snapshot()
             guard isActive else { return }
-            AppTelemetry.signal(
-                "icloud_sync_status_checked",
-                parameters: ["icloud_available": appleSyncSnapshot.isICloudAvailable ? "true" : "false"]
-            )
             if iCloudSyncEnabled && !appleSyncSnapshot.isICloudAvailable {
                 appleSyncStatusText = "Sign in to iCloud on this iPhone before enabling Muesli sync."
             } else if iCloudSyncEnabled {

--- a/Muesli/SettingsView.swift
+++ b/Muesli/SettingsView.swift
@@ -6,8 +6,6 @@ struct SettingsView: View {
     var openSyncPrivacyRequest: UUID?
     var onSelectSection: ((AppSection) -> Void)?
 
-    @AppStorage(MuesliPreferences.appearanceModeKey) private var appearanceMode = MuesliAppearanceMode.system.rawValue
-    @AppStorage(MuesliPreferences.accentThemeKey) private var accentTheme = MuesliAccentTheme.blue.rawValue
     @AppStorage(MuesliPreferences.liveActivitiesForDictationsKey) private var liveActivitiesForDictations = true
     @AppStorage(MuesliPreferences.liveActivitiesForMeetingsKey) private var liveActivitiesForMeetings = true
     @AppStorage(MuesliPreferences.keyboardSessionModeKey) private var keyboardSessionMode = false
@@ -205,46 +203,7 @@ struct SettingsView: View {
     }
 
     private var appearanceSettings: some View {
-        VStack(alignment: .leading, spacing: MuesliTheme.spacing16) {
-            MuesliSurface {
-                VStack(alignment: .leading, spacing: MuesliTheme.spacing12) {
-                    SettingsAppearanceModePicker(selection: $appearanceMode)
-                    Divider().overlay(MuesliTheme.surfaceBorder)
-                    SettingsAccentThemePicker(selection: $accentTheme)
-                }
-                .padding(MuesliTheme.spacing16)
-            }
-
-            MuesliSurface {
-                VStack(alignment: .leading, spacing: MuesliTheme.spacing12) {
-                    Text("Preview")
-                        .font(MuesliTheme.headline())
-                        .foregroundStyle(MuesliTheme.textPrimary)
-
-                    HStack(spacing: MuesliTheme.spacing12) {
-                        MuesliTheme.accent
-                            .frame(width: 44, height: 44)
-                            .clipShape(Circle())
-                            .overlay(Circle().strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1))
-
-                        VStack(alignment: .leading, spacing: MuesliTheme.spacing4) {
-                            Text(selectedAccentTheme.label)
-                                .font(MuesliTheme.headline())
-                                .foregroundStyle(MuesliTheme.textPrimary)
-                            Text("\(selectedAppearanceMode.label) appearance")
-                                .font(MuesliTheme.caption())
-                                .foregroundStyle(MuesliTheme.textSecondary)
-                        }
-
-                        Spacer()
-                    }
-                    .padding(MuesliTheme.spacing12)
-                    .background(MuesliTheme.surfacePrimary)
-                    .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
-                }
-                .padding(MuesliTheme.spacing16)
-            }
-        }
+        AppearanceSettingsContent()
     }
 
     private var inputSettings: some View {
@@ -556,14 +515,6 @@ struct SettingsView: View {
         MeetingSummaryBackend(rawValue: meetingSummaryBackend) ?? .openRouter
     }
 
-    private var selectedAppearanceMode: MuesliAppearanceMode {
-        MuesliAppearanceMode(rawValue: appearanceMode) ?? .system
-    }
-
-    private var selectedAccentTheme: MuesliAccentTheme {
-        MuesliAccentTheme.resolved(rawValue: accentTheme)
-    }
-
     private var modelButtonTitle: String {
         switch coordinator.modelPreparation.phase {
         case .ready:
@@ -749,6 +700,108 @@ private enum SettingsSection: String, CaseIterable, Identifiable {
         case .aiSummaries:
             "sparkles"
         }
+    }
+}
+
+private struct AppearanceSettingsContent: View {
+    @AppStorage(MuesliPreferences.appearanceModeKey) private var appearanceMode = MuesliAppearanceMode.system.rawValue
+    @AppStorage(MuesliPreferences.accentThemeKey) private var accentTheme = MuesliAccentTheme.blue.rawValue
+
+    private var selectedAppearanceMode: MuesliAppearanceMode {
+        MuesliAppearanceMode(rawValue: appearanceMode) ?? .system
+    }
+
+    private var selectedAccentTheme: MuesliAccentTheme {
+        MuesliAccentTheme.resolved(rawValue: accentTheme)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: MuesliTheme.spacing16) {
+            MuesliSurface {
+                VStack(alignment: .leading, spacing: MuesliTheme.spacing12) {
+                    SettingsAppearanceModePicker(selection: $appearanceMode)
+                    Divider().overlay(MuesliTheme.surfaceBorder)
+                    SettingsAccentThemePicker(selection: $accentTheme)
+                }
+                .padding(MuesliTheme.spacing16)
+            }
+
+            MuesliSurface {
+                VStack(alignment: .leading, spacing: MuesliTheme.spacing12) {
+                    Text("Preview")
+                        .font(MuesliTheme.headline())
+                        .foregroundStyle(MuesliTheme.textPrimary)
+
+                    appearancePreviewSurface
+                }
+                .padding(MuesliTheme.spacing16)
+            }
+        }
+    }
+
+    private var appearancePreviewSurface: some View {
+        VStack(alignment: .leading, spacing: MuesliTheme.spacing12) {
+            HStack(spacing: MuesliTheme.spacing12) {
+                MuesliTheme.accent
+                    .frame(width: 44, height: 44)
+                    .clipShape(Circle())
+                    .overlay(Circle().strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1))
+
+                VStack(alignment: .leading, spacing: MuesliTheme.spacing4) {
+                    Text(selectedAccentTheme.label)
+                        .font(MuesliTheme.headline())
+                        .foregroundStyle(MuesliTheme.textPrimary)
+                    Text("\(selectedAppearanceMode.label) appearance")
+                        .font(MuesliTheme.caption())
+                        .foregroundStyle(MuesliTheme.textSecondary)
+                }
+
+                Spacer()
+            }
+
+            HStack(spacing: MuesliTheme.spacing8) {
+                previewMetric("3", "streak", tint: Color(hex: 0xFF9F2D))
+                previewMetric("152", "WPM", tint: MuesliTheme.success)
+                previewRecorderButton
+            }
+        }
+        .padding(MuesliTheme.spacing12)
+        .background(MuesliTheme.surfacePrimary)
+        .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+    }
+
+    private func previewMetric(_ value: String, _ label: String, tint: Color) -> some View {
+        VStack(spacing: 2) {
+            Text(value)
+                .font(MuesliTheme.headline())
+                .monospacedDigit()
+                .foregroundStyle(MuesliTheme.textPrimary)
+            Text(label)
+                .font(MuesliTheme.caption())
+                .foregroundStyle(MuesliTheme.textSecondary)
+        }
+        .frame(maxWidth: .infinity)
+        .frame(height: 52)
+        .background(tint.opacity(0.10))
+        .overlay(
+            RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall, style: .continuous)
+                .strokeBorder(tint.opacity(0.28), lineWidth: 1)
+        )
+        .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall, style: .continuous))
+    }
+
+    private var previewRecorderButton: some View {
+        HStack(spacing: MuesliTheme.spacing8) {
+            Image(systemName: "mic.fill")
+                .font(.system(size: 15, weight: .semibold))
+            Text("Record")
+                .font(MuesliTheme.captionMedium())
+        }
+        .foregroundStyle(.white)
+        .frame(maxWidth: .infinity)
+        .frame(height: 52)
+        .background(MuesliTheme.accent)
+        .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall, style: .continuous))
     }
 }
 
@@ -1107,7 +1160,7 @@ private struct SettingsAccentThemePicker: View {
                         selection = theme.rawValue
                     } label: {
                         MuesliTheme.color(for: theme)
-                            .frame(width: 42, height: 42)
+                            .frame(width: 44, height: 44)
                             .clipShape(Circle())
                             .overlay {
                                 Circle()

--- a/MuesliKeyboard/KeyboardController.swift
+++ b/MuesliKeyboard/KeyboardController.swift
@@ -7,6 +7,8 @@ final class KeyboardController {
     private static let staleRecordingInterval: TimeInterval = 45
     private static let staleStoppingInterval: TimeInterval = 10
     private static let staleTranscribingInterval: TimeInterval = 120
+    private static let runtimeLevelMinUpdateInterval: TimeInterval = 0.16
+    private static let runtimeLevelMinDelta = 0.02
 
     private let store = SharedStore()
     private let handoffRecoveryPolicy = KeyboardHandoffRecoveryPolicy.keyboardDefaults
@@ -19,6 +21,7 @@ final class KeyboardController {
     private var latestRuntimeStatus: KeyboardRuntimeStatus?
     private var insertedRequestIDs = Set<UUID>()
     private var cancelledRequestIDs = Set<UUID>()
+    private var lastRuntimeLevelUpdateAt = Date.distantPast
 
     var statusText = "Record a voice note first"
     var hasLatestDictation = false
@@ -358,11 +361,11 @@ final class KeyboardController {
                    Date().timeIntervalSince(lastFullRefresh) < 0.45
                 {
                     self.refreshRuntimeLevelOnly()
-                    try? await Task.sleep(for: .milliseconds(100))
+                    try? await Task.sleep(for: .milliseconds(125))
                 } else {
                     self.refreshLatestDictation()
                     lastFullRefresh = Date()
-                    try? await Task.sleep(for: self.dictationPhase == .recording ? .milliseconds(100) : .milliseconds(500))
+                    try? await Task.sleep(for: self.dictationPhase == .recording ? .milliseconds(125) : .milliseconds(500))
                 }
             }
         }
@@ -539,8 +542,9 @@ final class KeyboardController {
     }
 
     private func apply(runtimeStatus: KeyboardRuntimeStatus?) {
-        let isRecent = runtimeStatus.map { Date().timeIntervalSince($0.updatedAt) < 8 } ?? false
-        inputLevel = isRecent ? (runtimeStatus?.inputLevel ?? 0) : 0
+        let now = Date()
+        let isRecent = runtimeStatus.map { now.timeIntervalSince($0.updatedAt) < 8 } ?? false
+        applyRuntimeInputLevel(isRecent ? (runtimeStatus?.inputLevel ?? 0) : 0, now: now)
         canUseRuntimeStart = runtimeStatus?.isActive == true
             && isRecent
             && runtimeStatus?.supportsBackgroundStart == true
@@ -556,6 +560,28 @@ final class KeyboardController {
         if runtimeStatus?.phase == .idle {
             statusText = runtimeStatus?.message ?? "Session ready"
         }
+    }
+
+    private func applyRuntimeInputLevel(_ rawLevel: Double, now: Date) {
+        let level = min(max(rawLevel, 0), 1)
+
+        guard level > 0 else {
+            if inputLevel != 0 {
+                inputLevel = 0
+            }
+            lastRuntimeLevelUpdateAt = now
+            return
+        }
+
+        let hasMeaningfulDelta = abs(inputLevel - level) >= Self.runtimeLevelMinDelta
+        let hasReachedCadence = now.timeIntervalSince(lastRuntimeLevelUpdateAt) >= Self.runtimeLevelMinUpdateInterval
+
+        guard hasMeaningfulDelta || hasReachedCadence else {
+            return
+        }
+
+        inputLevel = level
+        lastRuntimeLevelUpdateAt = now
     }
 
     private func apply(status: DictationStatus) {

--- a/MuesliKeyboard/KeyboardRootView.swift
+++ b/MuesliKeyboard/KeyboardRootView.swift
@@ -125,8 +125,9 @@ struct KeyboardRootView: View {
                     mode: controller.waveformMode,
                     color: activeStatusColor,
                     level: controller.waveformLevel,
-                    barCount: 32,
-                    spacing: 2.5
+                    barCount: 24,
+                    spacing: 2.5,
+                    framesPerSecond: 18
                 )
                 .frame(height: 68)
                 .shadow(color: activeStatusColor.opacity(0.36), radius: 12)
@@ -290,7 +291,7 @@ struct KeyboardRootView: View {
             return MuesliTheme.textTertiary
         }
 
-        return controller.stylesPrimaryButtonAsStop ? MuesliTheme.destructive : .white
+        return .white
     }
 
     private var primaryBackground: LinearGradient {
@@ -298,7 +299,7 @@ struct KeyboardRootView: View {
         if controller.isPrimaryButtonDisabled {
             colors = [MuesliTheme.surfacePrimary, MuesliTheme.surfacePrimary.opacity(0.78)]
         } else if controller.stylesPrimaryButtonAsStop {
-            colors = [MuesliTheme.destructive.opacity(0.22), MuesliTheme.destructive.opacity(0.12)]
+            colors = [MuesliTheme.destructive.opacity(0.82), MuesliTheme.destructive.opacity(0.62)]
         } else {
             colors = [Color(hex: 0x4F88FF), MuesliTheme.recording]
         }
@@ -308,7 +309,7 @@ struct KeyboardRootView: View {
 
     private var primaryBorder: Color {
         if controller.stylesPrimaryButtonAsStop {
-            return MuesliTheme.destructive.opacity(0.42)
+            return MuesliTheme.destructive.opacity(0.55)
         }
 
         return Color.white.opacity(0.18)
@@ -316,7 +317,7 @@ struct KeyboardRootView: View {
 
     private var primaryShadow: Color {
         if controller.stylesPrimaryButtonAsStop {
-            return MuesliTheme.destructive.opacity(0.12)
+            return MuesliTheme.destructive.opacity(0.22)
         }
 
         return MuesliTheme.recording.opacity(0.22)
@@ -370,7 +371,7 @@ private struct KeyboardIconLabel: View {
         Image(systemName: systemImage)
             .font(.system(size: 17, weight: .semibold))
             .foregroundStyle(MuesliTheme.textPrimary)
-            .frame(width: 44, height: 38)
+            .frame(width: 44, height: 44)
             .background(
                 RoundedRectangle(cornerRadius: 14, style: .continuous)
                     .fill(MuesliTheme.surfacePrimary.opacity(0.76))
@@ -430,7 +431,7 @@ private struct KeyboardTextKeyLabel: View {
         }
         .foregroundStyle(MuesliTheme.textPrimary)
         .frame(maxWidth: .infinity)
-        .frame(height: 42)
+        .frame(minHeight: 44)
         .contentShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
     }
 

--- a/Shared/MuesliTheme.swift
+++ b/Shared/MuesliTheme.swift
@@ -62,14 +62,15 @@ enum MuesliTheme {
     static let destructive = Color.adaptive(dark: 0xFF453A, light: 0xD70015)
     static var destructiveSubtle: Color { destructive.opacity(0.16) }
 
-    static func title1() -> Font { .system(size: 28, weight: .bold) }
-    static func title2() -> Font { .system(size: 22, weight: .semibold) }
-    static func title3() -> Font { .system(size: 18, weight: .semibold) }
-    static func headline() -> Font { .system(size: 15, weight: .semibold) }
-    static func body() -> Font { .system(size: 14, weight: .regular) }
-    static func callout() -> Font { .system(size: 13, weight: .regular) }
-    static func caption() -> Font { .system(size: 12, weight: .regular) }
-    static func captionMedium() -> Font { .system(size: 12, weight: .medium) }
+    static func title1() -> Font { .system(.title, design: .default, weight: .bold) }
+    static func title2() -> Font { .system(.title2, design: .default, weight: .semibold) }
+    static func title3() -> Font { .system(.headline, design: .default, weight: .semibold) }
+    static func headline() -> Font { .system(.callout, design: .default, weight: .semibold) }
+    static func body() -> Font { .system(.subheadline, design: .default, weight: .regular) }
+    static func transcript() -> Font { .system(.body, design: .default, weight: .regular) }
+    static func callout() -> Font { .system(.footnote, design: .default, weight: .regular) }
+    static func caption() -> Font { .system(.caption, design: .default, weight: .regular) }
+    static func captionMedium() -> Font { .system(.caption, design: .default, weight: .medium) }
 
     static let spacing4: CGFloat = 4
     static let spacing8: CGFloat = 8

--- a/Shared/MuesliWaveformView.swift
+++ b/Shared/MuesliWaveformView.swift
@@ -69,6 +69,7 @@ struct MuesliInlineWaveformView: View {
     var level: Double? = nil
     var barCount: Int = 24
     var spacing: CGFloat = 3
+    var framesPerSecond: Double = 24
 
     @State private var liveSamples: [CGFloat] = []
     @State private var sampleSequence = 0
@@ -81,9 +82,9 @@ struct MuesliInlineWaveformView: View {
     ]
 
     var body: some View {
-        TimelineView(.animation(minimumInterval: 1.0 / 30.0)) { timeline in
+        TimelineView(.animation(minimumInterval: 1.0 / max(framesPerSecond, 1.0))) { timeline in
             let elapsed = timeline.date.timeIntervalSinceReferenceDate
-            waveformBars(elapsed: elapsed)
+            waveformCanvas(elapsed: elapsed)
         }
         .onAppear {
             seedLiveSamplesIfNeeded()
@@ -96,28 +97,42 @@ struct MuesliInlineWaveformView: View {
         }
     }
 
-    private func waveformBars(elapsed: TimeInterval) -> some View {
+    private func waveformCanvas(elapsed: TimeInterval) -> some View {
         GeometryReader { geometry in
-            let count = max(48, barCount * 2)
-            let totalSpacing = spacing * CGFloat(count - 1)
-            let barWidth = max(2, min(5, (geometry.size.width - totalSpacing) / CGFloat(count)))
+            let count = sampleCount
             let samples = samplesForRender(count: count, elapsed: elapsed)
-            HStack(alignment: .center, spacing: spacing) {
-                ForEach(0..<count, id: \.self) { index in
+            Canvas { context, size in
+                let totalSpacing = spacing * CGFloat(count - 1)
+                let barWidth = max(2, min(5, (size.width - totalSpacing) / CGFloat(count)))
+                let xOffset = max((size.width - (barWidth * CGFloat(count) + totalSpacing)) / 2, 0)
+                let centerY = size.height / 2
+
+                for index in 0..<count {
                     let sample = samples[index]
-                    RoundedRectangle(cornerRadius: barWidth / 2, style: .continuous)
-                        .fill(color.opacity(mode == .waiting ? waitingOpacity(index: index, elapsed: elapsed) : 0.94))
-                        .frame(
-                            width: barWidth,
-                            height: barHeight(
-                                sample: sample,
-                                maxHeight: geometry.size.height
-                            )
-                        )
+                    let height = barHeight(sample: sample, maxHeight: size.height)
+                    let rect = CGRect(
+                        x: xOffset + CGFloat(index) * (barWidth + spacing),
+                        y: centerY - height / 2,
+                        width: barWidth,
+                        height: height
+                    )
+                    let path = Path(
+                        roundedRect: rect,
+                        cornerRadius: barWidth / 2,
+                        style: .continuous
+                    )
+                    context.fill(
+                        path,
+                        with: .color(color.opacity(mode == .waiting ? waitingOpacity(index: index, elapsed: elapsed) : 0.94))
+                    )
                 }
             }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .frame(width: geometry.size.width, height: geometry.size.height)
         }
+    }
+
+    private var sampleCount: Int {
+        max(12, barCount)
     }
 
     private func barHeight(sample: CGFloat, maxHeight: CGFloat) -> CGFloat {
@@ -151,7 +166,7 @@ struct MuesliInlineWaveformView: View {
             let base = basePattern[index % basePattern.count]
             let localPhase = CGFloat(elapsed) * 8.6 + CGFloat(index) * 0.58
             let broadPhase = CGFloat(elapsed) * 2.1 + CGFloat(index) * 0.13
-            let motion = 0.54 + 0.22 * sin(localPhase) + 0.12 * sin(broadPhase) + base * 0.22
+            let motion = 0.48 + 0.30 * sin(localPhase) + 0.16 * sin(broadPhase) + base * 0.35
             let texture = 0.90 + 0.12 * sin(localPhase * 1.47)
             let sample = shaped * motion * texture
             samples[index] = min(0.98, max(0.01, sample))
@@ -162,7 +177,7 @@ struct MuesliInlineWaveformView: View {
 
     private func paddedLiveSamples(count: Int) -> [CGFloat] {
         guard !liveSamples.isEmpty else {
-            return Array(repeating: 0.08, count: count)
+            return Array(repeating: 0, count: count)
         }
 
         let suffix = liveSamples.suffix(count)
@@ -170,7 +185,7 @@ struct MuesliInlineWaveformView: View {
             return Array(suffix)
         }
 
-        return Array(repeating: 0.08, count: count - suffix.count) + suffix
+        return Array(repeating: 0, count: count - suffix.count) + suffix
     }
 
     private func waitingSamples(count: Int, elapsed: TimeInterval) -> [CGFloat] {
@@ -189,8 +204,7 @@ struct MuesliInlineWaveformView: View {
     private func seedLiveSamplesIfNeeded(force: Bool = false) {
         guard force || liveSamples.isEmpty else { return }
 
-        let count = max(48, barCount * 2)
-        liveSamples = Array(repeating: 0, count: count)
+        liveSamples = Array(repeating: 0, count: sampleCount)
     }
 
     private func appendLiveSample(_ rawLevel: Double) {
@@ -201,7 +215,7 @@ struct MuesliInlineWaveformView: View {
         let shaped = pow(gatedLevel, 0.72)
         let texture = CGFloat(0.90 + 0.16 * sin(Double(sampleSequence) * 1.73))
         let sample = gatedLevel <= 0.02 ? 0 : min(0.98, max(0.01, shaped * 0.92 * texture))
-        let maxSamples = max(48, barCount * 2) * 3
+        let maxSamples = sampleCount * 3
 
         sampleSequence += 1
         liveSamples.append(sample)

--- a/Shared/MuesliWaveformView.swift
+++ b/Shared/MuesliWaveformView.swift
@@ -67,6 +67,7 @@ struct MuesliInlineWaveformView: View {
     var mode: MuesliFloatingWaveformMode
     var color: Color
     var level: Double? = nil
+    var isActive: Bool = true
     var barCount: Int = 24
     var spacing: CGFloat = 3
     var framesPerSecond: Double = 24
@@ -82,17 +83,28 @@ struct MuesliInlineWaveformView: View {
     ]
 
     var body: some View {
-        TimelineView(.animation(minimumInterval: 1.0 / max(framesPerSecond, 1.0))) { timeline in
-            let elapsed = timeline.date.timeIntervalSinceReferenceDate
-            waveformCanvas(elapsed: elapsed)
+        Group {
+            if isActive {
+                TimelineView(.animation(minimumInterval: 1.0 / max(framesPerSecond, 1.0))) { timeline in
+                    let elapsed = timeline.date.timeIntervalSinceReferenceDate
+                    waveformCanvas(elapsed: elapsed)
+                }
+            } else {
+                waveformCanvas(elapsed: 0)
+            }
         }
         .onAppear {
             seedLiveSamplesIfNeeded()
         }
         .onChange(of: level ?? 0) { _, newValue in
+            guard isActive else { return }
             appendLiveSample(newValue)
         }
         .onChange(of: mode) { _, _ in
+            seedLiveSamplesIfNeeded(force: true)
+        }
+        .onChange(of: isActive) { _, active in
+            guard active else { return }
             seedLiveSamplesIfNeeded(force: true)
         }
     }


### PR DESCRIPTION
## Summary
- Keep all pinned mobile tab pages mounted inside the paged TabView.
- Remove the Color.clear placeholder optimization that could leave the selected tab with no visible content after an interactive swipe.

## Root Cause
The paged TabView was dynamically pruning offscreen pages. During swipe transitions, SwiftUI could reconcile the active page to a placeholder while the custom tab bar still selected the destination, producing a blank content area.

## Validation
- Reproduced the blank page on simulator by swiping from Meetings back to Voice Notes.
- Verified Voice Notes -> Meetings -> Settings -> Meetings swipe transitions no longer blank.
- Ran simulator Debug build successfully.
- Built, installed, and launched the Debug build on connected Picophone.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli-ios/pr/13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785629603&installation_id=136549638&pr_number=13&repository=Muesli-HQ%2Fmuesli-ios&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli-ios%2Fpull%2F13&signature=65b74788f9fbcd9713ff0d8b43bd7983162bf947d388e67ebf2b1ad5581afe47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/muesli-hq/muesli-ios/pull/13" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added clearer “discard” controls for active dictation, onboarding test, and meeting recordings.
  * Improved appearance settings with a dedicated theme preview experience.
* **Bug Fixes**
  * Enhanced recording cancellation to reliably stop audio, clear temporary data, and reset audio/session state.
  * Onboarding test dictation can now be canceled safely without leaving stale recording/transcription state.
* **Style**
  * Refreshed waveform visuals and refined button sizing, destructive actions, and typography across dictation, meetings, onboarding, settings, and keyboard.
* **Performance**
  * Throttled runtime audio level updates and smoothed waveform animation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->