### PR TITLE
Improve keyboard session Live Activity handling

### DIFF
--- a/Muesli/AudioInputRouteManager.swift
+++ b/Muesli/AudioInputRouteManager.swift
@@ -61,7 +61,17 @@ enum AudioInputRouteManager {
             )
             try session.setActive(true)
         } catch {
-            throw AudioRecorder.RecordingError.audioSessionFailed(stage: stage, underlying: error)
+            do {
+                try? session.setActive(false, options: .notifyOthersOnDeactivation)
+                try session.setCategory(
+                    .playAndRecord,
+                    mode: .spokenAudio,
+                    options: recordingCategoryOptions
+                )
+                try session.setActive(true)
+            } catch {
+                throw AudioRecorder.RecordingError.audioSessionFailed(stage: stage, underlying: error)
+            }
         }
 
         let preferredInput = preferredInput(for: preference, in: session.availableInputs ?? [])

--- a/Muesli/AudioInputRouteManager.swift
+++ b/Muesli/AudioInputRouteManager.swift
@@ -90,28 +90,6 @@ enum AudioInputRouteManager {
         return snapshot
     }
 
-    static func configureForKeyboardKeepAlive(stage: String) throws -> AudioInputRouteSnapshot {
-        let session = AVAudioSession.sharedInstance()
-        do {
-            try session.setCategory(
-                .playAndRecord,
-                mode: .spokenAudio,
-                options: [.mixWithOthers]
-            )
-            try session.setActive(true)
-        } catch {
-            throw AudioRecorder.RecordingError.audioSessionFailed(stage: stage, underlying: error)
-        }
-
-        let builtInInput = (session.availableInputs ?? []).first(where: isBuiltInInput)
-        try? session.setPreferredInput(builtInInput)
-
-        #if DEBUG
-        print("Muesli audio route configured [\(stage)]: preference=\(RecordingMicrophonePreference.builtIn.rawValue)")
-        #endif
-        return currentSnapshot(preference: .builtIn)
-    }
-
     static func currentSnapshot(
         preference: RecordingMicrophonePreference = MuesliPreferences.recordingMicrophonePreference
     ) -> AudioInputRouteSnapshot {

--- a/Muesli/DictationCoordinator.swift
+++ b/Muesli/DictationCoordinator.swift
@@ -3058,8 +3058,13 @@ final class DictationCoordinator {
         let delay = Self.keyboardSessionRetryBaseDelaySeconds * pow(2, Double(retryAttempt - 1))
         keyboardSessionRetryTask?.cancel()
         keyboardSessionRetryTask = Task { @MainActor [weak self] in
-            try? await Task.sleep(for: .seconds(delay))
+            do {
+                try await Task.sleep(for: .seconds(delay))
+            } catch {
+                return
+            }
             guard let self,
+                  !Task.isCancelled,
                   MuesliPreferences.keyboardSessionModeEnabled,
                   !self.keyboardSessionKeeper.canAcceptStartCommand
             else { return }

--- a/Muesli/DictationCoordinator.swift
+++ b/Muesli/DictationCoordinator.swift
@@ -30,6 +30,7 @@ final class DictationCoordinator {
     private var commandPollingTask: Task<Void, Never>?
     private var keyboardRuntimePollingTask: Task<Void, Never>?
     private var keyboardSessionTimeoutTask: Task<Void, Never>?
+    private var keyboardSessionLiveActivityRequestIDs = Set<UUID>()
     private var iCloudSyncTask: Task<Void, Never>?
     private var iCloudSyncDebounceTask: Task<Void, Never>?
     private var lastKeyboardRuntimeLevelWriteAt = Date.distantPast
@@ -723,6 +724,22 @@ final class DictationCoordinator {
         if enabled {
             Task { await startKeyboardSessionMode() }
         } else {
+            guard isKeyboardSessionArmed || keyboardSessionActivitySession != nil || keyboardSessionKeeper.isRunning else {
+                if keyboardSessionStatusText == "Ready"
+                    || keyboardSessionStatusText == "Starting"
+                    || keyboardSessionStatusText == "Resuming"
+                    || keyboardSessionStatusText == "Recording"
+                    || keyboardSessionStatusText == "Timed out" {
+                    keyboardSessionStatusText = "Off"
+                }
+                saveKeyboardRuntimeStatus(
+                    isActive: false,
+                    activeRequestID: activeRequest?.id,
+                    phase: activeRequest == nil ? .idle : .recording,
+                    message: "Turned off"
+                )
+                return
+            }
             stopKeyboardSessionMode(reason: "Turned off")
         }
     }
@@ -777,8 +794,11 @@ final class DictationCoordinator {
             )
             AppTelemetry.signal("keyboard_session_started")
         } catch {
-            isKeyboardSessionArmed = false
-            UserDefaults.standard.set(false, forKey: MuesliPreferences.keyboardSessionModeKey)
+            let isRecoverable = isRecoverableKeyboardSessionError(error)
+            isKeyboardSessionArmed = isRecoverable
+            if !isRecoverable {
+                UserDefaults.standard.set(false, forKey: MuesliPreferences.keyboardSessionModeKey)
+            }
             keyboardSessionStatusText = error.localizedDescription
             saveKeyboardRuntimeStatus(
                 isActive: false,
@@ -791,11 +811,10 @@ final class DictationCoordinator {
     }
 
     func stopKeyboardSessionMode(reason: String = "Stopped") {
-        UserDefaults.standard.set(false, forKey: MuesliPreferences.keyboardSessionModeKey)
         keyboardSessionTimeoutTask?.cancel()
         keyboardSessionTimeoutTask = nil
         isKeyboardSessionArmed = false
-        keyboardSessionStatusText = "Off"
+        keyboardSessionStatusText = reason == "Timed out" ? "Timed out" : "Off"
         keyboardSessionKeeper.stop(deactivateSession: !isRecording)
         saveKeyboardRuntimeStatus(
             isActive: false,
@@ -816,6 +835,13 @@ final class DictationCoordinator {
         }
         keyboardSessionActivitySession = nil
         AppTelemetry.signal("keyboard_session_stopped", parameters: ["reason": reason])
+    }
+
+    private func isRecoverableKeyboardSessionError(_ error: Error) -> Bool {
+        if case AudioRecorder.RecordingError.microphonePermissionDenied = error {
+            return false
+        }
+        return true
     }
 
     private func refreshKeyboardSessionLiveActivity(phase: String, detail: String) {
@@ -839,6 +865,22 @@ final class DictationCoordinator {
                 detail: detail
             )
         }
+    }
+
+    private func setUsesKeyboardSessionLiveActivity(_ usesKeyboardSession: Bool, for requestID: UUID) {
+        if usesKeyboardSession {
+            keyboardSessionLiveActivityRequestIDs.insert(requestID)
+        } else {
+            keyboardSessionLiveActivityRequestIDs.remove(requestID)
+        }
+    }
+
+    private func usesKeyboardSessionLiveActivity(for requestID: UUID) -> Bool {
+        keyboardSessionLiveActivityRequestIDs.contains(requestID)
+    }
+
+    private func clearKeyboardSessionLiveActivityRoute(for requestID: UUID) {
+        keyboardSessionLiveActivityRequestIDs.remove(requestID)
     }
 
     func transcript(for session: RecordingSession) -> Transcript? {
@@ -1268,6 +1310,8 @@ final class DictationCoordinator {
             return
         }
         activeRequest = request
+        let usesKeyboardSessionLiveActivity = source == "keyboard" && isKeyboardSessionArmed
+        setUsesKeyboardSessionLiveActivity(usesKeyboardSessionLiveActivity, for: request.id)
         liveDictationTranscript = ""
         realtimeDictationCommittedText = ""
         clearKeyboardLiveTranscript()
@@ -1292,7 +1336,7 @@ final class DictationCoordinator {
                 session.startedAt = .now
                 try store.saveSession(session)
                 try await recorder.requestPermission()
-                if source == "keyboard", isKeyboardSessionArmed {
+                if usesKeyboardSessionLiveActivity {
                     keyboardSessionKeeper.stop(deactivateSession: false)
                     keyboardSessionStatusText = "Recording"
                 }
@@ -1317,7 +1361,7 @@ final class DictationCoordinator {
                         activeRequestID: request.id,
                         phase: .recording,
                         message: "Listening",
-                        supportsBackgroundStart: isKeyboardSessionArmed
+                        supportsBackgroundStart: usesKeyboardSessionLiveActivity || isKeyboardSessionArmed
                     )
                 }
                 startMetering { [weak self] level in
@@ -1335,7 +1379,7 @@ final class DictationCoordinator {
                 try store.saveRequest(request)
                 try store.saveStatus(.init(requestID: request.id, phase: .recording))
                 Task {
-                    if source == "keyboard", isKeyboardSessionArmed {
+                    if usesKeyboardSessionLiveActivity {
                         refreshKeyboardSessionLiveActivity(
                             phase: "Listening",
                             detail: "Keyboard voice note active"
@@ -1359,6 +1403,7 @@ final class DictationCoordinator {
                 stopRecordingTimer()
                 statusText = error.localizedDescription
                 clearKeyboardLiveTranscript()
+                clearKeyboardSessionLiveActivityRoute(for: request.id)
                 stopMetering()
                 resumeKeyboardSessionKeeperIfNeeded()
                 AppTelemetry.signal("dictation_failed", parameters: ["stage": "recording"])
@@ -1501,6 +1546,7 @@ final class DictationCoordinator {
             return
         }
 
+        let usesKeyboardSessionLiveActivity = usesKeyboardSessionLiveActivity(for: request.id)
         isRecording = false
         stopMetering()
         stopRecordingTimer()
@@ -1518,7 +1564,7 @@ final class DictationCoordinator {
                 activeRequestID: request.id,
                 phase: .transcribing,
                 message: "Transcribing",
-                supportsBackgroundStart: isKeyboardSessionArmed
+                supportsBackgroundStart: usesKeyboardSessionLiveActivity || isKeyboardSessionArmed
             )
         }
         if var session {
@@ -1527,7 +1573,7 @@ final class DictationCoordinator {
             try? store.saveSession(session)
             activeSession = session
             Task {
-                if isKeyboardHandoffActive, isKeyboardSessionArmed {
+                if usesKeyboardSessionLiveActivity {
                     refreshKeyboardSessionLiveActivity(
                         phase: "Transcribing",
                         detail: "Preparing text for the keyboard"
@@ -1598,9 +1644,10 @@ final class DictationCoordinator {
                             activeRequestID: nil,
                             phase: .idle,
                             message: isKeyboardSessionArmed ? "Keyboard session ready" : "Ready",
-                            supportsBackgroundStart: isKeyboardSessionArmed
+                            supportsBackgroundStart: usesKeyboardSessionLiveActivity || isKeyboardSessionArmed
                         )
                     }
+                    clearKeyboardSessionLiveActivityRoute(for: request.id)
                     try? store.clearPendingRequest()
                     try? store.saveStatus(.idle)
                     return
@@ -1657,7 +1704,7 @@ final class DictationCoordinator {
                         activeRequestID: nil,
                         phase: .idle,
                         message: isKeyboardSessionArmed ? "Keyboard session ready" : "Ready",
-                        supportsBackgroundStart: isKeyboardSessionArmed
+                        supportsBackgroundStart: usesKeyboardSessionLiveActivity || isKeyboardSessionArmed
                     )
                 }
                 isKeyboardHandoffActive = false
@@ -1666,7 +1713,7 @@ final class DictationCoordinator {
                 liveDictationTranscript = ""
                 realtimeDictationCommittedText = ""
                 if let completedSession = try? store.recordingSession(requestID: request.id) {
-                    if startedFromKeyboard, isKeyboardSessionArmed {
+                    if startedFromKeyboard, usesKeyboardSessionLiveActivity {
                         refreshKeyboardSessionLiveActivity(
                             phase: "Ready",
                             detail: "Keyboard voice note session active"
@@ -1682,6 +1729,7 @@ final class DictationCoordinator {
                         }
                     }
                 }
+                clearKeyboardSessionLiveActivityRoute(for: request.id)
                 AppTelemetry.signal(
                     "dictation_completed",
                     parameters: [
@@ -1699,14 +1747,15 @@ final class DictationCoordinator {
                 activeRequest = nil
                 activeSession = nil
                 saveKeyboardRuntimeStatus(
-                    isActive: isKeyboardHandoffActive || isKeyboardSessionArmed,
+                    isActive: isKeyboardHandoffActive || usesKeyboardSessionLiveActivity || isKeyboardSessionArmed,
                     activeRequestID: nil,
                     phase: .failed,
                     message: error.localizedDescription,
-                    supportsBackgroundStart: isKeyboardSessionArmed
+                    supportsBackgroundStart: usesKeyboardSessionLiveActivity || isKeyboardSessionArmed
                 )
                 isKeyboardHandoffActive = false
                 resumeKeyboardSessionKeeperIfNeeded()
+                clearKeyboardSessionLiveActivityRoute(for: request.id)
                 realtimeDictationRecorder?.cancel()
                 realtimeDictationRecorder = nil
                 realtimeDictationBufferPipe?.finish()
@@ -2574,7 +2623,7 @@ final class DictationCoordinator {
             activeRequestID: requestID,
             phase: .recording,
             message: "Listening",
-            supportsBackgroundStart: isKeyboardSessionArmed,
+            supportsBackgroundStart: usesKeyboardSessionLiveActivity(for: requestID) || isKeyboardSessionArmed,
             inputLevel: level
         )
     }
@@ -2620,6 +2669,10 @@ final class DictationCoordinator {
         keyboardSessionTimeoutTask = Task { @MainActor [weak self] in
             try? await Task.sleep(for: .seconds(timeoutMinutes * 60))
             guard let self, self.isKeyboardSessionArmed else { return }
+            guard !self.isRecording, !self.isMeetingRecording else {
+                self.scheduleKeyboardSessionTimeout()
+                return
+            }
             self.stopKeyboardSessionMode(reason: "Timed out")
         }
     }
@@ -2649,8 +2702,11 @@ final class DictationCoordinator {
                     )
                 }
             } catch {
-                self.isKeyboardSessionArmed = false
-                UserDefaults.standard.set(false, forKey: MuesliPreferences.keyboardSessionModeKey)
+                let isRecoverable = self.isRecoverableKeyboardSessionError(error)
+                self.isKeyboardSessionArmed = isRecoverable
+                if !isRecoverable {
+                    UserDefaults.standard.set(false, forKey: MuesliPreferences.keyboardSessionModeKey)
+                }
                 self.keyboardSessionStatusText = error.localizedDescription
                 self.saveKeyboardRuntimeStatus(
                     isActive: false,
@@ -2682,6 +2738,7 @@ final class DictationCoordinator {
             if let pendingRequest = try? store.pendingRequest(), pendingRequest.id == requestID {
                 try? store.clearPendingRequest()
             }
+            clearKeyboardSessionLiveActivityRoute(for: requestID)
             if activeRequest == nil {
                 try? store.saveStatus(.idle)
                 saveKeyboardRuntimeStatus(
@@ -2696,6 +2753,7 @@ final class DictationCoordinator {
             return
         }
         isRecording = false
+        let usesKeyboardSessionLiveActivity = usesKeyboardSessionLiveActivity(for: requestID)
         stopMetering()
         stopRecordingTimer()
         stopCommandPolling()
@@ -2709,7 +2767,7 @@ final class DictationCoordinator {
             if let index = recordingSessions.firstIndex(where: { $0.id == session.id }) {
                 recordingSessions[index] = session
             }
-            if isKeyboardHandoffActive, isKeyboardSessionArmed {
+            if usesKeyboardSessionLiveActivity {
                 refreshKeyboardSessionLiveActivity(
                     phase: "Ready",
                     detail: "Keyboard voice note session active"
@@ -2724,6 +2782,7 @@ final class DictationCoordinator {
                 }
             }
         }
+        clearKeyboardSessionLiveActivityRoute(for: requestID)
         activeRequest = nil
         activeSession = nil
         resumeKeyboardSessionKeeperIfNeeded()

--- a/Muesli/DictationCoordinator.swift
+++ b/Muesli/DictationCoordinator.swift
@@ -778,6 +778,7 @@ final class DictationCoordinator {
             AppTelemetry.signal("keyboard_session_started")
         } catch {
             isKeyboardSessionArmed = false
+            UserDefaults.standard.set(false, forKey: MuesliPreferences.keyboardSessionModeKey)
             keyboardSessionStatusText = error.localizedDescription
             saveKeyboardRuntimeStatus(
                 isActive: false,
@@ -790,6 +791,7 @@ final class DictationCoordinator {
     }
 
     func stopKeyboardSessionMode(reason: String = "Stopped") {
+        UserDefaults.standard.set(false, forKey: MuesliPreferences.keyboardSessionModeKey)
         keyboardSessionTimeoutTask?.cancel()
         keyboardSessionTimeoutTask = nil
         isKeyboardSessionArmed = false
@@ -814,6 +816,29 @@ final class DictationCoordinator {
         }
         keyboardSessionActivitySession = nil
         AppTelemetry.signal("keyboard_session_stopped", parameters: ["reason": reason])
+    }
+
+    private func refreshKeyboardSessionLiveActivity(phase: String, detail: String) {
+        guard isKeyboardSessionArmed else { return }
+
+        if keyboardSessionActivitySession == nil {
+            keyboardSessionActivitySession = RecordingSession(
+                kind: .keyboardDictation,
+                title: "Keyboard Session",
+                startedAt: .now,
+                phase: .recording
+            )
+        }
+
+        guard let session = keyboardSessionActivitySession else { return }
+        Task {
+            await liveActivityController.start(
+                session: session,
+                requestID: nil,
+                phase: phase,
+                detail: detail
+            )
+        }
     }
 
     func transcript(for session: RecordingSession) -> Transcript? {
@@ -1310,12 +1335,19 @@ final class DictationCoordinator {
                 try store.saveRequest(request)
                 try store.saveStatus(.init(requestID: request.id, phase: .recording))
                 Task {
-                    await liveActivityController.start(
-                        session: session,
-                        requestID: request.id,
-                        phase: "Listening",
-                        detail: source == "keyboard" ? "Keyboard voice note active" : "Recording voice note"
-                    )
+                    if source == "keyboard", isKeyboardSessionArmed {
+                        refreshKeyboardSessionLiveActivity(
+                            phase: "Listening",
+                            detail: "Keyboard voice note active"
+                        )
+                    } else {
+                        await liveActivityController.start(
+                            session: session,
+                            requestID: request.id,
+                            phase: "Listening",
+                            detail: "Recording voice note"
+                        )
+                    }
                 }
             } catch {
                 session.phase = .failed
@@ -1495,11 +1527,18 @@ final class DictationCoordinator {
             try? store.saveSession(session)
             activeSession = session
             Task {
-                await liveActivityController.update(
-                    phase: "Transcribing",
-                    detail: "Preparing text for the keyboard",
-                    session: session
-                )
+                if isKeyboardHandoffActive, isKeyboardSessionArmed {
+                    refreshKeyboardSessionLiveActivity(
+                        phase: "Transcribing",
+                        detail: "Preparing text for the keyboard"
+                    )
+                } else {
+                    await liveActivityController.update(
+                        phase: "Transcribing",
+                        detail: "Preparing text for the keyboard",
+                        session: session
+                    )
+                }
             }
         }
 
@@ -1627,13 +1666,20 @@ final class DictationCoordinator {
                 liveDictationTranscript = ""
                 realtimeDictationCommittedText = ""
                 if let completedSession = try? store.recordingSession(requestID: request.id) {
-                    Task {
-                        await liveActivityController.end(
-                            phase: "Completed",
-                            detail: "Transcript saved",
-                            session: completedSession,
-                            dismissal: .immediate
+                    if startedFromKeyboard, isKeyboardSessionArmed {
+                        refreshKeyboardSessionLiveActivity(
+                            phase: "Ready",
+                            detail: "Keyboard voice note session active"
                         )
+                    } else {
+                        Task {
+                            await liveActivityController.end(
+                                phase: "Completed",
+                                detail: "Transcript saved",
+                                session: completedSession,
+                                dismissal: .immediate
+                            )
+                        }
                     }
                 }
                 AppTelemetry.signal(
@@ -2604,6 +2650,7 @@ final class DictationCoordinator {
                 }
             } catch {
                 self.isKeyboardSessionArmed = false
+                UserDefaults.standard.set(false, forKey: MuesliPreferences.keyboardSessionModeKey)
                 self.keyboardSessionStatusText = error.localizedDescription
                 self.saveKeyboardRuntimeStatus(
                     isActive: false,
@@ -2662,12 +2709,19 @@ final class DictationCoordinator {
             if let index = recordingSessions.firstIndex(where: { $0.id == session.id }) {
                 recordingSessions[index] = session
             }
-            Task {
-                await liveActivityController.end(
-                    phase: "Cancelled",
-                    detail: "Recording cancelled",
-                    session: session
+            if isKeyboardHandoffActive, isKeyboardSessionArmed {
+                refreshKeyboardSessionLiveActivity(
+                    phase: "Ready",
+                    detail: "Keyboard voice note session active"
                 )
+            } else {
+                Task {
+                    await liveActivityController.end(
+                        phase: "Cancelled",
+                        detail: "Recording cancelled",
+                        session: session
+                    )
+                }
             }
         }
         activeRequest = nil

--- a/Muesli/DictationCoordinator.swift
+++ b/Muesli/DictationCoordinator.swift
@@ -4,6 +4,117 @@ import Foundation
 import Observation
 import UIKit
 
+private struct KeyboardSessionState: Equatable {
+    enum Phase: Equatable {
+        case off
+        case arming
+        case ready
+        case handoff(UUID)
+        case recording(UUID)
+        case transcribing(UUID)
+        case retrying(String)
+        case failed(String)
+        case timedOut
+    }
+
+    var phase: Phase = .off
+    var sessionAvailable = false
+
+    var isArmed: Bool {
+        switch phase {
+        case .ready, .handoff, .recording, .transcribing, .arming:
+            sessionAvailable
+        case .off, .retrying, .failed, .timedOut:
+            false
+        }
+    }
+
+    var isKeyboardHandoffActive: Bool {
+        switch phase {
+        case .handoff, .recording, .transcribing:
+            true
+        case .off, .arming, .ready, .retrying, .failed, .timedOut:
+            false
+        }
+    }
+
+    var isWorkflowActive: Bool {
+        switch phase {
+        case .handoff, .recording, .transcribing, .arming:
+            true
+        case .off, .ready, .retrying, .failed, .timedOut:
+            false
+        }
+    }
+
+    var statusText: String {
+        switch phase {
+        case .off:
+            "Off"
+        case .arming:
+            "Starting"
+        case .ready:
+            "Ready"
+        case .handoff:
+            "Starting"
+        case .recording:
+            "Recording"
+        case .transcribing:
+            "Transcribing"
+        case .retrying(let message):
+            message
+        case .failed(let message):
+            message
+        case .timedOut:
+            "Timed out"
+        }
+    }
+}
+
+private enum KeyboardSessionEvent {
+    case startRequested
+    case startSucceeded
+    case startFailed(message: String, recoverable: Bool)
+    case retryScheduled(message: String)
+    case resumeRequested
+    case handoffStarted(UUID)
+    case recordingStarted(UUID)
+    case transcribing(UUID)
+    case requestFinished
+    case stop(reason: String)
+}
+
+private enum KeyboardSessionReducer {
+    static func reduce(_ state: KeyboardSessionState, event: KeyboardSessionEvent) -> KeyboardSessionState {
+        switch event {
+        case .startRequested:
+            return KeyboardSessionState(phase: .arming)
+        case .startSucceeded:
+            return KeyboardSessionState(phase: .ready, sessionAvailable: true)
+        case .startFailed(let message, let recoverable):
+            return KeyboardSessionState(phase: recoverable ? .retrying(message) : .failed(message))
+        case .retryScheduled(let message):
+            return KeyboardSessionState(phase: .retrying(message))
+        case .resumeRequested:
+            guard state.isArmed else { return state }
+            return KeyboardSessionState(phase: .arming, sessionAvailable: true)
+        case .handoffStarted(let requestID):
+            return KeyboardSessionState(phase: .handoff(requestID), sessionAvailable: state.sessionAvailable)
+        case .recordingStarted(let requestID):
+            return KeyboardSessionState(phase: .recording(requestID), sessionAvailable: state.sessionAvailable)
+        case .transcribing(let requestID):
+            return KeyboardSessionState(phase: .transcribing(requestID), sessionAvailable: state.sessionAvailable)
+        case .requestFinished:
+            return KeyboardSessionState(
+                phase: state.sessionAvailable ? .ready : .off,
+                sessionAvailable: state.sessionAvailable
+            )
+        case .stop(let reason):
+            return KeyboardSessionState(phase: reason == "Timed out" ? .timedOut : .off)
+        }
+    }
+}
+
 @MainActor
 @Observable
 final class DictationCoordinator {
@@ -48,9 +159,10 @@ final class DictationCoordinator {
     private var activeRequest: DictationRequest?
     private var activeSession: RecordingSession?
     private var keyboardSessionActivitySession: RecordingSession?
-    var isKeyboardHandoffActive = false
-    var isKeyboardSessionArmed = false
-    var keyboardSessionStatusText = "Off"
+    private var keyboardSessionState = KeyboardSessionState()
+    var isKeyboardHandoffActive: Bool { keyboardSessionState.isKeyboardHandoffActive }
+    var isKeyboardSessionArmed: Bool { keyboardSessionState.isArmed }
+    var keyboardSessionStatusText: String { keyboardSessionState.statusText }
     var iCloudSyncStatusText: String?
     var isICloudSyncInProgress = false
     var settingsNavigationRequestID: UUID?
@@ -175,6 +287,10 @@ final class DictationCoordinator {
         audioInputRouteText = AudioInputRouteManager.currentSnapshot().displayText
     }
 
+    private func transitionKeyboardSession(_ event: KeyboardSessionEvent) {
+        keyboardSessionState = KeyboardSessionReducer.reduce(keyboardSessionState, event: event)
+    }
+
     func handleOpenURL(_ url: URL) {
         #if DEBUG
         if handleDebugURL(url) {
@@ -219,7 +335,7 @@ final class DictationCoordinator {
         if recoverKeyboardRequestIfNeeded(request) {
             return
         }
-        isKeyboardHandoffActive = true
+        transitionKeyboardSession(.handoffStarted(request.id))
         activeRequest = request
         startKeyboardRuntimePolling()
         startRecording(for: request, source: "keyboard")
@@ -241,10 +357,11 @@ final class DictationCoordinator {
     private func refreshActiveKeyboardRequestIfNeeded(_ request: DictationRequest) -> Bool {
         guard activeRequest?.id == request.id else { return false }
 
-        isKeyboardHandoffActive = true
+        transitionKeyboardSession(.handoffStarted(request.id))
         startKeyboardRuntimePolling()
 
         if isRecording {
+            transitionKeyboardSession(.recordingStarted(request.id))
             saveKeyboardHandoff(
                 requestID: request.id,
                 phase: .recordingStarted,
@@ -261,6 +378,7 @@ final class DictationCoordinator {
         }
 
         if statusText == "Transcribing" || activeSession?.requestID == request.id {
+            transitionKeyboardSession(.transcribing(request.id))
             try? store.saveStatus(.init(
                 requestID: request.id,
                 phase: .transcribing,
@@ -318,7 +436,7 @@ final class DictationCoordinator {
             return true
         }
 
-        isKeyboardHandoffActive = true
+        transitionKeyboardSession(.transcribing(request.id))
         activeRequest = request
         activeSession = session
         statusText = "Transcribing"
@@ -380,7 +498,7 @@ final class DictationCoordinator {
         userName = "UI Tests"
         selectedUseCase = .everything
         selectedTranscriptionModel = .defaultModel
-        isKeyboardHandoffActive = false
+        transitionKeyboardSession(.stop(reason: "Off"))
         UserDefaults.standard.set(true, forKey: Self.onboardingCompletedKey)
         UserDefaults.standard.set(userName, forKey: Self.userNameKey)
         UserDefaults.standard.set(selectedUseCase.rawValue, forKey: Self.useCaseKey)
@@ -728,13 +846,7 @@ final class DictationCoordinator {
             guard isKeyboardSessionArmed || keyboardSessionActivitySession != nil || keyboardSessionKeeper.isRunning else {
                 keyboardSessionRetryTask?.cancel()
                 keyboardSessionRetryTask = nil
-                if keyboardSessionStatusText == "Ready"
-                    || keyboardSessionStatusText == "Starting"
-                    || keyboardSessionStatusText == "Resuming"
-                    || keyboardSessionStatusText == "Recording"
-                    || keyboardSessionStatusText == "Timed out" {
-                    keyboardSessionStatusText = "Off"
-                }
+                transitionKeyboardSession(.stop(reason: "Turned off"))
                 saveKeyboardRuntimeStatus(
                     isActive: false,
                     activeRequestID: activeRequest?.id,
@@ -765,15 +877,13 @@ final class DictationCoordinator {
             return
         }
 
-        keyboardSessionStatusText = "Starting"
+        transitionKeyboardSession(.startRequested)
         do {
             try await keyboardSessionKeeper.start()
             keyboardSessionRetryTask?.cancel()
             keyboardSessionRetryTask = nil
-            isKeyboardSessionArmed = true
             prewarmModelIfNeeded(reason: "keyboard_session")
-            keyboardSessionStatusText = "Ready"
-            isKeyboardHandoffActive = false
+            transitionKeyboardSession(.startSucceeded)
             startKeyboardRuntimePolling()
             scheduleKeyboardSessionTimeout()
 
@@ -800,13 +910,13 @@ final class DictationCoordinator {
             AppTelemetry.signal("keyboard_session_started")
         } catch {
             let isRecoverable = isRecoverableKeyboardSessionError(error)
-            isKeyboardSessionArmed = false
             if isRecoverable {
+                transitionKeyboardSession(.retryScheduled(message: error.localizedDescription))
                 scheduleKeyboardSessionRetry()
             } else {
+                transitionKeyboardSession(.startFailed(message: error.localizedDescription, recoverable: false))
                 UserDefaults.standard.set(false, forKey: MuesliPreferences.keyboardSessionModeKey)
             }
-            keyboardSessionStatusText = error.localizedDescription
             saveKeyboardRuntimeStatus(
                 isActive: false,
                 activeRequestID: nil,
@@ -822,8 +932,7 @@ final class DictationCoordinator {
         keyboardSessionTimeoutTask = nil
         keyboardSessionRetryTask?.cancel()
         keyboardSessionRetryTask = nil
-        isKeyboardSessionArmed = false
-        keyboardSessionStatusText = reason == "Timed out" ? "Timed out" : "Off"
+        transitionKeyboardSession(.stop(reason: reason))
         keyboardSessionKeeper.stop(deactivateSession: !isRecording)
         saveKeyboardRuntimeStatus(
             isActive: false,
@@ -854,7 +963,7 @@ final class DictationCoordinator {
     }
 
     private func refreshKeyboardSessionLiveActivity(phase: String, detail: String) {
-        guard isKeyboardSessionArmed else { return }
+        guard isKeyboardSessionArmed || keyboardSessionActivitySession != nil else { return }
 
         if keyboardSessionActivitySession == nil {
             keyboardSessionActivitySession = RecordingSession(
@@ -1347,7 +1456,7 @@ final class DictationCoordinator {
                 try await recorder.requestPermission()
                 if usesKeyboardSessionLiveActivity {
                     keyboardSessionKeeper.stop(deactivateSession: false)
-                    keyboardSessionStatusText = "Recording"
+                    transitionKeyboardSession(.recordingStarted(request.id))
                 }
                 if selectedTranscriptionModel.supportsRealtimeStreaming {
                     try await startRealtimeDictationRecorder(audioURL: audioURL, sessionID: session.id)
@@ -1357,6 +1466,9 @@ final class DictationCoordinator {
                 refreshAudioInputRoute()
                 activeSession = session
                 isRecording = true
+                if source == "keyboard", !usesKeyboardSessionLiveActivity {
+                    transitionKeyboardSession(.recordingStarted(request.id))
+                }
                 startRecordingTimer(startedAt: session.startedAt ?? .now)
                 if source == "keyboard" {
                     saveKeyboardHandoff(
@@ -1481,7 +1593,7 @@ final class DictationCoordinator {
                 try store.clearPendingRequest()
                 activeRequest = nil
                 activeSession = nil
-                isKeyboardHandoffActive = false
+                transitionKeyboardSession(.requestFinished)
                 statusText = "Ready"
                 refreshHistory()
                 saveKeyboardRuntimeStatus(
@@ -1517,7 +1629,7 @@ final class DictationCoordinator {
                 )
                 activeRequest = nil
                 activeSession = nil
-                isKeyboardHandoffActive = false
+                transitionKeyboardSession(.requestFinished)
                 statusText = error.localizedDescription
                 saveKeyboardRuntimeStatus(
                     isActive: isKeyboardSessionArmed,
@@ -1561,6 +1673,9 @@ final class DictationCoordinator {
         stopRecordingTimer()
         stopCommandPolling()
         statusText = "Transcribing"
+        if isKeyboardHandoffActive {
+            transitionKeyboardSession(.transcribing(request.id))
+        }
         try? store.saveStatus(.init(requestID: request.id, phase: .transcribing, message: "Transcribing"))
         if isKeyboardHandoffActive {
             saveKeyboardHandoff(
@@ -1663,7 +1778,7 @@ final class DictationCoordinator {
                 }
                 if isKeyboardSessionArmed {
                     try? await keyboardSessionKeeper.start()
-                    keyboardSessionStatusText = "Transcribing"
+                    transitionKeyboardSession(.transcribing(request.id))
                 }
                 let completedSession = activeSession ?? session
                 let transcript: Transcript?
@@ -1716,7 +1831,7 @@ final class DictationCoordinator {
                         supportsBackgroundStart: usesKeyboardSessionLiveActivity || isKeyboardSessionArmed
                     )
                 }
-                isKeyboardHandoffActive = false
+                transitionKeyboardSession(.requestFinished)
                 resumeKeyboardSessionKeeperIfNeeded()
                 statusText = "Ready"
                 liveDictationTranscript = ""
@@ -1766,7 +1881,7 @@ final class DictationCoordinator {
                         detail: "Keyboard voice note failed. Session active"
                     )
                 }
-                isKeyboardHandoffActive = false
+                transitionKeyboardSession(.requestFinished)
                 resumeKeyboardSessionKeeperIfNeeded()
                 clearKeyboardSessionLiveActivityRoute(for: request.id)
                 realtimeDictationRecorder?.cancel()
@@ -2569,7 +2684,7 @@ final class DictationCoordinator {
                         continue
                     }
 
-                    self.isKeyboardHandoffActive = true
+                    self.transitionKeyboardSession(.handoffStarted(request.id))
                     self.activeRequest = request
                     self.startRecording(for: request, source: "keyboard")
                 }
@@ -2682,7 +2797,11 @@ final class DictationCoordinator {
         keyboardSessionTimeoutTask = Task { @MainActor [weak self] in
             try? await Task.sleep(for: .seconds(timeoutMinutes * 60))
             guard let self, self.isKeyboardSessionArmed else { return }
-            guard !self.isRecording, !self.isMeetingRecording else {
+            guard !self.keyboardSessionState.isWorkflowActive,
+                  !self.isRecording,
+                  !self.isMeetingRecording,
+                  self.activeRequest == nil
+            else {
                 self.scheduleKeyboardSessionTimeout()
                 return
             }
@@ -2697,6 +2816,7 @@ final class DictationCoordinator {
             guard let self,
                   MuesliPreferences.keyboardSessionModeEnabled,
                   !self.isKeyboardSessionArmed,
+                  !self.keyboardSessionState.isWorkflowActive,
                   !self.isRecording,
                   !self.isMeetingRecording
             else { return }
@@ -2707,14 +2827,14 @@ final class DictationCoordinator {
 
     private func resumeKeyboardSessionKeeperIfNeeded() {
         guard isKeyboardSessionArmed, !isRecording, !isMeetingRecording else { return }
-        keyboardSessionStatusText = "Resuming"
+        transitionKeyboardSession(.resumeRequested)
         Task { @MainActor [weak self] in
             guard let self, self.isKeyboardSessionArmed else { return }
             do {
                 try await self.keyboardSessionKeeper.start()
                 self.keyboardSessionRetryTask?.cancel()
                 self.keyboardSessionRetryTask = nil
-                self.keyboardSessionStatusText = "Ready"
+                self.transitionKeyboardSession(.startSucceeded)
                 self.scheduleKeyboardSessionTimeout()
                 self.saveKeyboardRuntimeStatus(
                     isActive: true,
@@ -2733,13 +2853,13 @@ final class DictationCoordinator {
                 }
             } catch {
                 let isRecoverable = self.isRecoverableKeyboardSessionError(error)
-                self.isKeyboardSessionArmed = false
                 if isRecoverable {
+                    self.transitionKeyboardSession(.retryScheduled(message: error.localizedDescription))
                     self.scheduleKeyboardSessionRetry()
                 } else {
+                    self.transitionKeyboardSession(.startFailed(message: error.localizedDescription, recoverable: false))
                     UserDefaults.standard.set(false, forKey: MuesliPreferences.keyboardSessionModeKey)
                 }
-                self.keyboardSessionStatusText = error.localizedDescription
                 self.saveKeyboardRuntimeStatus(
                     isActive: false,
                     activeRequestID: nil,
@@ -2825,7 +2945,7 @@ final class DictationCoordinator {
             message: isKeyboardSessionArmed ? "Keyboard session ready" : "Ready",
             supportsBackgroundStart: isKeyboardSessionArmed
         )
-        isKeyboardHandoffActive = false
+        transitionKeyboardSession(.requestFinished)
         statusText = "Ready"
         try? store.clearPendingCommand()
         try? store.clearPendingRequest()

--- a/Muesli/DictationCoordinator.swift
+++ b/Muesli/DictationCoordinator.swift
@@ -160,6 +160,7 @@ final class DictationCoordinator {
     private var recordingTimerTask: Task<Void, Never>?
     private var commandPollingTask: Task<Void, Never>?
     private var keyboardRuntimePollingTask: Task<Void, Never>?
+    private var keyboardRuntimeTickInProgress = false
     private var keyboardSessionTimeoutTask: Task<Void, Never>?
     private var keyboardSessionRetryTask: Task<Void, Never>?
     private var keyboardSessionRetryAttempt = 0
@@ -183,6 +184,16 @@ final class DictationCoordinator {
     private var keyboardSessionState = KeyboardSessionState()
     var isKeyboardHandoffActive: Bool { keyboardSessionState.isKeyboardHandoffActive }
     var isKeyboardSessionArmed: Bool { keyboardSessionState.isArmed }
+    private var isKeyboardHotMicEngineReady: Bool {
+        isKeyboardSessionArmed && keyboardSessionKeeper.canAcceptStartCommand
+    }
+    private var canStartKeyboardRequestsInBackground: Bool {
+        isKeyboardHotMicEngineReady
+            && !isRecording
+            && !isMeetingRecording
+            && activeRequest == nil
+            && statusText != "Transcribing"
+    }
     var keyboardSessionStatusText: String { keyboardSessionState.statusText }
     var iCloudSyncStatusText: String?
     var isICloudSyncInProgress = false
@@ -287,9 +298,15 @@ final class DictationCoordinator {
                 self?.refreshAudioInputRoute()
             }
         }
+        keyboardSessionKeeper.setInputActivityHandler { [weak self] powerDB, isCapturing in
+            Task { @MainActor in
+                await self?.handleKeyboardSessionInputActivity(powerDB: powerDB, isCapturing: isCapturing)
+            }
+        }
 
         refreshAudioInputRoute()
         refreshHistory()
+        saveKeyboardSessionPreference(isEnabled: MuesliPreferences.keyboardSessionModeEnabled)
         Task {
             await liveActivityController.endAllActivities(
                 detail: "Recovered from interrupted session"
@@ -398,7 +415,7 @@ final class DictationCoordinator {
                 activeRequestID: request.id,
                 phase: .recording,
                 message: "Listening",
-                supportsBackgroundStart: isKeyboardSessionArmed
+                supportsBackgroundStart: canStartKeyboardRequestsInBackground
             )
             return true
         }
@@ -420,7 +437,7 @@ final class DictationCoordinator {
                 activeRequestID: request.id,
                 phase: .transcribing,
                 message: "Transcribing",
-                supportsBackgroundStart: isKeyboardSessionArmed
+                supportsBackgroundStart: canStartKeyboardRequestsInBackground
             )
             return true
         }
@@ -435,7 +452,7 @@ final class DictationCoordinator {
             activeRequestID: request.id,
             phase: .requested,
             message: "Starting",
-            supportsBackgroundStart: isKeyboardSessionArmed
+            supportsBackgroundStart: canStartKeyboardRequestsInBackground
         )
         return true
     }
@@ -477,7 +494,7 @@ final class DictationCoordinator {
             activeRequestID: request.id,
             phase: .transcribing,
             message: "Recovering transcription",
-            supportsBackgroundStart: isKeyboardSessionArmed
+            supportsBackgroundStart: canStartKeyboardRequestsInBackground
         )
         recoverKeyboardTranscription(request: request, session: session, audioURL: audioURL)
         return true
@@ -866,6 +883,7 @@ final class DictationCoordinator {
 
     func setKeyboardSessionModeEnabled(_ enabled: Bool) {
         UserDefaults.standard.set(enabled, forKey: MuesliPreferences.keyboardSessionModeKey)
+        saveKeyboardSessionPreference(isEnabled: enabled)
         if enabled {
             Task { await startKeyboardSessionMode() }
         } else {
@@ -887,19 +905,23 @@ final class DictationCoordinator {
     }
 
     func refreshKeyboardSessionTimeout() {
-        guard isKeyboardSessionArmed else { return }
-        scheduleKeyboardSessionTimeout()
+        keyboardSessionTimeoutTask?.cancel()
+        keyboardSessionTimeoutTask = nil
     }
 
     func startKeyboardSessionMode() async {
         guard !isKeyboardSessionArmed else {
             prewarmModelIfNeeded(reason: "keyboard_session")
+            if !isRecording, !isMeetingRecording, activeRequest == nil {
+                _ = await ensureKeyboardSessionKeeperRunning(publishReady: true)
+            }
+            let isReady = canStartKeyboardRequestsInBackground
             saveKeyboardRuntimeStatus(
-                isActive: true,
+                isActive: isKeyboardHotMicEngineReady || isRecording || activeRequest != nil,
                 activeRequestID: activeRequest?.id,
                 phase: isRecording ? .recording : .idle,
-                message: isRecording ? "Listening" : "Keyboard session ready",
-                supportsBackgroundStart: true
+                message: isRecording ? "Listening" : (isReady ? "Keyboard session ready" : "Mic session warming up"),
+                supportsBackgroundStart: isReady
             )
             return
         }
@@ -907,13 +929,15 @@ final class DictationCoordinator {
         transitionKeyboardSession(.startRequested)
         do {
             try await keyboardSessionKeeper.start()
+            guard await keyboardSessionKeeper.waitUntilCanAcceptStartCommand() else {
+                throw AudioRecorder.RecordingError.startFailed(stage: "keyboard session input")
+            }
             keyboardSessionRetryTask?.cancel()
             keyboardSessionRetryTask = nil
             keyboardSessionRetryAttempt = 0
             prewarmModelIfNeeded(reason: "keyboard_session")
             transitionKeyboardSession(.startSucceeded)
             startKeyboardRuntimePolling()
-            scheduleKeyboardSessionTimeout()
 
             let session = RecordingSession(
                 kind: .keyboardDictation,
@@ -944,7 +968,6 @@ final class DictationCoordinator {
             } else {
                 keyboardSessionRetryAttempt = 0
                 transitionKeyboardSession(.startFailed(message: error.localizedDescription, recoverable: false))
-                UserDefaults.standard.set(false, forKey: MuesliPreferences.keyboardSessionModeKey)
             }
             saveKeyboardRuntimeStatus(
                 isActive: false,
@@ -983,6 +1006,10 @@ final class DictationCoordinator {
         }
         keyboardSessionActivitySession = nil
         AppTelemetry.signal("keyboard_session_stopped", parameters: ["reason": reason.message])
+    }
+
+    private func saveKeyboardSessionPreference(isEnabled: Bool) {
+        try? store.saveKeyboardSessionPreference(.init(isEnabled: isEnabled))
     }
 
     private func isRecoverableKeyboardSessionError(_ error: Error) -> Bool {
@@ -1448,11 +1475,11 @@ final class DictationCoordinator {
                 try? store.saveStatus(.init(requestID: request.id, phase: .failed, message: message))
                 saveKeyboardHandoff(requestID: request.id, phase: .failed, message: message)
                 saveKeyboardRuntimeStatus(
-                    isActive: isKeyboardSessionArmed,
+                    isActive: canStartKeyboardRequestsInBackground,
                     activeRequestID: nil,
                     phase: .failed,
                     message: message,
-                    supportsBackgroundStart: isKeyboardSessionArmed
+                    supportsBackgroundStart: canStartKeyboardRequestsInBackground
                 )
             }
             return
@@ -1484,11 +1511,25 @@ final class DictationCoordinator {
                 session.startedAt = .now
                 try store.saveSession(session)
                 try await recorder.requestPermission()
-                if usesKeyboardSessionLiveActivity {
-                    keyboardSessionKeeper.stop(deactivateSession: false)
-                    transitionKeyboardSession(.recordingStarted(request.id))
+                if !usesKeyboardSessionLiveActivity, keyboardSessionKeeper.isRunning {
+                    keyboardSessionKeeper.stop(deactivateSession: true)
+                    transitionKeyboardSession(.requestFinished)
+                    try? store.clearKeyboardRuntimeStatus()
+                    try? await Task.sleep(for: .milliseconds(150))
                 }
-                if selectedTranscriptionModel.supportsRealtimeStreaming {
+                if usesKeyboardSessionLiveActivity {
+                    if !keyboardSessionKeeper.canAcceptStartCommand {
+                        if !keyboardSessionKeeper.isRunning {
+                            try await keyboardSessionKeeper.start()
+                        }
+                        guard await keyboardSessionKeeper.waitUntilCanAcceptStartCommand() else {
+                            throw AudioRecorder.RecordingError.startFailed(stage: "keyboard session input")
+                        }
+                        transitionKeyboardSession(.startSucceeded)
+                    }
+                    try keyboardSessionKeeper.beginSegment(outputURL: audioURL)
+                    transitionKeyboardSession(.recordingStarted(request.id))
+                } else if selectedTranscriptionModel.supportsRealtimeStreaming {
                     try await startRealtimeDictationRecorder(audioURL: audioURL, sessionID: session.id)
                 } else {
                     try recorder.start(outputURL: audioURL)
@@ -1512,7 +1553,7 @@ final class DictationCoordinator {
                         activeRequestID: request.id,
                         phase: .recording,
                         message: "Listening",
-                        supportsBackgroundStart: usesKeyboardSessionLiveActivity || isKeyboardSessionArmed
+                        supportsBackgroundStart: canStartKeyboardRequestsInBackground
                     )
                 }
                 startMetering { [weak self] level in
@@ -1556,6 +1597,9 @@ final class DictationCoordinator {
                 clearKeyboardLiveTranscript()
                 clearKeyboardSessionLiveActivityRoute(for: request.id)
                 stopMetering()
+                if usesKeyboardSessionLiveActivity {
+                    keyboardSessionKeeper.cancelSegment()
+                }
                 transitionKeyboardSession(.requestFinished)
                 resumeKeyboardSessionKeeperIfNeeded()
                 AppTelemetry.signal("dictation_failed", parameters: ["stage": "recording"])
@@ -1628,11 +1672,11 @@ final class DictationCoordinator {
                 statusText = "Ready"
                 refreshHistory()
                 saveKeyboardRuntimeStatus(
-                    isActive: isKeyboardSessionArmed,
+                    isActive: canStartKeyboardRequestsInBackground,
                     activeRequestID: nil,
                     phase: .idle,
                     message: isKeyboardSessionArmed ? "Keyboard session ready" : "Ready",
-                    supportsBackgroundStart: isKeyboardSessionArmed
+                    supportsBackgroundStart: canStartKeyboardRequestsInBackground
                 )
                 resumeKeyboardSessionKeeperIfNeeded()
                 AppTelemetry.signal(
@@ -1663,11 +1707,11 @@ final class DictationCoordinator {
                 transitionKeyboardSession(.requestFinished)
                 statusText = error.localizedDescription
                 saveKeyboardRuntimeStatus(
-                    isActive: isKeyboardSessionArmed,
+                    isActive: canStartKeyboardRequestsInBackground,
                     activeRequestID: nil,
                     phase: .failed,
                     message: error.localizedDescription,
-                    supportsBackgroundStart: isKeyboardSessionArmed
+                    supportsBackgroundStart: canStartKeyboardRequestsInBackground
                 )
                 resumeKeyboardSessionKeeperIfNeeded()
                 AppTelemetry.signal(
@@ -1702,7 +1746,9 @@ final class DictationCoordinator {
         isRecording = false
         stopMetering()
         stopRecordingTimer()
-        stopCommandPolling()
+        if !usesKeyboardSessionLiveActivity {
+            stopCommandPolling()
+        }
         statusText = "Transcribing"
         if isKeyboardHandoffActive {
             transitionKeyboardSession(.transcribing(request.id))
@@ -1719,7 +1765,7 @@ final class DictationCoordinator {
                 activeRequestID: request.id,
                 phase: .transcribing,
                 message: "Transcribing",
-                supportsBackgroundStart: usesKeyboardSessionLiveActivity || isKeyboardSessionArmed
+                supportsBackgroundStart: canStartKeyboardRequestsInBackground
             )
         }
         if var session {
@@ -1745,7 +1791,10 @@ final class DictationCoordinator {
 
         beginTranscriptionBackgroundTask()
         Task {
-            defer { endTranscriptionBackgroundTask() }
+            defer {
+                stopCommandPolling()
+                endTranscriptionBackgroundTask()
+            }
             let startedFromKeyboard = isKeyboardHandoffActive
 
             do {
@@ -1753,7 +1802,17 @@ final class DictationCoordinator {
                 let audioURL: URL
                 var text: String
 
-                if usesRealtimeStreaming {
+                if usesKeyboardSessionLiveActivity {
+                    audioURL = try keyboardSessionKeeper.finishSegment()
+                    if startedFromKeyboard {
+                        saveKeyboardHandoff(
+                            requestID: request.id,
+                            phase: .transcribingStarted,
+                            message: "Transcribing"
+                        )
+                    }
+                    text = postProcessTranscript(try await engine.transcribe(audioURL: audioURL))
+                } else if usesRealtimeStreaming {
                     let stoppedAudio = realtimeDictationRecorder?.stop()
                     realtimeDictationRecorder = nil
                     realtimeDictationBufferPipe?.finish()
@@ -1795,11 +1854,11 @@ final class DictationCoordinator {
                     if startedFromKeyboard {
                         saveKeyboardHandoff(requestID: request.id, phase: .cancelled, message: "Cancelled")
                         saveKeyboardRuntimeStatus(
-                            isActive: isKeyboardSessionArmed,
+                            isActive: canStartKeyboardRequestsInBackground,
                             activeRequestID: nil,
                             phase: .idle,
                             message: isKeyboardSessionArmed ? "Keyboard session ready" : "Ready",
-                            supportsBackgroundStart: usesKeyboardSessionLiveActivity || isKeyboardSessionArmed
+                            supportsBackgroundStart: canStartKeyboardRequestsInBackground
                         )
                     }
                     clearKeyboardSessionLiveActivityRoute(for: request.id)
@@ -1808,7 +1867,6 @@ final class DictationCoordinator {
                     return
                 }
                 if isKeyboardSessionArmed {
-                    try? await keyboardSessionKeeper.start()
                     transitionKeyboardSession(.transcribing(request.id))
                 }
                 let completedSession = activeSession ?? session
@@ -1855,15 +1913,19 @@ final class DictationCoordinator {
                 activeSession = nil
                 if startedFromKeyboard {
                     saveKeyboardRuntimeStatus(
-                        isActive: true,
+                        isActive: canStartKeyboardRequestsInBackground,
                         activeRequestID: nil,
                         phase: .idle,
                         message: isKeyboardSessionArmed ? "Keyboard session ready" : "Ready",
-                        supportsBackgroundStart: usesKeyboardSessionLiveActivity || isKeyboardSessionArmed
+                        supportsBackgroundStart: canStartKeyboardRequestsInBackground
                     )
+                }
+                if usesKeyboardSessionLiveActivity {
+                    keyboardSessionKeeper.cancelSegment()
                 }
                 transitionKeyboardSession(.requestFinished)
                 resumeKeyboardSessionKeeperIfNeeded()
+                publishKeyboardSessionReadyIfAvailable()
                 statusText = "Ready"
                 liveDictationTranscript = ""
                 realtimeDictationCommittedText = ""
@@ -1900,11 +1962,11 @@ final class DictationCoordinator {
                 activeRequest = nil
                 activeSession = nil
                 saveKeyboardRuntimeStatus(
-                    isActive: isKeyboardHandoffActive || usesKeyboardSessionLiveActivity || isKeyboardSessionArmed,
+                    isActive: isKeyboardHandoffActive || usesKeyboardSessionLiveActivity || canStartKeyboardRequestsInBackground,
                     activeRequestID: nil,
                     phase: .failed,
                     message: error.localizedDescription,
-                    supportsBackgroundStart: usesKeyboardSessionLiveActivity || isKeyboardSessionArmed
+                    supportsBackgroundStart: canStartKeyboardRequestsInBackground
                 )
                 if usesKeyboardSessionLiveActivity {
                     refreshKeyboardSessionLiveActivity(
@@ -1914,6 +1976,7 @@ final class DictationCoordinator {
                 }
                 transitionKeyboardSession(.requestFinished)
                 resumeKeyboardSessionKeeperIfNeeded()
+                publishKeyboardSessionReadyIfAvailable()
                 clearKeyboardSessionLiveActivityRoute(for: request.id)
                 realtimeDictationRecorder?.cancel()
                 realtimeDictationRecorder = nil
@@ -2545,7 +2608,11 @@ final class DictationCoordinator {
 
             while !Task.isCancelled {
                 guard let self else { return }
-                let power = Double(self.realtimeDictationRecorder?.currentPower() ?? self.recorder.currentPower())
+                let power = if self.keyboardSessionKeeper.isRecordingSegment {
+                    Double(self.keyboardSessionKeeper.currentPower())
+                } else {
+                    Double(self.realtimeDictationRecorder?.currentPower() ?? self.recorder.currentPower())
+                }
                 let normalized = min(max((power + 50) / 50, 0), 1)
                 smoothedLevel = (0.35 * normalized) + (0.65 * smoothedLevel)
                 update(smoothedLevel)
@@ -2663,69 +2730,85 @@ final class DictationCoordinator {
         keyboardRuntimePollingTask = Task { @MainActor [weak self] in
             while !Task.isCancelled {
                 guard let self else { return }
-                self.refreshKeyboardRuntimeHeartbeat()
-
-                if let command = try? self.store.pendingCommand() {
-                    try? self.store.clearPendingCommand()
-                    switch command.action {
-                    case .start:
-                        break
-                    case .stop:
-                        self.saveKeyboardHandoff(
-                            requestID: command.requestID,
-                            phase: .stopAcknowledged,
-                            message: "Stopping"
-                        )
-                        self.stopRecording(requestID: command.requestID)
-                        try? await Task.sleep(for: .milliseconds(500))
-                        continue
-                    case .cancel:
-                        self.saveKeyboardHandoff(
-                            requestID: command.requestID,
-                            phase: .cancelled,
-                            message: "Cancelled"
-                        )
-                        self.cancelRecording(requestID: command.requestID)
-                        try? await Task.sleep(for: .milliseconds(500))
-                        continue
-                    }
-
-                    let pendingRequest = try? self.store.pendingRequest()
-                    let request = pendingRequest?.id == command.requestID
-                        ? pendingRequest!
-                        : DictationRequest(id: command.requestID)
-
-                    if self.refreshActiveKeyboardRequestIfNeeded(request) {
-                        try? await Task.sleep(for: .milliseconds(500))
-                        continue
-                    }
-
-                    guard !self.isRecording, !self.isMeetingRecording, self.statusText != "Transcribing" else {
-                        self.saveKeyboardHandoff(
-                            requestID: command.requestID,
-                            phase: .failed,
-                            message: "Muesli is busy"
-                        )
-                        try? self.store.saveStatus(.init(
-                            requestID: command.requestID,
-                            phase: .failed,
-                            message: "Muesli is busy"
-                        ))
-                        try? await Task.sleep(for: .milliseconds(500))
-                        continue
-                    }
-
-                    self.transitionKeyboardSession(.handoffStarted(request.id))
-                    self.activeRequest = request
-                    self.startRecording(for: request, source: "keyboard")
-                }
-
+                await self.processKeyboardRuntimeTick()
                 try? await Task.sleep(for: .milliseconds(500))
             }
         }
     }
 
-    private func refreshKeyboardRuntimeHeartbeat() {
+    private func handleKeyboardSessionInputActivity(powerDB: Float, isCapturing: Bool) async {
+        guard MuesliPreferences.keyboardSessionModeEnabled || isCapturing else { return }
+        let normalized = min(max((Double(powerDB) + 50) / 50, 0), 1)
+        await processKeyboardRuntimeTick(inputLevel: normalized)
+    }
+
+    private func processKeyboardRuntimeTick(inputLevel: Double? = nil) async {
+        guard !keyboardRuntimeTickInProgress else { return }
+        keyboardRuntimeTickInProgress = true
+        defer { keyboardRuntimeTickInProgress = false }
+
+        if isKeyboardSessionArmed,
+           !keyboardSessionKeeper.isRunning,
+           !isRecording,
+           !isMeetingRecording,
+           activeRequest == nil
+        {
+            _ = await ensureKeyboardSessionKeeperRunning(publishReady: false)
+        }
+        refreshKeyboardRuntimeHeartbeat(inputLevel: inputLevel)
+
+        guard let command = try? store.pendingCommand() else { return }
+        try? store.clearPendingCommand()
+        switch command.action {
+        case .start:
+            break
+        case .stop:
+            saveKeyboardHandoff(
+                requestID: command.requestID,
+                phase: .stopAcknowledged,
+                message: "Stopping"
+            )
+            stopRecording(requestID: command.requestID)
+            return
+        case .cancel:
+            saveKeyboardHandoff(
+                requestID: command.requestID,
+                phase: .cancelled,
+                message: "Cancelled"
+            )
+            cancelRecording(requestID: command.requestID)
+            return
+        }
+
+        let pendingRequest = try? store.pendingRequest()
+        let request = pendingRequest?.id == command.requestID
+            ? pendingRequest!
+            : DictationRequest(id: command.requestID)
+
+        if refreshActiveKeyboardRequestIfNeeded(request) {
+            return
+        }
+
+        guard !isRecording, !isMeetingRecording, statusText != "Transcribing" else {
+            saveKeyboardHandoff(
+                requestID: command.requestID,
+                phase: .failed,
+                message: "Muesli is busy"
+            )
+            try? store.saveStatus(.init(
+                requestID: command.requestID,
+                phase: .failed,
+                message: "Muesli is busy"
+            ))
+            return
+        }
+
+        transitionKeyboardSession(.handoffStarted(request.id))
+        activeRequest = request
+        startRecording(for: request, source: "keyboard")
+    }
+
+    private func refreshKeyboardRuntimeHeartbeat(inputLevel: Double? = nil) {
         let phase: DictationPhase
         let message: String
 
@@ -2744,12 +2827,94 @@ final class DictationCoordinator {
         }
 
         saveKeyboardRuntimeStatus(
-            isActive: isKeyboardSessionArmed || isRecording || activeRequest != nil,
+            isActive: isKeyboardHotMicEngineReady || isRecording || activeRequest != nil,
             activeRequestID: activeRequest?.id,
             phase: phase,
             message: message,
-            supportsBackgroundStart: isKeyboardSessionArmed
+            supportsBackgroundStart: canStartKeyboardRequestsInBackground,
+            inputLevel: inputLevel
         )
+    }
+
+    private func publishKeyboardSessionReadyIfAvailable() {
+        guard canStartKeyboardRequestsInBackground else { return }
+        startKeyboardRuntimePolling()
+        saveKeyboardRuntimeStatus(
+            isActive: true,
+            activeRequestID: nil,
+            phase: .idle,
+            message: "Keyboard session ready",
+            supportsBackgroundStart: true
+        )
+    }
+
+    @discardableResult
+    private func ensureKeyboardSessionKeeperRunning(publishReady: Bool = true) async -> Bool {
+        guard isKeyboardSessionArmed else { return false }
+        if keyboardSessionKeeper.canAcceptStartCommand {
+            if publishReady, !isRecording, !isMeetingRecording, activeRequest == nil {
+                publishKeyboardSessionReadyIfAvailable()
+            }
+            return true
+        }
+        guard !isRecording, !isMeetingRecording else { return false }
+        if keyboardSessionKeeper.isRunning {
+            let becameReady = await keyboardSessionKeeper.waitUntilCanAcceptStartCommand(timeout: 0.75)
+            if becameReady {
+                if publishReady, activeRequest == nil {
+                    publishKeyboardSessionReadyIfAvailable()
+                }
+                return true
+            }
+            keyboardSessionKeeper.stop(deactivateSession: false)
+            try? await Task.sleep(for: .milliseconds(150))
+        }
+
+        transitionKeyboardSession(.resumeRequested)
+        do {
+            try await keyboardSessionKeeper.start()
+            guard await keyboardSessionKeeper.waitUntilCanAcceptStartCommand() else {
+                throw AudioRecorder.RecordingError.startFailed(stage: "keyboard session input")
+            }
+            keyboardSessionRetryTask?.cancel()
+            keyboardSessionRetryTask = nil
+            keyboardSessionRetryAttempt = 0
+            transitionKeyboardSession(.startSucceeded)
+            if publishReady, activeRequest == nil {
+                saveKeyboardRuntimeStatus(
+                    isActive: true,
+                    activeRequestID: nil,
+                    phase: .idle,
+                    message: "Keyboard session ready",
+                    supportsBackgroundStart: true
+                )
+            }
+            if let session = keyboardSessionActivitySession {
+                await liveActivityController.start(
+                    session: session,
+                    requestID: nil,
+                    phase: "Ready",
+                    detail: "Keyboard voice note session active"
+                )
+            }
+            return true
+        } catch {
+            let isRecoverable = isRecoverableKeyboardSessionError(error)
+            if isRecoverable {
+                transitionKeyboardSession(.retryScheduled(message: Self.keyboardSessionRetryMessage))
+                scheduleKeyboardSessionRetry()
+            } else {
+                keyboardSessionRetryAttempt = 0
+                transitionKeyboardSession(.startFailed(message: error.localizedDescription, recoverable: false))
+            }
+            saveKeyboardRuntimeStatus(
+                isActive: false,
+                activeRequestID: nil,
+                phase: .failed,
+                message: isRecoverable ? Self.keyboardSessionRetryMessage : error.localizedDescription
+            )
+            return false
+        }
     }
 
     private func saveKeyboardRuntimeStatus(
@@ -2761,12 +2926,18 @@ final class DictationCoordinator {
         inputLevel: Double? = nil
     ) {
         let runtimeInputLevel = inputLevel ?? (phase == .recording ? self.inputLevel : 0)
+        let canAcceptStartCommand = isActive
+            && supportsBackgroundStart
+            && activeRequestID == nil
+            && phase == .idle
         try? store.saveKeyboardRuntimeStatus(.init(
             isActive: isActive,
             activeRequestID: activeRequestID,
             phase: phase,
             message: message,
+            sessionModeEnabled: MuesliPreferences.keyboardSessionModeEnabled || isKeyboardSessionArmed,
             supportsBackgroundStart: supportsBackgroundStart,
+            canAcceptStartCommand: canAcceptStartCommand,
             inputLevel: runtimeInputLevel
         ))
     }
@@ -2782,7 +2953,7 @@ final class DictationCoordinator {
             activeRequestID: requestID,
             phase: .recording,
             message: "Listening",
-            supportsBackgroundStart: usesKeyboardSessionLiveActivity(for: requestID) || isKeyboardSessionArmed,
+            supportsBackgroundStart: canStartKeyboardRequestsInBackground,
             inputLevel: level
         )
     }
@@ -2824,20 +2995,7 @@ final class DictationCoordinator {
 
     private func scheduleKeyboardSessionTimeout() {
         keyboardSessionTimeoutTask?.cancel()
-        let timeoutMinutes = MuesliPreferences.keyboardSessionTimeoutMinutes
-        keyboardSessionTimeoutTask = Task { @MainActor [weak self] in
-            try? await Task.sleep(for: .seconds(timeoutMinutes * 60))
-            guard let self, self.isKeyboardSessionArmed else { return }
-            guard !self.keyboardSessionState.isWorkflowActive,
-                  !self.isRecording,
-                  !self.isMeetingRecording,
-                  self.activeRequest == nil
-            else {
-                self.scheduleKeyboardSessionTimeout()
-                return
-            }
-            self.stopKeyboardSessionMode(reason: .timedOut)
-        }
+        keyboardSessionTimeoutTask = nil
     }
 
     private func scheduleKeyboardSessionRetry(attempt: Int? = nil) {
@@ -2864,7 +3022,7 @@ final class DictationCoordinator {
             try? await Task.sleep(for: .seconds(delay))
             guard let self,
                   MuesliPreferences.keyboardSessionModeEnabled,
-                  !self.isKeyboardSessionArmed
+                  !self.keyboardSessionKeeper.canAcceptStartCommand
             else { return }
 
             guard !self.keyboardSessionState.isWorkflowActive,
@@ -2882,48 +3040,9 @@ final class DictationCoordinator {
 
     private func resumeKeyboardSessionKeeperIfNeeded() {
         guard isKeyboardSessionArmed, !isRecording, !isMeetingRecording else { return }
-        transitionKeyboardSession(.resumeRequested)
         Task { @MainActor [weak self] in
-            guard let self, self.isKeyboardSessionArmed else { return }
-            do {
-                try await self.keyboardSessionKeeper.start()
-                self.keyboardSessionRetryTask?.cancel()
-                self.keyboardSessionRetryTask = nil
-                self.keyboardSessionRetryAttempt = 0
-                self.transitionKeyboardSession(.startSucceeded)
-                self.scheduleKeyboardSessionTimeout()
-                self.saveKeyboardRuntimeStatus(
-                    isActive: true,
-                    activeRequestID: nil,
-                    phase: .idle,
-                    message: "Keyboard session ready",
-                    supportsBackgroundStart: true
-                )
-                if let session = self.keyboardSessionActivitySession {
-                    await self.liveActivityController.start(
-                        session: session,
-                        requestID: nil,
-                        phase: "Ready",
-                        detail: "Keyboard voice note session active"
-                    )
-                }
-            } catch {
-                let isRecoverable = self.isRecoverableKeyboardSessionError(error)
-                if isRecoverable {
-                    self.transitionKeyboardSession(.retryScheduled(message: Self.keyboardSessionRetryMessage))
-                    self.scheduleKeyboardSessionRetry()
-                } else {
-                    self.keyboardSessionRetryAttempt = 0
-                    self.transitionKeyboardSession(.startFailed(message: error.localizedDescription, recoverable: false))
-                    UserDefaults.standard.set(false, forKey: MuesliPreferences.keyboardSessionModeKey)
-                }
-                self.saveKeyboardRuntimeStatus(
-                    isActive: false,
-                    activeRequestID: nil,
-                    phase: .failed,
-                    message: isRecoverable ? Self.keyboardSessionRetryMessage : error.localizedDescription
-                )
-            }
+            guard let self else { return }
+            await self.ensureKeyboardSessionKeeperRunning()
         }
     }
 
@@ -2951,11 +3070,11 @@ final class DictationCoordinator {
             if activeRequest == nil {
                 try? store.saveStatus(.idle)
                 saveKeyboardRuntimeStatus(
-                    isActive: isKeyboardSessionArmed,
+                    isActive: canStartKeyboardRequestsInBackground,
                     activeRequestID: nil,
                     phase: .idle,
                     message: isKeyboardSessionArmed ? "Keyboard session ready" : "Ready",
-                    supportsBackgroundStart: isKeyboardSessionArmed
+                    supportsBackgroundStart: canStartKeyboardRequestsInBackground
                 )
             }
             saveKeyboardHandoff(requestID: requestID, phase: .cancelled, message: "Cancelled")
@@ -2966,8 +3085,12 @@ final class DictationCoordinator {
         stopMetering()
         stopRecordingTimer()
         stopCommandPolling()
-        _ = try? recorder.stop()
-        cleanupRealtimeDictationRecorder()
+        if usesKeyboardSessionLiveActivity {
+            keyboardSessionKeeper.cancelSegment()
+        } else {
+            _ = try? recorder.stop()
+            cleanupRealtimeDictationRecorder()
+        }
         if var session = activeSession {
             session.phase = .cancelled
             session.endedAt = .now
@@ -2996,11 +3119,11 @@ final class DictationCoordinator {
         activeSession = nil
         resumeKeyboardSessionKeeperIfNeeded()
         saveKeyboardRuntimeStatus(
-            isActive: isKeyboardSessionArmed,
+            isActive: canStartKeyboardRequestsInBackground,
             activeRequestID: nil,
             phase: .idle,
             message: isKeyboardSessionArmed ? "Keyboard session ready" : "Ready",
-            supportsBackgroundStart: isKeyboardSessionArmed
+            supportsBackgroundStart: canStartKeyboardRequestsInBackground
         )
         transitionKeyboardSession(.requestFinished)
         statusText = "Ready"

--- a/Muesli/DictationCoordinator.swift
+++ b/Muesli/DictationCoordinator.swift
@@ -14,7 +14,6 @@ private struct KeyboardSessionState: Equatable {
         case transcribing(UUID)
         case retrying(String)
         case failed(String)
-        case timedOut
     }
 
     var phase: Phase = .off
@@ -24,7 +23,7 @@ private struct KeyboardSessionState: Equatable {
         switch phase {
         case .ready, .handoff, .recording, .transcribing, .arming:
             sessionAvailable
-        case .off, .retrying, .failed, .timedOut:
+        case .off, .retrying, .failed:
             false
         }
     }
@@ -33,7 +32,7 @@ private struct KeyboardSessionState: Equatable {
         switch phase {
         case .handoff, .recording, .transcribing:
             true
-        case .off, .arming, .ready, .retrying, .failed, .timedOut:
+        case .off, .arming, .ready, .retrying, .failed:
             false
         }
     }
@@ -42,7 +41,7 @@ private struct KeyboardSessionState: Equatable {
         switch phase {
         case .handoff, .recording, .transcribing, .arming:
             true
-        case .off, .ready, .retrying, .failed, .timedOut:
+        case .off, .ready, .retrying, .failed:
             false
         }
     }
@@ -65,8 +64,6 @@ private struct KeyboardSessionState: Equatable {
             message
         case .failed(let message):
             message
-        case .timedOut:
-            "Timed out"
         }
     }
 }
@@ -86,7 +83,6 @@ private enum KeyboardSessionEvent {
 
 private enum KeyboardSessionStopReason: Equatable {
     case off
-    case timedOut
     case turnedOff
     case stopped
 
@@ -94,8 +90,6 @@ private enum KeyboardSessionStopReason: Equatable {
         switch self {
         case .off:
             "Off"
-        case .timedOut:
-            "Timed out"
         case .turnedOff:
             "Turned off"
         case .stopped:
@@ -129,8 +123,8 @@ private enum KeyboardSessionReducer {
                 phase: state.sessionAvailable ? .ready : .off,
                 sessionAvailable: state.sessionAvailable
             )
-        case .stop(let reason):
-            return KeyboardSessionState(phase: reason == .timedOut ? .timedOut : .off)
+        case .stop:
+            return KeyboardSessionState(phase: .off)
         }
     }
 }
@@ -161,7 +155,6 @@ final class DictationCoordinator {
     private var commandPollingTask: Task<Void, Never>?
     private var keyboardRuntimePollingTask: Task<Void, Never>?
     private var keyboardRuntimeTickInProgress = false
-    private var keyboardSessionTimeoutTask: Task<Void, Never>?
     private var keyboardSessionRetryTask: Task<Void, Never>?
     private var keyboardSessionRetryAttempt = 0
     private var keyboardSessionLiveActivityRequestIDs = Set<UUID>()
@@ -904,11 +897,6 @@ final class DictationCoordinator {
         }
     }
 
-    func refreshKeyboardSessionTimeout() {
-        keyboardSessionTimeoutTask?.cancel()
-        keyboardSessionTimeoutTask = nil
-    }
-
     func startKeyboardSessionMode() async {
         guard !isKeyboardSessionArmed else {
             prewarmModelIfNeeded(reason: "keyboard_session")
@@ -980,8 +968,6 @@ final class DictationCoordinator {
     }
 
     private func stopKeyboardSessionMode(reason: KeyboardSessionStopReason = .stopped) {
-        keyboardSessionTimeoutTask?.cancel()
-        keyboardSessionTimeoutTask = nil
         keyboardSessionRetryTask?.cancel()
         keyboardSessionRetryTask = nil
         keyboardSessionRetryAttempt = 0
@@ -2991,11 +2977,6 @@ final class DictationCoordinator {
 
     private func clearKeyboardLiveTranscript() {
         try? store.clearKeyboardLiveTranscript()
-    }
-
-    private func scheduleKeyboardSessionTimeout() {
-        keyboardSessionTimeoutTask?.cancel()
-        keyboardSessionTimeoutTask = nil
     }
 
     private func scheduleKeyboardSessionRetry(attempt: Int? = nil) {

--- a/Muesli/DictationCoordinator.swift
+++ b/Muesli/DictationCoordinator.swift
@@ -30,6 +30,7 @@ final class DictationCoordinator {
     private var commandPollingTask: Task<Void, Never>?
     private var keyboardRuntimePollingTask: Task<Void, Never>?
     private var keyboardSessionTimeoutTask: Task<Void, Never>?
+    private var keyboardSessionRetryTask: Task<Void, Never>?
     private var keyboardSessionLiveActivityRequestIDs = Set<UUID>()
     private var iCloudSyncTask: Task<Void, Never>?
     private var iCloudSyncDebounceTask: Task<Void, Never>?
@@ -725,6 +726,8 @@ final class DictationCoordinator {
             Task { await startKeyboardSessionMode() }
         } else {
             guard isKeyboardSessionArmed || keyboardSessionActivitySession != nil || keyboardSessionKeeper.isRunning else {
+                keyboardSessionRetryTask?.cancel()
+                keyboardSessionRetryTask = nil
                 if keyboardSessionStatusText == "Ready"
                     || keyboardSessionStatusText == "Starting"
                     || keyboardSessionStatusText == "Resuming"
@@ -765,6 +768,8 @@ final class DictationCoordinator {
         keyboardSessionStatusText = "Starting"
         do {
             try await keyboardSessionKeeper.start()
+            keyboardSessionRetryTask?.cancel()
+            keyboardSessionRetryTask = nil
             isKeyboardSessionArmed = true
             prewarmModelIfNeeded(reason: "keyboard_session")
             keyboardSessionStatusText = "Ready"
@@ -795,8 +800,10 @@ final class DictationCoordinator {
             AppTelemetry.signal("keyboard_session_started")
         } catch {
             let isRecoverable = isRecoverableKeyboardSessionError(error)
-            isKeyboardSessionArmed = isRecoverable
-            if !isRecoverable {
+            isKeyboardSessionArmed = false
+            if isRecoverable {
+                scheduleKeyboardSessionRetry()
+            } else {
                 UserDefaults.standard.set(false, forKey: MuesliPreferences.keyboardSessionModeKey)
             }
             keyboardSessionStatusText = error.localizedDescription
@@ -813,6 +820,8 @@ final class DictationCoordinator {
     func stopKeyboardSessionMode(reason: String = "Stopped") {
         keyboardSessionTimeoutTask?.cancel()
         keyboardSessionTimeoutTask = nil
+        keyboardSessionRetryTask?.cancel()
+        keyboardSessionRetryTask = nil
         isKeyboardSessionArmed = false
         keyboardSessionStatusText = reason == "Timed out" ? "Timed out" : "Off"
         keyboardSessionKeeper.stop(deactivateSession: !isRecording)
@@ -1712,21 +1721,19 @@ final class DictationCoordinator {
                 statusText = "Ready"
                 liveDictationTranscript = ""
                 realtimeDictationCommittedText = ""
-                if let completedSession = try? store.recordingSession(requestID: request.id) {
-                    if startedFromKeyboard, usesKeyboardSessionLiveActivity {
-                        refreshKeyboardSessionLiveActivity(
-                            phase: "Ready",
-                            detail: "Keyboard voice note session active"
+                if startedFromKeyboard, usesKeyboardSessionLiveActivity {
+                    refreshKeyboardSessionLiveActivity(
+                        phase: "Ready",
+                        detail: "Keyboard voice note session active"
+                    )
+                } else if let completedSession = try? store.recordingSession(requestID: request.id) {
+                    Task {
+                        await liveActivityController.end(
+                            phase: "Completed",
+                            detail: "Transcript saved",
+                            session: completedSession,
+                            dismissal: .immediate
                         )
-                    } else {
-                        Task {
-                            await liveActivityController.end(
-                                phase: "Completed",
-                                detail: "Transcript saved",
-                                session: completedSession,
-                                dismissal: .immediate
-                            )
-                        }
                     }
                 }
                 clearKeyboardSessionLiveActivityRoute(for: request.id)
@@ -1753,6 +1760,12 @@ final class DictationCoordinator {
                     message: error.localizedDescription,
                     supportsBackgroundStart: usesKeyboardSessionLiveActivity || isKeyboardSessionArmed
                 )
+                if usesKeyboardSessionLiveActivity {
+                    refreshKeyboardSessionLiveActivity(
+                        phase: "Ready",
+                        detail: "Keyboard voice note failed. Session active"
+                    )
+                }
                 isKeyboardHandoffActive = false
                 resumeKeyboardSessionKeeperIfNeeded()
                 clearKeyboardSessionLiveActivityRoute(for: request.id)
@@ -2677,6 +2690,21 @@ final class DictationCoordinator {
         }
     }
 
+    private func scheduleKeyboardSessionRetry() {
+        keyboardSessionRetryTask?.cancel()
+        keyboardSessionRetryTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .seconds(15))
+            guard let self,
+                  MuesliPreferences.keyboardSessionModeEnabled,
+                  !self.isKeyboardSessionArmed,
+                  !self.isRecording,
+                  !self.isMeetingRecording
+            else { return }
+
+            await self.startKeyboardSessionMode()
+        }
+    }
+
     private func resumeKeyboardSessionKeeperIfNeeded() {
         guard isKeyboardSessionArmed, !isRecording, !isMeetingRecording else { return }
         keyboardSessionStatusText = "Resuming"
@@ -2684,6 +2712,8 @@ final class DictationCoordinator {
             guard let self, self.isKeyboardSessionArmed else { return }
             do {
                 try await self.keyboardSessionKeeper.start()
+                self.keyboardSessionRetryTask?.cancel()
+                self.keyboardSessionRetryTask = nil
                 self.keyboardSessionStatusText = "Ready"
                 self.scheduleKeyboardSessionTimeout()
                 self.saveKeyboardRuntimeStatus(
@@ -2703,8 +2733,10 @@ final class DictationCoordinator {
                 }
             } catch {
                 let isRecoverable = self.isRecoverableKeyboardSessionError(error)
-                self.isKeyboardSessionArmed = isRecoverable
-                if !isRecoverable {
+                self.isKeyboardSessionArmed = false
+                if isRecoverable {
+                    self.scheduleKeyboardSessionRetry()
+                } else {
                     UserDefaults.standard.set(false, forKey: MuesliPreferences.keyboardSessionModeKey)
                 }
                 self.keyboardSessionStatusText = error.localizedDescription

--- a/Muesli/DictationCoordinator.swift
+++ b/Muesli/DictationCoordinator.swift
@@ -81,7 +81,27 @@ private enum KeyboardSessionEvent {
     case recordingStarted(UUID)
     case transcribing(UUID)
     case requestFinished
-    case stop(reason: String)
+    case stop(KeyboardSessionStopReason)
+}
+
+private enum KeyboardSessionStopReason: Equatable {
+    case off
+    case timedOut
+    case turnedOff
+    case stopped
+
+    var message: String {
+        switch self {
+        case .off:
+            "Off"
+        case .timedOut:
+            "Timed out"
+        case .turnedOff:
+            "Turned off"
+        case .stopped:
+            "Stopped"
+        }
+    }
 }
 
 private enum KeyboardSessionReducer {
@@ -110,7 +130,7 @@ private enum KeyboardSessionReducer {
                 sessionAvailable: state.sessionAvailable
             )
         case .stop(let reason):
-            return KeyboardSessionState(phase: reason == "Timed out" ? .timedOut : .off)
+            return KeyboardSessionState(phase: reason == .timedOut ? .timedOut : .off)
         }
     }
 }
@@ -142,6 +162,7 @@ final class DictationCoordinator {
     private var keyboardRuntimePollingTask: Task<Void, Never>?
     private var keyboardSessionTimeoutTask: Task<Void, Never>?
     private var keyboardSessionRetryTask: Task<Void, Never>?
+    private var keyboardSessionRetryAttempt = 0
     private var keyboardSessionLiveActivityRequestIDs = Set<UUID>()
     private var iCloudSyncTask: Task<Void, Never>?
     private var iCloudSyncDebounceTask: Task<Void, Never>?
@@ -173,6 +194,11 @@ final class DictationCoordinator {
             }
         }
     }
+
+    private static let keyboardSessionRetryMessage = "Retrying session standby"
+    private static let keyboardSessionUnavailableMessage = "Session standby unavailable. Tap Start to record normally."
+    private static let keyboardSessionMaxRetryAttempts = 3
+    private static let keyboardSessionRetryBaseDelaySeconds: TimeInterval = 15
     var syncSetupSource: String?
     var hasCompletedOnboarding = UserDefaults.standard.bool(forKey: onboardingCompletedKey)
     var userName = UserDefaults.standard.string(forKey: userNameKey) ?? ""
@@ -498,7 +524,7 @@ final class DictationCoordinator {
         userName = "UI Tests"
         selectedUseCase = .everything
         selectedTranscriptionModel = .defaultModel
-        transitionKeyboardSession(.stop(reason: "Off"))
+        transitionKeyboardSession(.stop(.off))
         UserDefaults.standard.set(true, forKey: Self.onboardingCompletedKey)
         UserDefaults.standard.set(userName, forKey: Self.userNameKey)
         UserDefaults.standard.set(selectedUseCase.rawValue, forKey: Self.useCaseKey)
@@ -846,16 +872,17 @@ final class DictationCoordinator {
             guard isKeyboardSessionArmed || keyboardSessionActivitySession != nil || keyboardSessionKeeper.isRunning else {
                 keyboardSessionRetryTask?.cancel()
                 keyboardSessionRetryTask = nil
-                transitionKeyboardSession(.stop(reason: "Turned off"))
+                keyboardSessionRetryAttempt = 0
+                transitionKeyboardSession(.stop(.turnedOff))
                 saveKeyboardRuntimeStatus(
                     isActive: false,
                     activeRequestID: activeRequest?.id,
                     phase: activeRequest == nil ? .idle : .recording,
-                    message: "Turned off"
+                    message: KeyboardSessionStopReason.turnedOff.message
                 )
                 return
             }
-            stopKeyboardSessionMode(reason: "Turned off")
+            stopKeyboardSessionMode(reason: .turnedOff)
         }
     }
 
@@ -882,6 +909,7 @@ final class DictationCoordinator {
             try await keyboardSessionKeeper.start()
             keyboardSessionRetryTask?.cancel()
             keyboardSessionRetryTask = nil
+            keyboardSessionRetryAttempt = 0
             prewarmModelIfNeeded(reason: "keyboard_session")
             transitionKeyboardSession(.startSucceeded)
             startKeyboardRuntimePolling()
@@ -911,9 +939,10 @@ final class DictationCoordinator {
         } catch {
             let isRecoverable = isRecoverableKeyboardSessionError(error)
             if isRecoverable {
-                transitionKeyboardSession(.retryScheduled(message: error.localizedDescription))
+                transitionKeyboardSession(.retryScheduled(message: Self.keyboardSessionRetryMessage))
                 scheduleKeyboardSessionRetry()
             } else {
+                keyboardSessionRetryAttempt = 0
                 transitionKeyboardSession(.startFailed(message: error.localizedDescription, recoverable: false))
                 UserDefaults.standard.set(false, forKey: MuesliPreferences.keyboardSessionModeKey)
             }
@@ -921,38 +950,39 @@ final class DictationCoordinator {
                 isActive: false,
                 activeRequestID: nil,
                 phase: .failed,
-                message: error.localizedDescription
+                message: isRecoverable ? Self.keyboardSessionRetryMessage : error.localizedDescription
             )
             AppTelemetry.signal("keyboard_session_failed", parameters: ["error": String(describing: type(of: error))])
         }
     }
 
-    func stopKeyboardSessionMode(reason: String = "Stopped") {
+    private func stopKeyboardSessionMode(reason: KeyboardSessionStopReason = .stopped) {
         keyboardSessionTimeoutTask?.cancel()
         keyboardSessionTimeoutTask = nil
         keyboardSessionRetryTask?.cancel()
         keyboardSessionRetryTask = nil
-        transitionKeyboardSession(.stop(reason: reason))
+        keyboardSessionRetryAttempt = 0
+        transitionKeyboardSession(.stop(reason))
         keyboardSessionKeeper.stop(deactivateSession: !isRecording)
         saveKeyboardRuntimeStatus(
             isActive: false,
             activeRequestID: activeRequest?.id,
             phase: activeRequest == nil ? .idle : .recording,
-            message: reason
+            message: reason.message
         )
 
         if let session = keyboardSessionActivitySession {
             Task {
                 await liveActivityController.end(
                     phase: "Ended",
-                    detail: reason,
+                    detail: reason.message,
                     session: session,
                     dismissal: .immediate
                 )
             }
         }
         keyboardSessionActivitySession = nil
-        AppTelemetry.signal("keyboard_session_stopped", parameters: ["reason": reason])
+        AppTelemetry.signal("keyboard_session_stopped", parameters: ["reason": reason.message])
     }
 
     private func isRecoverableKeyboardSessionError(_ error: Error) -> Bool {
@@ -1526,6 +1556,7 @@ final class DictationCoordinator {
                 clearKeyboardLiveTranscript()
                 clearKeyboardSessionLiveActivityRoute(for: request.id)
                 stopMetering()
+                transitionKeyboardSession(.requestFinished)
                 resumeKeyboardSessionKeeperIfNeeded()
                 AppTelemetry.signal("dictation_failed", parameters: ["stage": "recording"])
                 try? store.saveStatus(.init(requestID: request.id, phase: .failed, message: error.localizedDescription))
@@ -2805,21 +2836,45 @@ final class DictationCoordinator {
                 self.scheduleKeyboardSessionTimeout()
                 return
             }
-            self.stopKeyboardSessionMode(reason: "Timed out")
+            self.stopKeyboardSessionMode(reason: .timedOut)
         }
     }
 
-    private func scheduleKeyboardSessionRetry() {
+    private func scheduleKeyboardSessionRetry(attempt: Int? = nil) {
+        guard MuesliPreferences.keyboardSessionModeEnabled else { return }
+        let retryAttempt = attempt ?? (keyboardSessionRetryAttempt + 1)
+        guard retryAttempt <= Self.keyboardSessionMaxRetryAttempts else {
+            keyboardSessionRetryTask?.cancel()
+            keyboardSessionRetryTask = nil
+            keyboardSessionRetryAttempt = 0
+            transitionKeyboardSession(.startFailed(message: Self.keyboardSessionUnavailableMessage, recoverable: false))
+            saveKeyboardRuntimeStatus(
+                isActive: false,
+                activeRequestID: nil,
+                phase: .failed,
+                message: Self.keyboardSessionUnavailableMessage
+            )
+            return
+        }
+
+        keyboardSessionRetryAttempt = retryAttempt
+        let delay = Self.keyboardSessionRetryBaseDelaySeconds * pow(2, Double(retryAttempt - 1))
         keyboardSessionRetryTask?.cancel()
         keyboardSessionRetryTask = Task { @MainActor [weak self] in
-            try? await Task.sleep(for: .seconds(15))
+            try? await Task.sleep(for: .seconds(delay))
             guard let self,
                   MuesliPreferences.keyboardSessionModeEnabled,
-                  !self.isKeyboardSessionArmed,
-                  !self.keyboardSessionState.isWorkflowActive,
-                  !self.isRecording,
-                  !self.isMeetingRecording
+                  !self.isKeyboardSessionArmed
             else { return }
+
+            guard !self.keyboardSessionState.isWorkflowActive,
+                  !self.isRecording,
+                  !self.isMeetingRecording,
+                  self.activeRequest == nil
+            else {
+                self.scheduleKeyboardSessionRetry(attempt: retryAttempt)
+                return
+            }
 
             await self.startKeyboardSessionMode()
         }
@@ -2834,6 +2889,7 @@ final class DictationCoordinator {
                 try await self.keyboardSessionKeeper.start()
                 self.keyboardSessionRetryTask?.cancel()
                 self.keyboardSessionRetryTask = nil
+                self.keyboardSessionRetryAttempt = 0
                 self.transitionKeyboardSession(.startSucceeded)
                 self.scheduleKeyboardSessionTimeout()
                 self.saveKeyboardRuntimeStatus(
@@ -2854,9 +2910,10 @@ final class DictationCoordinator {
             } catch {
                 let isRecoverable = self.isRecoverableKeyboardSessionError(error)
                 if isRecoverable {
-                    self.transitionKeyboardSession(.retryScheduled(message: error.localizedDescription))
+                    self.transitionKeyboardSession(.retryScheduled(message: Self.keyboardSessionRetryMessage))
                     self.scheduleKeyboardSessionRetry()
                 } else {
+                    self.keyboardSessionRetryAttempt = 0
                     self.transitionKeyboardSession(.startFailed(message: error.localizedDescription, recoverable: false))
                     UserDefaults.standard.set(false, forKey: MuesliPreferences.keyboardSessionModeKey)
                 }
@@ -2864,7 +2921,7 @@ final class DictationCoordinator {
                     isActive: false,
                     activeRequestID: nil,
                     phase: .failed,
-                    message: error.localizedDescription
+                    message: isRecoverable ? Self.keyboardSessionRetryMessage : error.localizedDescription
                 )
             }
         }

--- a/Muesli/DictationCoordinator.swift
+++ b/Muesli/DictationCoordinator.swift
@@ -175,6 +175,7 @@ final class DictationCoordinator {
     private var activeSession: RecordingSession?
     private var keyboardSessionActivitySession: RecordingSession?
     private var keyboardSessionState = KeyboardSessionState()
+    private var stopKeyboardSessionAfterCurrentRequest = false
     var isKeyboardHandoffActive: Bool { keyboardSessionState.isKeyboardHandoffActive }
     var isKeyboardSessionArmed: Bool { keyboardSessionState.isArmed }
     private var isKeyboardHotMicEngineReady: Bool {
@@ -299,7 +300,6 @@ final class DictationCoordinator {
 
         refreshAudioInputRoute()
         refreshHistory()
-        saveKeyboardSessionPreference(isEnabled: MuesliPreferences.keyboardSessionModeEnabled)
         Task {
             await liveActivityController.endAllActivities(
                 detail: "Recovered from interrupted session"
@@ -875,11 +875,27 @@ final class DictationCoordinator {
     }
 
     func setKeyboardSessionModeEnabled(_ enabled: Bool) {
-        UserDefaults.standard.set(enabled, forKey: MuesliPreferences.keyboardSessionModeKey)
-        saveKeyboardSessionPreference(isEnabled: enabled)
         if enabled {
+            stopKeyboardSessionAfterCurrentRequest = false
+            UserDefaults.standard.set(true, forKey: MuesliPreferences.keyboardSessionModeKey)
             Task { await startKeyboardSessionMode() }
         } else {
+            UserDefaults.standard.set(false, forKey: MuesliPreferences.keyboardSessionModeKey)
+            if shouldDeferKeyboardSessionStop {
+                stopKeyboardSessionAfterCurrentRequest = true
+                keyboardSessionRetryTask?.cancel()
+                keyboardSessionRetryTask = nil
+                keyboardSessionRetryAttempt = 0
+                saveKeyboardRuntimeStatus(
+                    isActive: true,
+                    activeRequestID: activeRequest?.id,
+                    phase: isRecording ? .recording : .transcribing,
+                    message: "Turns off after this keyboard voice note",
+                    supportsBackgroundStart: false,
+                    inputLevel: inputLevel
+                )
+                return
+            }
             guard isKeyboardSessionArmed || keyboardSessionActivitySession != nil || keyboardSessionKeeper.isRunning else {
                 keyboardSessionRetryTask?.cancel()
                 keyboardSessionRetryTask = nil
@@ -917,9 +933,11 @@ final class DictationCoordinator {
         transitionKeyboardSession(.startRequested)
         do {
             try await keyboardSessionKeeper.start()
+            guard !abortKeyboardSessionStartIfModeDisabled() else { return }
             guard await keyboardSessionKeeper.waitUntilCanAcceptStartCommand() else {
                 throw AudioRecorder.RecordingError.startFailed(stage: "keyboard session input")
             }
+            guard !abortKeyboardSessionStartIfModeDisabled() else { return }
             keyboardSessionRetryTask?.cancel()
             keyboardSessionRetryTask = nil
             keyboardSessionRetryAttempt = 0
@@ -967,7 +985,33 @@ final class DictationCoordinator {
         }
     }
 
+    private var shouldDeferKeyboardSessionStop: Bool {
+        if isRecording, let requestID = activeRequest?.id, usesKeyboardSessionLiveActivity(for: requestID) {
+            return true
+        }
+        return isKeyboardHandoffActive && activeRequest != nil
+    }
+
+    @discardableResult
+    private func abortKeyboardSessionStartIfModeDisabled() -> Bool {
+        guard !MuesliPreferences.keyboardSessionModeEnabled else { return false }
+
+        keyboardSessionRetryTask?.cancel()
+        keyboardSessionRetryTask = nil
+        keyboardSessionRetryAttempt = 0
+        keyboardSessionKeeper.stop(deactivateSession: !isRecording)
+        transitionKeyboardSession(.stop(.turnedOff))
+        saveKeyboardRuntimeStatus(
+            isActive: false,
+            activeRequestID: activeRequest?.id,
+            phase: activeRequest == nil ? .idle : .recording,
+            message: KeyboardSessionStopReason.turnedOff.message
+        )
+        return true
+    }
+
     private func stopKeyboardSessionMode(reason: KeyboardSessionStopReason = .stopped) {
+        stopKeyboardSessionAfterCurrentRequest = false
         keyboardSessionRetryTask?.cancel()
         keyboardSessionRetryTask = nil
         keyboardSessionRetryAttempt = 0
@@ -992,10 +1036,6 @@ final class DictationCoordinator {
         }
         keyboardSessionActivitySession = nil
         AppTelemetry.signal("keyboard_session_stopped", parameters: ["reason": reason.message])
-    }
-
-    private func saveKeyboardSessionPreference(isEnabled: Bool) {
-        try? store.saveKeyboardSessionPreference(.init(isEnabled: isEnabled))
     }
 
     private func isRecoverableKeyboardSessionError(_ error: Error) -> Bool {
@@ -1586,8 +1626,11 @@ final class DictationCoordinator {
                 if usesKeyboardSessionLiveActivity {
                     keyboardSessionKeeper.cancelSegment()
                 }
+                let completedDeferredStop = completeDeferredKeyboardSessionStopIfNeeded()
                 transitionKeyboardSession(.requestFinished)
-                resumeKeyboardSessionKeeperIfNeeded()
+                if !completedDeferredStop {
+                    resumeKeyboardSessionKeeperIfNeeded()
+                }
                 AppTelemetry.signal("dictation_failed", parameters: ["stage": "recording"])
                 try? store.saveStatus(.init(requestID: request.id, phase: .failed, message: error.localizedDescription))
                 if source == "keyboard" {
@@ -1654,17 +1697,20 @@ final class DictationCoordinator {
                 try store.clearPendingRequest()
                 activeRequest = nil
                 activeSession = nil
+                let completedDeferredStop = completeDeferredKeyboardSessionStopIfNeeded()
                 transitionKeyboardSession(.requestFinished)
                 statusText = "Ready"
                 refreshHistory()
-                saveKeyboardRuntimeStatus(
-                    isActive: canStartKeyboardRequestsInBackground,
-                    activeRequestID: nil,
-                    phase: .idle,
-                    message: isKeyboardSessionArmed ? "Keyboard session ready" : "Ready",
-                    supportsBackgroundStart: canStartKeyboardRequestsInBackground
-                )
-                resumeKeyboardSessionKeeperIfNeeded()
+                if !completedDeferredStop {
+                    saveKeyboardRuntimeStatus(
+                        isActive: canStartKeyboardRequestsInBackground,
+                        activeRequestID: nil,
+                        phase: .idle,
+                        message: isKeyboardSessionArmed ? "Keyboard session ready" : "Ready",
+                        supportsBackgroundStart: canStartKeyboardRequestsInBackground
+                    )
+                    resumeKeyboardSessionKeeperIfNeeded()
+                }
                 AppTelemetry.signal(
                     "keyboard_transcription_recovered",
                     parameters: [
@@ -1690,16 +1736,19 @@ final class DictationCoordinator {
                 )
                 activeRequest = nil
                 activeSession = nil
+                let completedDeferredStop = completeDeferredKeyboardSessionStopIfNeeded()
                 transitionKeyboardSession(.requestFinished)
                 statusText = error.localizedDescription
-                saveKeyboardRuntimeStatus(
-                    isActive: canStartKeyboardRequestsInBackground,
-                    activeRequestID: nil,
-                    phase: .failed,
-                    message: error.localizedDescription,
-                    supportsBackgroundStart: canStartKeyboardRequestsInBackground
-                )
-                resumeKeyboardSessionKeeperIfNeeded()
+                if !completedDeferredStop {
+                    saveKeyboardRuntimeStatus(
+                        isActive: canStartKeyboardRequestsInBackground,
+                        activeRequestID: nil,
+                        phase: .failed,
+                        message: error.localizedDescription,
+                        supportsBackgroundStart: canStartKeyboardRequestsInBackground
+                    )
+                    resumeKeyboardSessionKeeperIfNeeded()
+                }
                 AppTelemetry.signal(
                     "keyboard_transcription_recovery_failed",
                     parameters: [
@@ -1897,7 +1946,11 @@ final class DictationCoordinator {
                 lastTranscript = text
                 activeRequest = nil
                 activeSession = nil
-                if startedFromKeyboard {
+                if usesKeyboardSessionLiveActivity {
+                    keyboardSessionKeeper.cancelSegment()
+                }
+                let completedDeferredStop = completeDeferredKeyboardSessionStopIfNeeded()
+                if startedFromKeyboard, !completedDeferredStop {
                     saveKeyboardRuntimeStatus(
                         isActive: canStartKeyboardRequestsInBackground,
                         activeRequestID: nil,
@@ -1906,16 +1959,15 @@ final class DictationCoordinator {
                         supportsBackgroundStart: canStartKeyboardRequestsInBackground
                     )
                 }
-                if usesKeyboardSessionLiveActivity {
-                    keyboardSessionKeeper.cancelSegment()
-                }
                 transitionKeyboardSession(.requestFinished)
-                resumeKeyboardSessionKeeperIfNeeded()
-                publishKeyboardSessionReadyIfAvailable()
+                if !completedDeferredStop {
+                    resumeKeyboardSessionKeeperIfNeeded()
+                    publishKeyboardSessionReadyIfAvailable()
+                }
                 statusText = "Ready"
                 liveDictationTranscript = ""
                 realtimeDictationCommittedText = ""
-                if startedFromKeyboard, usesKeyboardSessionLiveActivity {
+                if startedFromKeyboard, usesKeyboardSessionLiveActivity, !completedDeferredStop {
                     refreshKeyboardSessionLiveActivity(
                         phase: "Ready",
                         detail: "Keyboard voice note session active"
@@ -1947,22 +1999,27 @@ final class DictationCoordinator {
                 }
                 activeRequest = nil
                 activeSession = nil
-                saveKeyboardRuntimeStatus(
-                    isActive: isKeyboardHandoffActive || usesKeyboardSessionLiveActivity || canStartKeyboardRequestsInBackground,
-                    activeRequestID: nil,
-                    phase: .failed,
-                    message: error.localizedDescription,
-                    supportsBackgroundStart: canStartKeyboardRequestsInBackground
-                )
-                if usesKeyboardSessionLiveActivity {
+                let completedDeferredStop = completeDeferredKeyboardSessionStopIfNeeded()
+                if !completedDeferredStop {
+                    saveKeyboardRuntimeStatus(
+                        isActive: isKeyboardHandoffActive || usesKeyboardSessionLiveActivity || canStartKeyboardRequestsInBackground,
+                        activeRequestID: nil,
+                        phase: .failed,
+                        message: error.localizedDescription,
+                        supportsBackgroundStart: canStartKeyboardRequestsInBackground
+                    )
+                }
+                if usesKeyboardSessionLiveActivity, !completedDeferredStop {
                     refreshKeyboardSessionLiveActivity(
                         phase: "Ready",
                         detail: "Keyboard voice note failed. Session active"
                     )
                 }
                 transitionKeyboardSession(.requestFinished)
-                resumeKeyboardSessionKeeperIfNeeded()
-                publishKeyboardSessionReadyIfAvailable()
+                if !completedDeferredStop {
+                    resumeKeyboardSessionKeeperIfNeeded()
+                    publishKeyboardSessionReadyIfAvailable()
+                }
                 clearKeyboardSessionLiveActivityRoute(for: request.id)
                 realtimeDictationRecorder?.cancel()
                 realtimeDictationRecorder = nil
@@ -2823,7 +2880,7 @@ final class DictationCoordinator {
     }
 
     private func publishKeyboardSessionReadyIfAvailable() {
-        guard canStartKeyboardRequestsInBackground else { return }
+        guard MuesliPreferences.keyboardSessionModeEnabled, canStartKeyboardRequestsInBackground else { return }
         startKeyboardRuntimePolling()
         saveKeyboardRuntimeStatus(
             isActive: true,
@@ -2836,7 +2893,7 @@ final class DictationCoordinator {
 
     @discardableResult
     private func ensureKeyboardSessionKeeperRunning(publishReady: Bool = true) async -> Bool {
-        guard isKeyboardSessionArmed else { return false }
+        guard MuesliPreferences.keyboardSessionModeEnabled, isKeyboardSessionArmed else { return false }
         if keyboardSessionKeeper.canAcceptStartCommand {
             if publishReady, !isRecording, !isMeetingRecording, activeRequest == nil {
                 publishKeyboardSessionReadyIfAvailable()
@@ -2859,9 +2916,11 @@ final class DictationCoordinator {
         transitionKeyboardSession(.resumeRequested)
         do {
             try await keyboardSessionKeeper.start()
+            guard !abortKeyboardSessionStartIfModeDisabled() else { return false }
             guard await keyboardSessionKeeper.waitUntilCanAcceptStartCommand() else {
                 throw AudioRecorder.RecordingError.startFailed(stage: "keyboard session input")
             }
+            guard !abortKeyboardSessionStartIfModeDisabled() else { return false }
             keyboardSessionRetryTask?.cancel()
             keyboardSessionRetryTask = nil
             keyboardSessionRetryAttempt = 0
@@ -2921,7 +2980,6 @@ final class DictationCoordinator {
             activeRequestID: activeRequestID,
             phase: phase,
             message: message,
-            sessionModeEnabled: MuesliPreferences.keyboardSessionModeEnabled || isKeyboardSessionArmed,
             supportsBackgroundStart: supportsBackgroundStart,
             canAcceptStartCommand: canAcceptStartCommand,
             inputLevel: runtimeInputLevel
@@ -3020,11 +3078,22 @@ final class DictationCoordinator {
     }
 
     private func resumeKeyboardSessionKeeperIfNeeded() {
-        guard isKeyboardSessionArmed, !isRecording, !isMeetingRecording else { return }
+        guard MuesliPreferences.keyboardSessionModeEnabled, isKeyboardSessionArmed, !isRecording, !isMeetingRecording else { return }
         Task { @MainActor [weak self] in
             guard let self else { return }
             await self.ensureKeyboardSessionKeeperRunning()
         }
+    }
+
+    @discardableResult
+    private func completeDeferredKeyboardSessionStopIfNeeded() -> Bool {
+        guard stopKeyboardSessionAfterCurrentRequest,
+              activeRequest == nil,
+              !isRecording
+        else { return false }
+
+        stopKeyboardSessionMode(reason: .turnedOff)
+        return true
     }
 
     private func beginTranscriptionBackgroundTask() {
@@ -3098,6 +3167,16 @@ final class DictationCoordinator {
         clearKeyboardSessionLiveActivityRoute(for: requestID)
         activeRequest = nil
         activeSession = nil
+        if completeDeferredKeyboardSessionStopIfNeeded() {
+            transitionKeyboardSession(.requestFinished)
+            statusText = "Ready"
+            try? store.clearPendingCommand()
+            try? store.clearPendingRequest()
+            try? store.saveStatus(.idle)
+            saveKeyboardHandoff(requestID: requestID, phase: .cancelled, message: "Cancelled")
+            clearKeyboardLiveTranscript()
+            return
+        }
         resumeKeyboardSessionKeeperIfNeeded()
         saveKeyboardRuntimeStatus(
             isActive: canStartKeyboardRequestsInBackground,

--- a/Muesli/DictationView.swift
+++ b/Muesli/DictationView.swift
@@ -11,6 +11,7 @@ struct DictationView: View {
     @Environment(\.scenePhase) private var scenePhase
     @AppStorage(MuesliPreferences.iCloudSyncEnabledKey) private var iCloudSyncEnabled = false
     @AppStorage(MuesliPreferences.recordingMicrophonePreferenceKey) private var microphonePreference = RecordingMicrophonePreference.automatic.rawValue
+    @AppStorage(MuesliPreferences.keyboardSessionModeKey) private var keyboardSessionMode = false
     @State private var sourceFilter: DictationSourceFilter = .all
     @State private var isSyncSetupPromptPresented = false
     @State private var shouldShowKeyboardSetupRow = false
@@ -23,6 +24,7 @@ struct DictationView: View {
                 LazyVStack(alignment: .leading, spacing: MuesliTheme.spacing16) {
                     header
                     homeStatsRow
+                    keyboardSessionHomeControl
                     recorderPanel
                     historyHeader
                     historyRows
@@ -72,6 +74,10 @@ struct DictationView: View {
             .onChange(of: microphonePreference) { _, _ in
                 guard isActive else { return }
                 coordinator.refreshAudioInputRoute()
+            }
+            .onChange(of: keyboardSessionMode) { _, enabled in
+                guard isActive else { return }
+                coordinator.setKeyboardSessionModeEnabled(enabled)
             }
             .navigationDestination(for: UUID.self) { resultID in
                 if let result = coordinator.dictationHistory.first(where: { $0.id == resultID }),
@@ -161,6 +167,75 @@ struct DictationView: View {
             meetings: formattedCompactCount(totalMeetingCount(in: sessions)),
             streak: "\(currentActivityStreak(history: history, sessions: sessions))"
         )
+    }
+
+    private var keyboardSessionHomeControl: some View {
+        MuesliSurface(
+            cornerRadius: MuesliTheme.cornerMedium,
+            tint: keyboardSessionMode ? MuesliTheme.success : MuesliTheme.accent,
+            isInteractive: true
+        ) {
+            HStack(spacing: MuesliTheme.spacing12) {
+                ZStack {
+                    Circle()
+                        .fill(keyboardSessionMode ? MuesliTheme.success.opacity(0.16) : MuesliTheme.accentSubtle)
+                    Image(systemName: keyboardSessionMode ? "mic.circle.fill" : "mic.circle")
+                        .font(.system(size: 20, weight: .semibold))
+                        .foregroundStyle(keyboardSessionMode ? MuesliTheme.success : MuesliTheme.accent)
+                }
+                .frame(width: 44, height: 44)
+                .accessibilityHidden(true)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Keep mic ready")
+                        .font(MuesliTheme.headline())
+                        .foregroundStyle(MuesliTheme.textPrimary)
+                    Text(keyboardSessionHomeDetail)
+                        .font(MuesliTheme.caption())
+                        .foregroundStyle(MuesliTheme.textSecondary)
+                        .lineLimit(2)
+                }
+
+                Spacer(minLength: MuesliTheme.spacing8)
+
+                Toggle("Keep mic ready", isOn: $keyboardSessionMode)
+                    .labelsHidden()
+                    .tint(MuesliTheme.success)
+                    .frame(minWidth: 56, minHeight: 44)
+            }
+            .padding(MuesliTheme.spacing12)
+            .contentShape(Rectangle())
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Keep mic ready")
+        .accessibilityValue(keyboardSessionMode ? "On" : "Off")
+        .accessibilityHint("Keeps a Muesli microphone session ready for keyboard dictation.")
+    }
+
+    private var keyboardSessionHomeDetail: String {
+        let status = coordinator.keyboardSessionStatusText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard keyboardSessionMode else {
+            return "Turn on before using Muesli Keyboard for fewer app switches."
+        }
+
+        if status.isEmpty || status == "Off" {
+            return "Starting keyboard microphone standby."
+        }
+
+        switch status {
+        case "Ready":
+            return "Keyboard dictation can start from text fields."
+        case "Starting":
+            return "Preparing the app-owned microphone session."
+        case "Recording":
+            return "Keyboard dictation is listening."
+        case "Transcribing":
+            return "Preparing text for insertion."
+        case "Timed out":
+            return "Timed out. Toggle off and on to restart standby."
+        default:
+            return "\(status)."
+        }
     }
 
     private func totalDictationWords(in history: [DictationResult]) -> Int {

--- a/Muesli/DictationView.swift
+++ b/Muesli/DictationView.swift
@@ -231,8 +231,6 @@ struct DictationView: View {
             return "Keyboard dictation is listening."
         case "Transcribing":
             return "Preparing text for insertion."
-        case "Timed out":
-            return "Timed out. Toggle off and on to restart standby."
         default:
             return "\(status)."
         }

--- a/Muesli/KeyboardSessionKeeper.swift
+++ b/Muesli/KeyboardSessionKeeper.swift
@@ -79,7 +79,7 @@ final class KeyboardSessionKeeper: @unchecked Sendable {
             let targetFormat = try Self.makeTargetFormat()
             let inputNode = engine.inputNode
             let inputFormat = inputNode.outputFormat(forBus: 0)
-            converter = inputFormat.sampleRate != targetFormat.sampleRate || inputFormat.channelCount != targetFormat.channelCount
+            converter = Self.requiresConversion(from: inputFormat, to: targetFormat)
                 ? AVAudioConverter(from: inputFormat, to: targetFormat)
                 : nil
 
@@ -295,7 +295,7 @@ final class KeyboardSessionKeeper: @unchecked Sendable {
 
     private func convert(buffer: AVAudioPCMBuffer, targetFormat: AVAudioFormat) -> AVAudioPCMBuffer? {
         guard let converter else {
-            return buffer
+            return copy(buffer)
         }
 
         let ratio = targetFormat.sampleRate / buffer.format.sampleRate
@@ -320,6 +320,26 @@ final class KeyboardSessionKeeper: @unchecked Sendable {
 
         guard error == nil else { return nil }
         return converted
+    }
+
+    private func copy(_ buffer: AVAudioPCMBuffer) -> AVAudioPCMBuffer? {
+        guard let copy = AVAudioPCMBuffer(pcmFormat: buffer.format, frameCapacity: buffer.frameLength) else {
+            return nil
+        }
+        copy.frameLength = buffer.frameLength
+
+        guard let source = buffer.floatChannelData,
+              let destination = copy.floatChannelData
+        else {
+            return nil
+        }
+
+        let channelCount = Int(buffer.format.channelCount)
+        let frameLength = Int(buffer.frameLength)
+        for channel in 0..<channelCount {
+            destination[channel].update(from: source[channel], count: frameLength)
+        }
+        return copy
     }
 
     private func cleanupAfterFailedStart() {
@@ -402,5 +422,12 @@ final class KeyboardSessionKeeper: @unchecked Sendable {
             throw AudioRecorder.RecordingError.startFailed(stage: "keyboard session format")
         }
         return format
+    }
+
+    private static func requiresConversion(from inputFormat: AVAudioFormat, to targetFormat: AVAudioFormat) -> Bool {
+        inputFormat.sampleRate != targetFormat.sampleRate
+            || inputFormat.channelCount != targetFormat.channelCount
+            || inputFormat.commonFormat != targetFormat.commonFormat
+            || inputFormat.isInterleaved != targetFormat.isInterleaved
     }
 }

--- a/Muesli/KeyboardSessionKeeper.swift
+++ b/Muesli/KeyboardSessionKeeper.swift
@@ -1,57 +1,346 @@
 import AVFoundation
 import Foundation
+import os
 
-@MainActor
-final class KeyboardSessionKeeper {
-    private var engine: AVAudioEngine?
+final class KeyboardSessionKeeper: @unchecked Sendable {
+    private struct FileState {
+        var activeFile: AVAudioFile?
+        var activeURL: URL?
+        var latestPowerDB: Float = -160
+        var segmentFrames: AVAudioFramePosition = 0
+        var lastInputBufferAt: Date?
+        var lastInputActivityNotifiedAt = Date.distantPast
+    }
+
+    private let engine = AVAudioEngine()
+    private let lock = NSLock()
+    private var state = FileState()
+    private var converter: AVAudioConverter?
+    private var isEngineRunning = false
+    private var isStarting = false
+    private var tapInstalled = false
+    private var inputActivityHandler: (@Sendable (_ powerDB: Float, _ isCapturing: Bool) -> Void)?
+
+    private static let sampleRate: Double = 16_000
+    private static let bufferSize: AVAudioFrameCount = 2_048
+
+    static func discardAudioTap(_ buffer: AVAudioPCMBuffer, when _: AVAudioTime) {
+        _ = buffer.frameLength
+    }
 
     var isRunning: Bool {
-        engine?.isRunning == true
+        lock.lock()
+        let shouldBeRunning = isEngineRunning
+        lock.unlock()
+        return shouldBeRunning && engine.isRunning
+    }
+
+    var canAcceptStartCommand: Bool {
+        lock.lock()
+        let shouldBeRunning = isEngineRunning
+        let hasTap = tapInstalled
+        lock.unlock()
+
+        return shouldBeRunning && hasTap && engine.isRunning
+    }
+
+    var isRecordingSegment: Bool {
+        lock.lock()
+        let recording = state.activeFile != nil
+        lock.unlock()
+        return recording
     }
 
     func start() async throws {
-        if isRunning { return }
-
-        let granted = await AVAudioApplication.requestRecordPermission()
-        guard granted else {
-            throw AudioRecorder.RecordingError.microphonePermissionDenied
-        }
-
-        _ = try AudioInputRouteManager.configureForKeyboardKeepAlive(stage: "keyboard session")
-
-        let engine = AVAudioEngine()
-        let inputNode = engine.inputNode
-        let format = inputNode.inputFormat(forBus: 0)
-        inputNode.installTap(onBus: 0, bufferSize: 1_024, format: format, block: Self.discardAudioTap)
-        engine.prepare()
-
-        do {
-            try engine.start()
-        } catch {
-            inputNode.removeTap(onBus: 0)
-            try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
-            throw AudioRecorder.RecordingError.startFailed(stage: "keyboard session")
-        }
-
-        self.engine = engine
-    }
-
-    func stop(deactivateSession: Bool = true) {
-        guard let engine else {
-            if deactivateSession {
-                try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
-            }
+        guard beginStartingIfNeeded() else {
             return
         }
 
-        engine.inputNode.removeTap(onBus: 0)
+        let granted = await AVAudioApplication.requestRecordPermission()
+        guard granted else {
+            setEngineStarting(false)
+            throw AudioRecorder.RecordingError.microphonePermissionDenied
+        }
+
+        do {
+            _ = try AudioInputRouteManager.configureForRecording(stage: "keyboard session")
+            prepareForStart()
+
+            let targetFormat = try Self.makeTargetFormat()
+            let inputNode = engine.inputNode
+            let inputFormat = inputNode.outputFormat(forBus: 0)
+            converter = inputFormat.sampleRate != targetFormat.sampleRate || inputFormat.channelCount != targetFormat.channelCount
+                ? AVAudioConverter(from: inputFormat, to: targetFormat)
+                : nil
+
+            inputNode.installTap(onBus: 0, bufferSize: Self.bufferSize, format: nil) { [weak self] buffer, _ in
+                self?.handle(buffer: buffer, targetFormat: targetFormat)
+            }
+            setTapInstalled(true)
+            engine.prepare()
+            try engine.start()
+
+            setEngineRunning(true)
+        } catch {
+            cleanupAfterFailedStart()
+            if error is AudioRecorder.RecordingError {
+                throw error
+            }
+            throw AudioRecorder.RecordingError.startFailed(stage: "keyboard session")
+        }
+    }
+
+    func setInputActivityHandler(
+        _ handler: (@Sendable (_ powerDB: Float, _ isCapturing: Bool) -> Void)?
+    ) {
+        lock.lock()
+        inputActivityHandler = handler
+        lock.unlock()
+    }
+
+    func beginSegment(outputURL: URL) throws {
+        guard isRunning else {
+            throw AudioRecorder.RecordingError.startFailed(stage: "keyboard session inactive")
+        }
+
+        try FileManager.default.createDirectory(at: outputURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        let file = try AVAudioFile(forWriting: outputURL, settings: Self.makeTargetFormat().settings)
+
+        lock.lock()
+        state.activeFile = file
+        state.activeURL = outputURL
+        state.segmentFrames = 0
+        lock.unlock()
+    }
+
+    @discardableResult
+    func finishSegment() throws -> URL {
+        lock.lock()
+        let url = state.activeURL
+        let frameCount = state.segmentFrames
+        state.activeFile = nil
+        state.activeURL = nil
+        state.segmentFrames = 0
+        lock.unlock()
+
+        guard let url, frameCount > 0 else {
+            throw AudioRecorder.RecordingError.noRecording
+        }
+        return url
+    }
+
+    func cancelSegment() {
+        lock.lock()
+        let url = state.activeURL
+        state.activeFile = nil
+        state.activeURL = nil
+        state.segmentFrames = 0
+        lock.unlock()
+
+        if let url {
+            try? FileManager.default.removeItem(at: url)
+        }
+    }
+
+    func stop(deactivateSession: Bool = true) {
+        cancelSegment()
+        if isTapInstalled {
+            engine.inputNode.removeTap(onBus: 0)
+            setTapInstalled(false)
+        }
         engine.stop()
-        self.engine = nil
+        converter = nil
+
+        lock.lock()
+        isStarting = false
+        isEngineRunning = false
+        state.latestPowerDB = -160
+        state.lastInputBufferAt = nil
+        lock.unlock()
 
         if deactivateSession {
             try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
         }
     }
 
-    nonisolated static func discardAudioTap(_: AVAudioPCMBuffer, when _: AVAudioTime) {}
+    func currentPower() -> Float {
+        lock.lock()
+        let value = state.latestPowerDB
+        lock.unlock()
+        return value
+    }
+
+    func waitUntilCanAcceptStartCommand(timeout: TimeInterval = 1.5) async -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if canAcceptStartCommand {
+                return true
+            }
+            try? await Task.sleep(for: .milliseconds(50))
+        }
+        return canAcceptStartCommand
+    }
+
+    private func handle(buffer: AVAudioPCMBuffer, targetFormat: AVAudioFormat) {
+        markInputBufferReceived()
+
+        guard let monoBuffer = convert(buffer: buffer, targetFormat: targetFormat),
+              let floatData = monoBuffer.floatChannelData?[0]
+        else { return }
+
+        let frameCount = Int(monoBuffer.frameLength)
+        guard frameCount > 0 else { return }
+
+        var sumSquares: Float = 0
+        for index in 0..<frameCount {
+            let sample = floatData[index]
+            sumSquares += sample * sample
+        }
+        let rms = sqrt(sumSquares / Float(frameCount))
+        let powerDB = rms > 0.000_001 ? max(-160, min(0, 20 * log10(rms))) : -160
+
+        let handler: (@Sendable (_ powerDB: Float, _ isCapturing: Bool) -> Void)?
+        let shouldNotifyActivity: Bool
+        let isCapturing: Bool
+        let now = Date()
+
+        lock.lock()
+        do {
+            try state.activeFile?.write(from: monoBuffer)
+            if state.activeFile != nil {
+                state.segmentFrames += AVAudioFramePosition(frameCount)
+            }
+            state.latestPowerDB = powerDB
+            state.lastInputBufferAt = now
+        } catch {
+            // Preserve the live session; stop/finish will surface missing audio if writes fail.
+        }
+
+        isCapturing = state.activeFile != nil
+        shouldNotifyActivity = now.timeIntervalSince(state.lastInputActivityNotifiedAt) >= 0.5
+        if shouldNotifyActivity {
+            state.lastInputActivityNotifiedAt = now
+        }
+        handler = inputActivityHandler
+        lock.unlock()
+
+        if shouldNotifyActivity {
+            handler?(powerDB, isCapturing)
+        }
+    }
+
+    private func markInputBufferReceived() {
+        lock.lock()
+        state.lastInputBufferAt = Date()
+        lock.unlock()
+    }
+
+    private func convert(buffer: AVAudioPCMBuffer, targetFormat: AVAudioFormat) -> AVAudioPCMBuffer? {
+        guard let converter else {
+            return buffer
+        }
+
+        let ratio = targetFormat.sampleRate / buffer.format.sampleRate
+        let frameCapacity = max(1, AVAudioFrameCount(Double(buffer.frameLength) * ratio) + 1)
+        guard let converted = AVAudioPCMBuffer(pcmFormat: targetFormat, frameCapacity: frameCapacity) else { return nil }
+
+        let didProvideInput = OSAllocatedUnfairLock(initialState: false)
+        var error: NSError?
+        converter.convert(to: converted, error: &error) { _, outStatus in
+            let shouldProvideInput = didProvideInput.withLock { hasProvidedInput in
+                guard !hasProvidedInput else { return false }
+                hasProvidedInput = true
+                return true
+            }
+            guard shouldProvideInput else {
+                outStatus.pointee = .noDataNow
+                return nil
+            }
+            outStatus.pointee = .haveData
+            return buffer
+        }
+
+        guard error == nil else { return nil }
+        return converted
+    }
+
+    private func cleanupAfterFailedStart() {
+        if isTapInstalled {
+            engine.inputNode.removeTap(onBus: 0)
+            setTapInstalled(false)
+        }
+        engine.stop()
+        converter = nil
+        lock.lock()
+        state = FileState()
+        isStarting = false
+        isEngineRunning = false
+        lock.unlock()
+        try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
+    }
+
+    private func prepareForStart() {
+        if isTapInstalled {
+            engine.inputNode.removeTap(onBus: 0)
+            setTapInstalled(false)
+        }
+        engine.stop()
+        converter = nil
+
+        lock.lock()
+        state.activeFile = nil
+        state.activeURL = nil
+        state.segmentFrames = 0
+        state.lastInputBufferAt = nil
+        isEngineRunning = false
+        lock.unlock()
+    }
+
+    private func beginStartingIfNeeded() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        guard !isStarting, !(isEngineRunning && engine.isRunning) else {
+            return false
+        }
+        isStarting = true
+        return true
+    }
+
+    private var isTapInstalled: Bool {
+        lock.lock()
+        let installed = tapInstalled
+        lock.unlock()
+        return installed
+    }
+
+    private func setTapInstalled(_ installed: Bool) {
+        lock.lock()
+        tapInstalled = installed
+        lock.unlock()
+    }
+
+    private func setEngineStarting(_ starting: Bool) {
+        lock.lock()
+        isStarting = starting
+        lock.unlock()
+    }
+
+    private func setEngineRunning(_ running: Bool) {
+        lock.lock()
+        isStarting = false
+        isEngineRunning = running
+        lock.unlock()
+    }
+
+    private static func makeTargetFormat() throws -> AVAudioFormat {
+        guard let format = AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: sampleRate,
+            channels: 1,
+            interleaved: false
+        ) else {
+            throw AudioRecorder.RecordingError.startFailed(stage: "keyboard session format")
+        }
+        return format
+    }
 }

--- a/Muesli/KeyboardSessionKeeper.swift
+++ b/Muesli/KeyboardSessionKeeper.swift
@@ -3,6 +3,10 @@ import Foundation
 import os
 
 final class KeyboardSessionKeeper: @unchecked Sendable {
+    private final class ConverterInputState: @unchecked Sendable {
+        var didProvideInput = false
+    }
+
     private struct FileState {
         var activeFile: AVAudioFile?
         var activeURL: URL?
@@ -73,6 +77,7 @@ final class KeyboardSessionKeeper: @unchecked Sendable {
         }
 
         do {
+            // Standby captures real keyboard dictation segments, so it must honor the selected route.
             _ = try AudioInputRouteManager.configureForRecording(stage: "keyboard session")
             prepareForStart()
 
@@ -298,14 +303,14 @@ final class KeyboardSessionKeeper: @unchecked Sendable {
         let frameCapacity = max(1, AVAudioFrameCount(Double(buffer.frameLength) * ratio) + 1)
         guard let converted = AVAudioPCMBuffer(pcmFormat: targetFormat, frameCapacity: frameCapacity) else { return nil }
 
-        var didProvideInput = false
+        let inputState = ConverterInputState()
         var error: NSError?
         converter.convert(to: converted, error: &error) { _, outStatus in
-            guard !didProvideInput else {
+            guard !inputState.didProvideInput else {
                 outStatus.pointee = .noDataNow
                 return nil
             }
-            didProvideInput = true
+            inputState.didProvideInput = true
             outStatus.pointee = .haveData
             return buffer
         }

--- a/Muesli/KeyboardSessionKeeper.swift
+++ b/Muesli/KeyboardSessionKeeper.swift
@@ -217,42 +217,23 @@ final class KeyboardSessionKeeper: @unchecked Sendable {
     }
 
     private func handle(buffer: AVAudioPCMBuffer, targetFormat: AVAudioFormat) {
-        markInputBufferReceived()
-
-        guard let monoBuffer = convert(buffer: buffer, targetFormat: targetFormat),
-              let floatData = monoBuffer.floatChannelData?[0]
-        else { return }
-
-        let frameCount = Int(monoBuffer.frameLength)
-        guard frameCount > 0 else { return }
-
-        var sumSquares: Float = 0
-        for index in 0..<frameCount {
-            let sample = floatData[index]
-            sumSquares += sample * sample
-        }
-        let rms = sqrt(sumSquares / Float(frameCount))
-        let powerDB = rms > 0.000_001 ? max(-160, min(0, 20 * log10(rms))) : -160
-
+        let powerDB = Self.powerDB(for: buffer)
+        let now = Date()
         let handler: (@Sendable (_ powerDB: Float, _ isCapturing: Bool) -> Void)?
         let shouldNotifyActivity: Bool
-        let isCapturing: Bool
-        let now = Date()
+        let file: AVAudioFile?
+        let segmentID: UUID?
 
         lock.lock()
-        if let file = state.activeFile,
-           let segmentID = state.activeSegmentID,
+        if let activeFile = state.activeFile,
+           let activeSegmentID = state.activeSegmentID,
            !state.isFinishingSegment
         {
-            enqueue(PendingFileWrite(
-                segmentID: segmentID,
-                file: file,
-                buffer: monoBuffer,
-                frameCount: frameCount
-            ))
-            isCapturing = true
+            file = activeFile
+            segmentID = activeSegmentID
         } else {
-            isCapturing = false
+            file = nil
+            segmentID = nil
         }
         state.latestPowerDB = powerDB
         state.lastInputBufferAt = now
@@ -263,8 +244,29 @@ final class KeyboardSessionKeeper: @unchecked Sendable {
         handler = inputActivityHandler
         lock.unlock()
 
+        if let file,
+           let segmentID,
+           let monoBuffer = convert(buffer: buffer, targetFormat: targetFormat)
+        {
+            let frameCount = Int(monoBuffer.frameLength)
+            if frameCount > 0 {
+                lock.lock()
+                let shouldWrite = state.activeSegmentID == segmentID && !state.isFinishingSegment
+                lock.unlock()
+
+                if shouldWrite {
+                    enqueue(PendingFileWrite(
+                        segmentID: segmentID,
+                        file: file,
+                        buffer: monoBuffer,
+                        frameCount: frameCount
+                    ))
+                }
+            }
+        }
+
         if shouldNotifyActivity {
-            handler?(powerDB, isCapturing)
+            handler?(powerDB, file != nil)
         }
     }
 
@@ -287,12 +289,6 @@ final class KeyboardSessionKeeper: @unchecked Sendable {
         lock.unlock()
     }
 
-    private func markInputBufferReceived() {
-        lock.lock()
-        state.lastInputBufferAt = Date()
-        lock.unlock()
-    }
-
     private func convert(buffer: AVAudioPCMBuffer, targetFormat: AVAudioFormat) -> AVAudioPCMBuffer? {
         guard let converter else {
             return copy(buffer)
@@ -302,18 +298,14 @@ final class KeyboardSessionKeeper: @unchecked Sendable {
         let frameCapacity = max(1, AVAudioFrameCount(Double(buffer.frameLength) * ratio) + 1)
         guard let converted = AVAudioPCMBuffer(pcmFormat: targetFormat, frameCapacity: frameCapacity) else { return nil }
 
-        let didProvideInput = OSAllocatedUnfairLock(initialState: false)
+        var didProvideInput = false
         var error: NSError?
         converter.convert(to: converted, error: &error) { _, outStatus in
-            let shouldProvideInput = didProvideInput.withLock { hasProvidedInput in
-                guard !hasProvidedInput else { return false }
-                hasProvidedInput = true
-                return true
-            }
-            guard shouldProvideInput else {
+            guard !didProvideInput else {
                 outStatus.pointee = .noDataNow
                 return nil
             }
+            didProvideInput = true
             outStatus.pointee = .haveData
             return buffer
         }
@@ -340,6 +332,22 @@ final class KeyboardSessionKeeper: @unchecked Sendable {
             destination[channel].update(from: source[channel], count: frameLength)
         }
         return copy
+    }
+
+    private static func powerDB(for buffer: AVAudioPCMBuffer) -> Float {
+        guard let floatData = buffer.floatChannelData?[0] else { return -160 }
+
+        let frameCount = Int(buffer.frameLength)
+        guard frameCount > 0 else { return -160 }
+
+        var sumSquares: Float = 0
+        for index in 0..<frameCount {
+            let sample = floatData[index]
+            sumSquares += sample * sample
+        }
+
+        let rms = sqrt(sumSquares / Float(frameCount))
+        return rms > 0.000_001 ? max(-160, min(0, 20 * log10(rms))) : -160
     }
 
     private func cleanupAfterFailedStart() {

--- a/Muesli/KeyboardSessionKeeper.swift
+++ b/Muesli/KeyboardSessionKeeper.swift
@@ -6,14 +6,24 @@ final class KeyboardSessionKeeper: @unchecked Sendable {
     private struct FileState {
         var activeFile: AVAudioFile?
         var activeURL: URL?
+        var activeSegmentID: UUID?
         var latestPowerDB: Float = -160
         var segmentFrames: AVAudioFramePosition = 0
         var lastInputBufferAt: Date?
         var lastInputActivityNotifiedAt = Date.distantPast
+        var isFinishingSegment = false
+    }
+
+    private struct PendingFileWrite: @unchecked Sendable {
+        let segmentID: UUID
+        let file: AVAudioFile
+        let buffer: AVAudioPCMBuffer
+        let frameCount: Int
     }
 
     private let engine = AVAudioEngine()
     private let lock = NSLock()
+    private let fileWriteQueue = DispatchQueue(label: "com.muesli.keyboardSessionKeeper.fileWrite")
     private var state = FileState()
     private var converter: AVAudioConverter?
     private var isEngineRunning = false
@@ -105,22 +115,36 @@ final class KeyboardSessionKeeper: @unchecked Sendable {
 
         try FileManager.default.createDirectory(at: outputURL.deletingLastPathComponent(), withIntermediateDirectories: true)
         let file = try AVAudioFile(forWriting: outputURL, settings: Self.makeTargetFormat().settings)
+        let segmentID = UUID()
 
         lock.lock()
         state.activeFile = file
         state.activeURL = outputURL
+        state.activeSegmentID = segmentID
         state.segmentFrames = 0
+        state.isFinishingSegment = false
         lock.unlock()
     }
 
     @discardableResult
     func finishSegment() throws -> URL {
         lock.lock()
+        state.isFinishingSegment = true
         let url = state.activeURL
-        let frameCount = state.segmentFrames
+        let segmentID = state.activeSegmentID
+        lock.unlock()
+
+        if segmentID != nil {
+            fileWriteQueue.sync {}
+        }
+
+        lock.lock()
+        let frameCount = segmentID == state.activeSegmentID ? state.segmentFrames : 0
         state.activeFile = nil
         state.activeURL = nil
+        state.activeSegmentID = nil
         state.segmentFrames = 0
+        state.isFinishingSegment = false
         lock.unlock()
 
         guard let url, frameCount > 0 else {
@@ -131,10 +155,21 @@ final class KeyboardSessionKeeper: @unchecked Sendable {
 
     func cancelSegment() {
         lock.lock()
+        state.isFinishingSegment = true
         let url = state.activeURL
+        let segmentID = state.activeSegmentID
+        lock.unlock()
+
+        if segmentID != nil {
+            fileWriteQueue.sync {}
+        }
+
+        lock.lock()
         state.activeFile = nil
         state.activeURL = nil
+        state.activeSegmentID = nil
         state.segmentFrames = 0
+        state.isFinishingSegment = false
         lock.unlock()
 
         if let url {
@@ -205,18 +240,22 @@ final class KeyboardSessionKeeper: @unchecked Sendable {
         let now = Date()
 
         lock.lock()
-        do {
-            try state.activeFile?.write(from: monoBuffer)
-            if state.activeFile != nil {
-                state.segmentFrames += AVAudioFramePosition(frameCount)
-            }
-            state.latestPowerDB = powerDB
-            state.lastInputBufferAt = now
-        } catch {
-            // Preserve the live session; stop/finish will surface missing audio if writes fail.
+        if let file = state.activeFile,
+           let segmentID = state.activeSegmentID,
+           !state.isFinishingSegment
+        {
+            enqueue(PendingFileWrite(
+                segmentID: segmentID,
+                file: file,
+                buffer: monoBuffer,
+                frameCount: frameCount
+            ))
+            isCapturing = true
+        } else {
+            isCapturing = false
         }
-
-        isCapturing = state.activeFile != nil
+        state.latestPowerDB = powerDB
+        state.lastInputBufferAt = now
         shouldNotifyActivity = now.timeIntervalSince(state.lastInputActivityNotifiedAt) >= 0.5
         if shouldNotifyActivity {
             state.lastInputActivityNotifiedAt = now
@@ -227,6 +266,25 @@ final class KeyboardSessionKeeper: @unchecked Sendable {
         if shouldNotifyActivity {
             handler?(powerDB, isCapturing)
         }
+    }
+
+    private func enqueue(_ write: PendingFileWrite) {
+        fileWriteQueue.async { [weak self] in
+            do {
+                try write.file.write(from: write.buffer)
+                self?.recordWrittenFrames(write.frameCount, for: write.segmentID)
+            } catch {
+                // Preserve the live session; stop/finish will surface missing audio if writes fail.
+            }
+        }
+    }
+
+    private func recordWrittenFrames(_ frameCount: Int, for segmentID: UUID) {
+        lock.lock()
+        if state.activeSegmentID == segmentID {
+            state.segmentFrames += AVAudioFramePosition(frameCount)
+        }
+        lock.unlock()
     }
 
     private func markInputBufferReceived() {
@@ -290,8 +348,10 @@ final class KeyboardSessionKeeper: @unchecked Sendable {
         lock.lock()
         state.activeFile = nil
         state.activeURL = nil
+        state.activeSegmentID = nil
         state.segmentFrames = 0
         state.lastInputBufferAt = nil
+        state.isFinishingSegment = false
         isEngineRunning = false
         lock.unlock()
     }

--- a/Muesli/MuesliLiveActivityController.swift
+++ b/Muesli/MuesliLiveActivityController.swift
@@ -12,7 +12,7 @@ actor MuesliLiveActivityController {
         guard ActivityAuthorizationInfo().areActivitiesEnabled else { return }
 
         await endInactiveActivities()
-        activity = activity(for: session)
+        activity = resolvedActivity(for: session)
         if activity != nil {
             await update(phase: phase, detail: detail, session: session)
             return
@@ -43,7 +43,7 @@ actor MuesliLiveActivityController {
             await endActivities(for: session.kind, phase: "Off", detail: "Live Activities disabled")
             return
         }
-        activity = activity(for: session)
+        activity = resolvedActivity(for: session)
         guard let activity else { return }
         await activity.update(ActivityContent(
             state: contentState(phase: phase, detail: detail, session: session),
@@ -52,15 +52,17 @@ actor MuesliLiveActivityController {
     }
 
     func end(phase: String, detail: String, session: RecordingSession, dismissal: ActivityUIDismissalPolicy = .default) async {
-        guard let activity = activity(for: session) else { return }
-        await activity.end(
+        guard let resolvedActivity = resolvedActivity(for: session) else { return }
+        await resolvedActivity.end(
             ActivityContent(
                 state: contentState(phase: phase, detail: detail, session: session),
                 staleDate: nil
             ),
             dismissalPolicy: dismissal
         )
-        self.activity = nil
+        if activity?.attributes.sessionID == session.id.uuidString {
+            activity = nil
+        }
     }
 
     func endInactiveActivities() async {
@@ -165,7 +167,7 @@ actor MuesliLiveActivityController {
         }
     }
 
-    private func activity(for session: RecordingSession) -> Activity<MuesliLiveActivityAttributes>? {
+    private func resolvedActivity(for session: RecordingSession) -> Activity<MuesliLiveActivityAttributes>? {
         if let activity, activity.attributes.sessionID == session.id.uuidString {
             return activity
         }

--- a/Muesli/MuesliLiveActivityController.swift
+++ b/Muesli/MuesliLiveActivityController.swift
@@ -12,7 +12,7 @@ actor MuesliLiveActivityController {
         guard ActivityAuthorizationInfo().areActivitiesEnabled else { return }
 
         await endInactiveActivities()
-        activity = activity ?? existingActivity(for: session)
+        activity = activity(for: session)
         if activity != nil {
             await update(phase: phase, detail: detail, session: session)
             return
@@ -43,7 +43,7 @@ actor MuesliLiveActivityController {
             await endActivities(for: session.kind, phase: "Off", detail: "Live Activities disabled")
             return
         }
-        activity = activity ?? existingActivity(for: session)
+        activity = activity(for: session)
         guard let activity else { return }
         await activity.update(ActivityContent(
             state: contentState(phase: phase, detail: detail, session: session),
@@ -52,8 +52,7 @@ actor MuesliLiveActivityController {
     }
 
     func end(phase: String, detail: String, session: RecordingSession, dismissal: ActivityUIDismissalPolicy = .default) async {
-        activity = activity ?? existingActivity(for: session)
-        guard let activity else { return }
+        guard let activity = activity(for: session) else { return }
         await activity.end(
             ActivityContent(
                 state: contentState(phase: phase, detail: detail, session: session),
@@ -164,6 +163,14 @@ actor MuesliLiveActivityController {
         Activity<MuesliLiveActivityAttributes>.activities.first {
             $0.attributes.sessionID == session.id.uuidString
         }
+    }
+
+    private func activity(for session: RecordingSession) -> Activity<MuesliLiveActivityAttributes>? {
+        if let activity, activity.attributes.sessionID == session.id.uuidString {
+            return activity
+        }
+
+        return existingActivity(for: session)
     }
 
     private func isActiveSessionPhase(_ phase: String) -> Bool {

--- a/Muesli/MuesliPreferences.swift
+++ b/Muesli/MuesliPreferences.swift
@@ -6,7 +6,6 @@ enum MuesliPreferences {
     static let liveActivitiesForDictationsKey = "muesli.liveActivities.dictations"
     static let liveActivitiesForMeetingsKey = "muesli.liveActivities.meetings"
     static let keyboardSessionModeKey = "muesli.keyboardSession.enabled"
-    static let keyboardSessionTimeoutMinutesKey = "muesli.keyboardSession.timeoutMinutes"
     static let fillerWordRemovalKey = "muesli.transcription.fillerWordRemoval"
     static let customDictionaryKey = "muesli.transcription.customDictionary"
     static let transcriptionModelKey = "muesli.transcription.localModel"
@@ -43,11 +42,6 @@ enum MuesliPreferences {
 
     static var keyboardSessionModeEnabled: Bool {
         bool(for: keyboardSessionModeKey, defaultValue: false)
-    }
-
-    static var keyboardSessionTimeoutMinutes: Int {
-        let value = UserDefaults.standard.integer(forKey: keyboardSessionTimeoutMinutesKey)
-        return value == 0 ? 10 : min(max(value, 1), 30)
     }
 
     static var fillerWordRemovalEnabled: Bool {

--- a/Muesli/SettingsView.swift
+++ b/Muesli/SettingsView.swift
@@ -234,14 +234,8 @@ struct SettingsView: View {
                     SettingsToggleRow(
                         icon: "keyboard.badge.ellipsis",
                         title: "Keyboard Session Mode",
-                        detail: "Keep Muesli ready for longer voice notes from the keyboard with a visible microphone session.",
+                        detail: keyboardSessionModeDetail,
                         isOn: $keyboardSessionMode
-                    )
-                    Divider().overlay(MuesliTheme.surfaceBorder)
-                    SettingsRow(
-                        icon: "waveform.badge.mic",
-                        title: "Session",
-                        value: coordinator.keyboardSessionStatusText
                     )
                     Divider().overlay(MuesliTheme.surfaceBorder)
                     SettingsMicrophonePicker(selection: $microphonePreference)
@@ -272,6 +266,16 @@ struct SettingsView: View {
                 .padding(MuesliTheme.spacing16)
             }
         }
+    }
+
+    private var keyboardSessionModeDetail: String {
+        guard keyboardSessionMode else {
+            return "Start from the keyboard will open Muesli when microphone access is needed."
+        }
+
+        let status = coordinator.keyboardSessionStatusText.trimmingCharacters(in: .whitespacesAndNewlines)
+        let statusText = status.isEmpty ? "Starting" : status
+        return "\(statusText). Keeps Muesli ready for longer voice notes from the keyboard with a visible microphone session."
     }
 
     private var meetingSettings: some View {

--- a/Muesli/SettingsView.swift
+++ b/Muesli/SettingsView.swift
@@ -269,13 +269,16 @@ struct SettingsView: View {
     }
 
     private var keyboardSessionModeDetail: String {
+        let status = coordinator.keyboardSessionStatusText.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !status.isEmpty, status != "Off" {
+            return "\(status). Keeps Muesli ready for longer voice notes from the keyboard with a visible microphone session."
+        }
+
         guard keyboardSessionMode else {
             return "Start from the keyboard will open Muesli when microphone access is needed."
         }
 
-        let status = coordinator.keyboardSessionStatusText.trimmingCharacters(in: .whitespacesAndNewlines)
-        let statusText = status.isEmpty ? "Starting" : status
-        return "\(statusText). Keeps Muesli ready for longer voice notes from the keyboard with a visible microphone session."
+        return "Starting. Keeps Muesli ready for longer voice notes from the keyboard with a visible microphone session."
     }
 
     private var meetingSettings: some View {

--- a/Muesli/SettingsView.swift
+++ b/Muesli/SettingsView.swift
@@ -269,16 +269,25 @@ struct SettingsView: View {
     }
 
     private var keyboardSessionModeDetail: String {
+        let baseDetail = "Keeps Muesli ready for longer voice notes from the keyboard with a visible microphone session."
         let status = coordinator.keyboardSessionStatusText.trimmingCharacters(in: .whitespacesAndNewlines)
         if !status.isEmpty, status != "Off" {
-            return "\(status). Keeps Muesli ready for longer voice notes from the keyboard with a visible microphone session."
+            switch status {
+            case "Ready", "Starting", "Recording", "Transcribing", "Timed out":
+                return "\(status). \(baseDetail)"
+            default:
+                if status.hasPrefix("Retrying session standby") || status.hasPrefix("Session standby unavailable") {
+                    return "\(status). \(baseDetail)"
+                }
+                return "Session standby needs attention. Tap Start to record normally, or toggle this off and on to retry."
+            }
         }
 
         guard keyboardSessionMode else {
             return "Start from the keyboard will open Muesli when microphone access is needed."
         }
 
-        return "Starting. Keeps Muesli ready for longer voice notes from the keyboard with a visible microphone session."
+        return "Starting. \(baseDetail)"
     }
 
     private var meetingSettings: some View {

--- a/Muesli/SettingsView.swift
+++ b/Muesli/SettingsView.swift
@@ -260,13 +260,13 @@ struct SettingsView: View {
         let status = coordinator.keyboardSessionStatusText.trimmingCharacters(in: .whitespacesAndNewlines)
         if !status.isEmpty, status != "Off" {
             switch status {
-            case "Ready", "Starting", "Recording", "Transcribing", "Timed out":
+            case "Ready", "Starting", "Recording", "Transcribing":
                 return "\(status). \(baseDetail)"
             default:
                 if status.hasPrefix("Retrying session standby") || status.hasPrefix("Session standby unavailable") {
                     return "\(status). \(baseDetail)"
                 }
-                return "Session standby needs attention. Tap Start to record normally, or toggle this off and on to retry."
+                return "\(status). Tap Start to record normally, or toggle this off and on to retry."
             }
         }
 

--- a/Muesli/SettingsView.swift
+++ b/Muesli/SettingsView.swift
@@ -64,6 +64,7 @@ struct SettingsView: View {
                 coordinator.applyLiveActivityPreferences()
             }
             .onChange(of: keyboardSessionMode) { _, enabled in
+                guard isActive else { return }
                 coordinator.setKeyboardSessionModeEnabled(enabled)
             }
             .onChange(of: microphonePreference) { _, newValue in

--- a/Muesli/SettingsView.swift
+++ b/Muesli/SettingsView.swift
@@ -10,7 +10,6 @@ struct SettingsView: View {
     @AppStorage(MuesliPreferences.liveActivitiesForDictationsKey) private var liveActivitiesForDictations = true
     @AppStorage(MuesliPreferences.liveActivitiesForMeetingsKey) private var liveActivitiesForMeetings = true
     @AppStorage(MuesliPreferences.keyboardSessionModeKey) private var keyboardSessionMode = false
-    @AppStorage(MuesliPreferences.keyboardSessionTimeoutMinutesKey) private var keyboardSessionTimeoutMinutes = 10
     @AppStorage(MuesliPreferences.recordingMicrophonePreferenceKey) private var microphonePreference = RecordingMicrophonePreference.automatic.rawValue
     @AppStorage(MuesliPreferences.keepDictationAudioRecordingsKey) private var keepDictationAudioRecordings = false
     @AppStorage(MuesliPreferences.keepMeetingAudioRecordingsKey) private var keepMeetingAudioRecordings = false
@@ -66,9 +65,6 @@ struct SettingsView: View {
             }
             .onChange(of: keyboardSessionMode) { _, enabled in
                 coordinator.setKeyboardSessionModeEnabled(enabled)
-            }
-            .onChange(of: keyboardSessionTimeoutMinutes) { _, _ in
-                coordinator.refreshKeyboardSessionTimeout()
             }
             .onChange(of: microphonePreference) { _, newValue in
                 guard isActive else { return }
@@ -240,15 +236,6 @@ struct SettingsView: View {
                     Divider().overlay(MuesliTheme.surfaceBorder)
                     SettingsMicrophonePicker(selection: $microphonePreference)
                     Divider().overlay(MuesliTheme.surfaceBorder)
-                    Stepper(value: $keyboardSessionTimeoutMinutes, in: 1...30, step: 1) {
-                        SettingsRow(
-                            icon: "timer",
-                            title: "Timeout",
-                            value: "\(keyboardSessionTimeoutMinutes) min"
-                        )
-                    }
-                    .disabled(!keyboardSessionMode)
-                    Divider().overlay(MuesliTheme.surfaceBorder)
                     SettingsToggleRow(
                         icon: "waveform.badge.mic",
                         title: "Voice Note Live Activities",
@@ -269,7 +256,7 @@ struct SettingsView: View {
     }
 
     private var keyboardSessionModeDetail: String {
-        let baseDetail = "Keeps Muesli ready for longer voice notes from the keyboard with a visible microphone session."
+        let baseDetail = "Keeps an app-owned microphone session live so the keyboard can start and stop voice notes without reopening Muesli."
         let status = coordinator.keyboardSessionStatusText.trimmingCharacters(in: .whitespacesAndNewlines)
         if !status.isEmpty, status != "Off" {
             switch status {
@@ -284,7 +271,7 @@ struct SettingsView: View {
         }
 
         guard keyboardSessionMode else {
-            return "Start from the keyboard will open Muesli when microphone access is needed."
+            return "When off, keyboard Start opens Muesli because iOS keyboards cannot own microphone access."
         }
 
         return "Starting. \(baseDetail)"

--- a/MuesliKeyboard/KeyboardController.swift
+++ b/MuesliKeyboard/KeyboardController.swift
@@ -22,6 +22,7 @@ final class KeyboardController {
     private var insertedRequestIDs = Set<UUID>()
     private var cancelledRequestIDs = Set<UUID>()
     private var lastRuntimeLevelUpdateAt = Date.distantPast
+    private var isKeyboardSessionModeEnabled = false
 
     var statusText = "Record a voice note first"
     var hasLatestDictation = false
@@ -101,7 +102,7 @@ final class KeyboardController {
         case .transcribing:
             .transcribing
         case .finished:
-            .inserted
+            .record
         default:
             .record
         }
@@ -110,7 +111,6 @@ final class KeyboardController {
     var isPrimaryButtonDisabled: Bool {
         recoveryRequestID == nil && (
             dictationPhase == .transcribing
-            || dictationPhase == .finished
             || latestHandoffState?.phase == .stopRequested
         )
     }
@@ -132,7 +132,7 @@ final class KeyboardController {
     }
 
     var canCancelActiveDictation: Bool {
-        [.requested, .recording].contains(dictationPhase)
+        [.requested, .recording, .transcribing].contains(dictationPhase)
     }
 
     var settingsURL: URL? {
@@ -161,8 +161,10 @@ final class KeyboardController {
         switch dictationPhase {
         case .requested, .recording:
             stopActiveDictation()
-        case .transcribing, .finished:
+        case .transcribing:
             break
+        case .finished:
+            startDictation()
         default:
             startDictation()
         }
@@ -384,8 +386,11 @@ final class KeyboardController {
         do {
             let runtimeStatus = try store.keyboardRuntimeStatus()
             latestRuntimeStatus = runtimeStatus
+            refreshKeyboardSessionPreference(runtimeStatus: runtimeStatus)
             apply(runtimeStatus: runtimeStatus)
         } catch {
+            refreshKeyboardSessionPreference(runtimeStatus: latestRuntimeStatus)
+            apply(runtimeStatus: latestRuntimeStatus)
             inputLevel = 0
         }
     }
@@ -394,6 +399,7 @@ final class KeyboardController {
         do {
             let runtimeStatus = try store.keyboardRuntimeStatus()
             latestRuntimeStatus = runtimeStatus
+            refreshKeyboardSessionPreference(runtimeStatus: runtimeStatus)
             apply(runtimeStatus: runtimeStatus)
 
             let handoffState = try store.keyboardHandoffState()
@@ -430,7 +436,17 @@ final class KeyboardController {
                 statusText = "Latest ready"
             }
         } catch {
+            refreshKeyboardSessionPreference(runtimeStatus: latestRuntimeStatus)
+            apply(runtimeStatus: latestRuntimeStatus)
             statusText = "Waiting for Full Access"
+        }
+    }
+
+    private func refreshKeyboardSessionPreference(runtimeStatus: KeyboardRuntimeStatus?) {
+        if let preference = try? store.keyboardSessionPreference() {
+            isKeyboardSessionModeEnabled = preference.isEnabled
+        } else if runtimeStatus?.sessionModeEnabled == true {
+            isKeyboardSessionModeEnabled = true
         }
     }
 
@@ -541,9 +557,7 @@ final class KeyboardController {
         let now = Date()
         let isRecent = runtimeStatus.map { now.timeIntervalSince($0.updatedAt) < 8 } ?? false
         applyRuntimeInputLevel(isRecent ? (runtimeStatus?.inputLevel ?? 0) : 0, now: now)
-        canUseRuntimeStart = runtimeStatus?.isActive == true
-            && isRecent
-            && runtimeStatus?.supportsBackgroundStart == true
+        canUseRuntimeStart = runtimeStatus?.canAcceptStartCommand == true && isRecent
 
         guard activeRequestID == nil, canUseRuntimeStart else { return }
         guard let runtimeRequestID = runtimeStatus?.activeRequestID,
@@ -747,8 +761,8 @@ final class KeyboardController {
         preparedRequest = nil
         recoveryRequestID = nil
         launchURL = nil
-        dictationPhase = .finished
-        statusText = "Inserted"
+        dictationPhase = .idle
+        statusText = "Latest ready"
         try? store.clearPendingRequest()
         try? store.clearPendingCommand()
         try? store.clearKeyboardLiveTranscript()
@@ -760,12 +774,6 @@ final class KeyboardController {
         try? store.saveStatus(.idle)
         prepareLaunchRequestIfNeeded()
 
-        Task { @MainActor [weak self] in
-            try? await Task.sleep(for: .seconds(1.2))
-            guard let self, self.dictationPhase == .finished else { return }
-            self.dictationPhase = .idle
-            self.statusText = "Latest ready"
-        }
     }
 
     private func makeLaunchURL(for request: DictationRequest) -> URL? {

--- a/MuesliKeyboard/KeyboardController.swift
+++ b/MuesliKeyboard/KeyboardController.swift
@@ -142,10 +142,6 @@ final class KeyboardController {
         return components.url
     }
 
-    var isRecoveryRequested: Bool {
-        recoveryRequestID != nil
-    }
-
     var opensMuesliFromPrimaryButton: Bool {
         recoveryRequestID != nil
             || !canUseRuntimeStart

--- a/MuesliKeyboard/KeyboardController.swift
+++ b/MuesliKeyboard/KeyboardController.swift
@@ -144,7 +144,12 @@ final class KeyboardController {
     var opensMuesliFromPrimaryButton: Bool {
         recoveryRequestID != nil
             || !canUseRuntimeStart
-            && (dictationPhase == .idle || dictationPhase == .failed || (dictationPhase == .requested && activeRequestID == nil))
+            && (
+                dictationPhase == .idle
+                    || dictationPhase == .finished
+                    || dictationPhase == .failed
+                    || (dictationPhase == .requested && activeRequestID == nil)
+            )
     }
 
     func primaryLaunchAction() {
@@ -163,7 +168,12 @@ final class KeyboardController {
         case .transcribing:
             break
         case .finished:
-            startDictation()
+            if canUseRuntimeStart {
+                startDictation()
+            } else {
+                prepareLaunchRequestIfNeeded()
+                statusText = "Open Muesli"
+            }
         default:
             startDictation()
         }

--- a/MuesliKeyboard/KeyboardController.swift
+++ b/MuesliKeyboard/KeyboardController.swift
@@ -395,10 +395,8 @@ final class KeyboardController {
         do {
             let runtimeStatus = try store.keyboardRuntimeStatus()
             latestRuntimeStatus = runtimeStatus
-            refreshKeyboardSessionPreference()
             apply(runtimeStatus: runtimeStatus)
         } catch {
-            refreshKeyboardSessionPreference()
             apply(runtimeStatus: latestRuntimeStatus)
             inputLevel = 0
         }
@@ -408,7 +406,6 @@ final class KeyboardController {
         do {
             let runtimeStatus = try store.keyboardRuntimeStatus()
             latestRuntimeStatus = runtimeStatus
-            refreshKeyboardSessionPreference()
             apply(runtimeStatus: runtimeStatus)
 
             let handoffState = try store.keyboardHandoffState()
@@ -445,15 +442,9 @@ final class KeyboardController {
                 statusText = "Latest ready"
             }
         } catch {
-            refreshKeyboardSessionPreference()
             apply(runtimeStatus: latestRuntimeStatus)
             statusText = "Waiting for Full Access"
         }
-    }
-
-    private func refreshKeyboardSessionPreference() {
-        // Preserve the shared-store read in case opening/reading the backing store has side effects.
-        _ = try? store.keyboardSessionPreference()
     }
 
     private func apply(handoffState: KeyboardHandoffState) {

--- a/MuesliKeyboard/KeyboardController.swift
+++ b/MuesliKeyboard/KeyboardController.swift
@@ -22,7 +22,6 @@ final class KeyboardController {
     private var insertedRequestIDs = Set<UUID>()
     private var cancelledRequestIDs = Set<UUID>()
     private var lastRuntimeLevelUpdateAt = Date.distantPast
-    private var isKeyboardSessionModeEnabled = false
 
     var statusText = "Record a voice note first"
     var hasLatestDictation = false
@@ -386,10 +385,10 @@ final class KeyboardController {
         do {
             let runtimeStatus = try store.keyboardRuntimeStatus()
             latestRuntimeStatus = runtimeStatus
-            refreshKeyboardSessionPreference(runtimeStatus: runtimeStatus)
+            refreshKeyboardSessionPreference()
             apply(runtimeStatus: runtimeStatus)
         } catch {
-            refreshKeyboardSessionPreference(runtimeStatus: latestRuntimeStatus)
+            refreshKeyboardSessionPreference()
             apply(runtimeStatus: latestRuntimeStatus)
             inputLevel = 0
         }
@@ -399,7 +398,7 @@ final class KeyboardController {
         do {
             let runtimeStatus = try store.keyboardRuntimeStatus()
             latestRuntimeStatus = runtimeStatus
-            refreshKeyboardSessionPreference(runtimeStatus: runtimeStatus)
+            refreshKeyboardSessionPreference()
             apply(runtimeStatus: runtimeStatus)
 
             let handoffState = try store.keyboardHandoffState()
@@ -436,18 +435,15 @@ final class KeyboardController {
                 statusText = "Latest ready"
             }
         } catch {
-            refreshKeyboardSessionPreference(runtimeStatus: latestRuntimeStatus)
+            refreshKeyboardSessionPreference()
             apply(runtimeStatus: latestRuntimeStatus)
             statusText = "Waiting for Full Access"
         }
     }
 
-    private func refreshKeyboardSessionPreference(runtimeStatus: KeyboardRuntimeStatus?) {
-        if let preference = try? store.keyboardSessionPreference() {
-            isKeyboardSessionModeEnabled = preference.isEnabled
-        } else if runtimeStatus?.sessionModeEnabled == true {
-            isKeyboardSessionModeEnabled = true
-        }
+    private func refreshKeyboardSessionPreference() {
+        // Preserve the shared-store read in case opening/reading the backing store has side effects.
+        _ = try? store.keyboardSessionPreference()
     }
 
     private func apply(handoffState: KeyboardHandoffState) {

--- a/MuesliKeyboard/KeyboardRootView.swift
+++ b/MuesliKeyboard/KeyboardRootView.swift
@@ -424,9 +424,12 @@ private struct KeyboardRepeatingTextKey: View {
 
     var body: some View {
         KeyboardTextKeyLabel(title: nil, systemImage: systemImage)
-            .buttonStyle(.plain)
             .muesliKeyboardKeySurface()
             .accessibilityLabel(accessibilityLabel)
+            .accessibilityAddTraits(.isButton)
+            .accessibilityAction {
+                action()
+            }
             .gesture(
                 DragGesture(minimumDistance: 0)
                     .onChanged { _ in startRepeatingIfNeeded() }

--- a/MuesliKeyboard/KeyboardRootView.swift
+++ b/MuesliKeyboard/KeyboardRootView.swift
@@ -4,13 +4,13 @@ struct KeyboardRootView: View {
     @Bindable var controller: KeyboardController
 
     var body: some View {
-        VStack(spacing: 10) {
+        VStack(spacing: 7) {
             keyboardDeck
             helperKeys
         }
-        .padding(.horizontal, 10)
-        .padding(.top, MuesliTheme.spacing8)
-        .padding(.bottom, 10)
+        .padding(.horizontal, MuesliTheme.spacing8)
+        .padding(.top, 6)
+        .padding(.bottom, MuesliTheme.spacing8)
         .background(
             LinearGradient(
                 colors: [
@@ -27,11 +27,10 @@ struct KeyboardRootView: View {
     }
 
     private var keyboardDeck: some View {
-        VStack(spacing: 14) {
+        VStack(spacing: 9) {
             Capsule()
                 .fill(MuesliTheme.textSecondary.opacity(0.7))
-                .frame(width: 44, height: 4)
-                .padding(.top, 2)
+                .frame(width: 40, height: 4)
 
             header
 
@@ -43,24 +42,25 @@ struct KeyboardRootView: View {
                     .transition(.opacity.combined(with: .scale(scale: 0.98)))
             }
         }
-        .padding(MuesliTheme.spacing12)
+        .padding(.horizontal, 10)
+        .padding(.top, MuesliTheme.spacing8)
+        .padding(.bottom, 10)
         .muesliKeyboardDeckSurface()
         .animation(.snappy(duration: 0.22), value: controller.showsActiveWaveform)
         .animation(.snappy(duration: 0.22), value: controller.primaryButtonRole)
     }
 
     private var header: some View {
-        HStack(spacing: 10) {
-            MuesliWaveformView(
-                isActive: false,
-                color: MuesliTheme.recording,
-                barCount: 13,
-                spacing: 1.4
-            )
-            .frame(width: 34, height: 24)
+        HStack(spacing: MuesliTheme.spacing8) {
+            Image("MuesliAppIcon")
+                .resizable()
+                .scaledToFit()
+                .frame(width: 32, height: 32)
+                .clipShape(RoundedRectangle(cornerRadius: 7, style: .continuous))
+                .accessibilityHidden(true)
 
             Text("muesli")
-                .font(.system(size: 22, weight: .bold))
+                .font(.system(size: 21, weight: .bold))
                 .foregroundStyle(MuesliTheme.textPrimary)
 
             Spacer()
@@ -80,14 +80,8 @@ struct KeyboardRootView: View {
     }
 
     private var readyRecorder: some View {
-        VStack(spacing: 10) {
+        VStack(spacing: MuesliTheme.spacing8) {
             primaryActionButton(isProminent: true)
-
-            Text(readyHint)
-                .font(.system(size: 13, weight: .medium))
-                .foregroundStyle(MuesliTheme.textSecondary)
-                .lineLimit(1)
-                .minimumScaleFactor(0.82)
 
             if controller.canInsertLatest {
                 Button {
@@ -97,7 +91,7 @@ struct KeyboardRootView: View {
                         .font(.system(size: 13, weight: .semibold))
                         .foregroundStyle(MuesliTheme.recording)
                         .frame(maxWidth: .infinity)
-                        .frame(height: 36)
+                        .frame(height: 32)
                         .background(MuesliTheme.recording.opacity(0.14), in: Capsule())
                         .contentShape(Capsule())
                 }
@@ -107,7 +101,7 @@ struct KeyboardRootView: View {
     }
 
     private var activeRecorder: some View {
-        VStack(spacing: 14) {
+        VStack(spacing: 10) {
             HStack(spacing: 6) {
                 Circle()
                     .fill(activeStatusColor)
@@ -129,7 +123,7 @@ struct KeyboardRootView: View {
                     spacing: 2.5,
                     framesPerSecond: 18
                 )
-                .frame(height: 68)
+                .frame(height: 54)
                 .shadow(color: activeStatusColor.opacity(0.36), radius: 12)
 
                 if controller.dictationPhase == .transcribing {
@@ -160,7 +154,7 @@ struct KeyboardRootView: View {
                         )
                     } else {
                         Color.clear
-                            .frame(height: 44)
+                            .frame(height: 40)
                     }
                 }
                 .frame(maxWidth: .infinity)
@@ -172,8 +166,8 @@ struct KeyboardRootView: View {
     }
 
     private var helperKeys: some View {
-        VStack(spacing: MuesliTheme.spacing8) {
-            HStack(spacing: MuesliTheme.spacing8) {
+        VStack(spacing: 6) {
+            HStack(spacing: 6) {
                 KeyboardTextKey(".") { controller.insertTextKey(".") }
                 KeyboardTextKey(",") { controller.insertTextKey(",") }
                 KeyboardTextKey("?") { controller.insertTextKey("?") }
@@ -184,7 +178,7 @@ struct KeyboardRootView: View {
                 }
             }
 
-            HStack(spacing: MuesliTheme.spacing8) {
+            HStack(spacing: 6) {
                 KeyboardTextKey(systemImage: "globe", accessibilityLabel: "Next keyboard") {
                     controller.switchInputMode()
                 }
@@ -235,7 +229,7 @@ struct KeyboardRootView: View {
         }
         .foregroundStyle(primaryForeground)
         .frame(maxWidth: .infinity)
-        .frame(height: isProminent ? 54 : 44)
+        .frame(height: isProminent ? 48 : 40)
         .background(primaryBackground, in: RoundedRectangle(cornerRadius: isProminent ? 15 : 12, style: .continuous))
         .overlay(
             RoundedRectangle(cornerRadius: isProminent ? 15 : 12, style: .continuous)
@@ -244,18 +238,6 @@ struct KeyboardRootView: View {
         .shadow(color: primaryShadow, radius: isProminent ? 12 : 8, x: 0, y: 5)
         .opacity(controller.isPrimaryButtonDisabled ? 0.55 : 1)
         .contentShape(RoundedRectangle(cornerRadius: isProminent ? 15 : 12, style: .continuous))
-    }
-
-    private var readyHint: String {
-        if controller.isRecoveryRequested {
-            return "Open Muesli to recover this voice note"
-        }
-
-        if controller.opensMuesliFromPrimaryButton {
-            return "Tap Start, then return here to stop and insert"
-        }
-
-        return controller.canInsertLatest ? "Tap Start or insert your latest voice note" : "Tap Start to begin dictating"
     }
 
     private var activeStatusText: String {
@@ -335,7 +317,7 @@ private struct KeyboardControlButton: View {
                 .font(.system(size: 16, weight: .bold))
                 .foregroundStyle(tint)
                 .frame(maxWidth: .infinity)
-                .frame(height: 44)
+                .frame(height: 40)
                 .background(
                     RoundedRectangle(cornerRadius: 12, style: .continuous)
                         .fill(tint.opacity(0.10))
@@ -371,16 +353,16 @@ private struct KeyboardIconLabel: View {
         Image(systemName: systemImage)
             .font(.system(size: 17, weight: .semibold))
             .foregroundStyle(MuesliTheme.textPrimary)
-            .frame(width: 44, height: 44)
+            .frame(width: 38, height: 38)
             .background(
-                RoundedRectangle(cornerRadius: 14, style: .continuous)
+                RoundedRectangle(cornerRadius: 12, style: .continuous)
                     .fill(MuesliTheme.surfacePrimary.opacity(0.76))
             )
             .overlay(
-                RoundedRectangle(cornerRadius: 14, style: .continuous)
+                RoundedRectangle(cornerRadius: 12, style: .continuous)
                     .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
             )
-            .contentShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+            .contentShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
     }
 }
 
@@ -431,7 +413,7 @@ private struct KeyboardTextKeyLabel: View {
         }
         .foregroundStyle(MuesliTheme.textPrimary)
         .frame(maxWidth: .infinity)
-        .frame(minHeight: 44)
+        .frame(minHeight: 40)
         .contentShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
     }
 

--- a/MuesliKeyboard/KeyboardRootView.swift
+++ b/MuesliKeyboard/KeyboardRootView.swift
@@ -1,16 +1,21 @@
 import SwiftUI
 
 struct KeyboardRootView: View {
+    private static let recorderBodyHeight: CGFloat = 84
+    private static let activeStatusWidth: CGFloat = 84
+    private static let activeControlButtonWidth: CGFloat = 120
+    private static let activeWaveformBarCount = 34
+
     @Bindable var controller: KeyboardController
 
     var body: some View {
-        VStack(spacing: 7) {
+        VStack(spacing: 5) {
             keyboardDeck
             helperKeys
         }
         .padding(.horizontal, MuesliTheme.spacing8)
-        .padding(.top, 6)
-        .padding(.bottom, MuesliTheme.spacing8)
+        .padding(.top, 4)
+        .padding(.bottom, 5)
         .background(
             LinearGradient(
                 colors: [
@@ -27,7 +32,7 @@ struct KeyboardRootView: View {
     }
 
     private var keyboardDeck: some View {
-        VStack(spacing: 9) {
+        VStack(spacing: 7) {
             Capsule()
                 .fill(MuesliTheme.textSecondary.opacity(0.7))
                 .frame(width: 40, height: 4)
@@ -43,8 +48,8 @@ struct KeyboardRootView: View {
             }
         }
         .padding(.horizontal, 10)
-        .padding(.top, MuesliTheme.spacing8)
-        .padding(.bottom, 10)
+        .padding(.top, 6)
+        .padding(.bottom, 8)
         .muesliKeyboardDeckSurface()
         .animation(.snappy(duration: 0.22), value: controller.showsActiveWaveform)
         .animation(.snappy(duration: 0.22), value: controller.primaryButtonRole)
@@ -55,12 +60,12 @@ struct KeyboardRootView: View {
             Image("MuesliAppIcon")
                 .resizable()
                 .scaledToFit()
-                .frame(width: 32, height: 32)
+                .frame(width: 28, height: 28)
                 .clipShape(RoundedRectangle(cornerRadius: 7, style: .continuous))
                 .accessibilityHidden(true)
 
             Text("muesli")
-                .font(.system(size: 21, weight: .bold))
+                .font(.system(size: 20, weight: .bold))
                 .foregroundStyle(MuesliTheme.textPrimary)
 
             Spacer()
@@ -96,55 +101,18 @@ struct KeyboardRootView: View {
                         .contentShape(Capsule())
                 }
                 .buttonStyle(.plain)
+            } else {
+                Color.clear
+                    .frame(height: 32)
             }
         }
+        .frame(height: Self.recorderBodyHeight)
     }
 
     private var activeRecorder: some View {
-        VStack(spacing: 10) {
-            HStack(spacing: 6) {
-                Circle()
-                    .fill(activeStatusColor)
-                    .frame(width: 7, height: 7)
-                    .shadow(color: activeStatusColor.opacity(0.75), radius: 5)
-
-                Text(activeStatusText)
-                    .font(.system(size: 14, weight: .semibold))
-                    .foregroundStyle(activeStatusColor)
-                    .lineLimit(1)
-            }
-
-            ZStack {
-                MuesliInlineWaveformView(
-                    mode: controller.waveformMode,
-                    color: activeStatusColor,
-                    level: controller.waveformLevel,
-                    barCount: 24,
-                    spacing: 2.5,
-                    framesPerSecond: 18
-                )
-                .frame(height: 54)
-                .shadow(color: activeStatusColor.opacity(0.36), radius: 12)
-
-                if controller.dictationPhase == .transcribing {
-                    ProgressView()
-                        .tint(activeStatusColor)
-                        .controlSize(.small)
-                }
-            }
-            .frame(maxWidth: .infinity)
-            .padding(.horizontal, MuesliTheme.spacing4)
-
-            if controller.showsLiveTranscript {
-                Text(controller.liveTranscript)
-                    .font(.system(size: 13, weight: .medium))
-                    .foregroundStyle(MuesliTheme.textSecondary)
-                    .lineLimit(2)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding(.horizontal, MuesliTheme.spacing4)
-            }
-
-            HStack(spacing: MuesliTheme.spacing12) {
+        VStack(spacing: MuesliTheme.spacing8) {
+            activeWaveformStrip
+            HStack(spacing: MuesliTheme.spacing8) {
                 Group {
                     if controller.canCancelActiveDictation {
                         KeyboardControlButton(
@@ -157,28 +125,77 @@ struct KeyboardRootView: View {
                             .frame(height: 40)
                     }
                 }
-                .frame(maxWidth: .infinity)
+                .frame(width: Self.activeControlButtonWidth)
 
                 primaryActionButton(isProminent: false)
-                    .frame(maxWidth: .infinity)
+                    .frame(width: Self.activeControlButtonWidth)
             }
         }
+        .frame(height: Self.recorderBodyHeight)
+    }
+
+    private var activeWaveformStrip: some View {
+        HStack(spacing: MuesliTheme.spacing8) {
+            HStack(spacing: 6) {
+                Circle()
+                    .fill(activeStatusColor)
+                    .frame(width: 7, height: 7)
+                    .shadow(color: activeStatusColor.opacity(0.75), radius: 5)
+
+                Text(activeStatusText)
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(activeStatusColor)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.82)
+            }
+            .frame(width: Self.activeStatusWidth, alignment: .leading)
+
+            ZStack {
+                MuesliInlineWaveformView(
+                    mode: controller.waveformMode,
+                    color: activeStatusColor,
+                    level: controller.waveformLevel,
+                    barCount: Self.activeWaveformBarCount,
+                    spacing: 2.2,
+                    framesPerSecond: 18
+                )
+                .frame(height: 24)
+                .shadow(color: activeStatusColor.opacity(0.28), radius: 8)
+
+                if controller.dictationPhase == .transcribing {
+                    ProgressView()
+                        .tint(activeStatusColor)
+                        .controlSize(.small)
+                }
+            }
+            .frame(maxWidth: .infinity)
+        }
+        .frame(height: 36)
+        .padding(.horizontal, 6)
+        .background(
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .fill(MuesliTheme.surfacePrimary.opacity(0.30))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .strokeBorder(activeStatusColor.opacity(0.12), lineWidth: 1)
+        )
     }
 
     private var helperKeys: some View {
-        VStack(spacing: 6) {
-            HStack(spacing: 6) {
+        VStack(spacing: 5) {
+            HStack(spacing: 5) {
                 KeyboardTextKey(".") { controller.insertTextKey(".") }
                 KeyboardTextKey(",") { controller.insertTextKey(",") }
                 KeyboardTextKey("?") { controller.insertTextKey("?") }
                 KeyboardTextKey("!") { controller.insertTextKey("!") }
                 KeyboardTextKey("'") { controller.insertTextKey("'") }
-                KeyboardTextKey(systemImage: "delete.left", accessibilityLabel: "Delete") {
+                KeyboardRepeatingTextKey(systemImage: "delete.left", accessibilityLabel: "Delete") {
                     controller.deleteBackward()
                 }
             }
 
-            HStack(spacing: 6) {
+            HStack(spacing: 5) {
                 KeyboardTextKey(systemImage: "globe", accessibilityLabel: "Next keyboard") {
                     controller.switchInputMode()
                 }
@@ -226,10 +243,12 @@ struct KeyboardRootView: View {
                 .font(.system(size: isProminent ? 21 : 15, weight: .bold))
             Text(primaryActionTitle)
                 .font(.system(size: isProminent ? 19 : 16, weight: .bold))
+                .lineLimit(1)
+                .minimumScaleFactor(0.72)
         }
         .foregroundStyle(primaryForeground)
         .frame(maxWidth: .infinity)
-        .frame(height: isProminent ? 48 : 40)
+        .frame(height: isProminent ? 44 : 36)
         .background(primaryBackground, in: RoundedRectangle(cornerRadius: isProminent ? 15 : 12, style: .continuous))
         .overlay(
             RoundedRectangle(cornerRadius: isProminent ? 15 : 12, style: .continuous)
@@ -317,7 +336,7 @@ private struct KeyboardControlButton: View {
                 .font(.system(size: 16, weight: .bold))
                 .foregroundStyle(tint)
                 .frame(maxWidth: .infinity)
-                .frame(height: 40)
+                .frame(height: 36)
                 .background(
                     RoundedRectangle(cornerRadius: 12, style: .continuous)
                         .fill(tint.opacity(0.10))
@@ -353,7 +372,7 @@ private struct KeyboardIconLabel: View {
         Image(systemName: systemImage)
             .font(.system(size: 17, weight: .semibold))
             .foregroundStyle(MuesliTheme.textPrimary)
-            .frame(width: 38, height: 38)
+            .frame(width: 34, height: 34)
             .background(
                 RoundedRectangle(cornerRadius: 12, style: .continuous)
                     .fill(MuesliTheme.surfacePrimary.opacity(0.76))
@@ -396,6 +415,46 @@ private struct KeyboardTextKey: View {
     }
 }
 
+private struct KeyboardRepeatingTextKey: View {
+    let systemImage: String
+    let accessibilityLabel: String
+    let action: () -> Void
+
+    @State private var repeatTask: Task<Void, Never>?
+
+    var body: some View {
+        KeyboardTextKeyLabel(title: nil, systemImage: systemImage)
+            .buttonStyle(.plain)
+            .muesliKeyboardKeySurface()
+            .accessibilityLabel(accessibilityLabel)
+            .gesture(
+                DragGesture(minimumDistance: 0)
+                    .onChanged { _ in startRepeatingIfNeeded() }
+                    .onEnded { _ in stopRepeating() }
+            )
+            .onDisappear {
+                stopRepeating()
+            }
+    }
+
+    private func startRepeatingIfNeeded() {
+        guard repeatTask == nil else { return }
+        action()
+        repeatTask = Task { @MainActor in
+            try? await Task.sleep(for: .milliseconds(360))
+            while !Task.isCancelled {
+                action()
+                try? await Task.sleep(for: .milliseconds(65))
+            }
+        }
+    }
+
+    private func stopRepeating() {
+        repeatTask?.cancel()
+        repeatTask = nil
+    }
+}
+
 private struct KeyboardTextKeyLabel: View {
     var title: String?
     var systemImage: String?
@@ -413,7 +472,7 @@ private struct KeyboardTextKeyLabel: View {
         }
         .foregroundStyle(MuesliTheme.textPrimary)
         .frame(maxWidth: .infinity)
-        .frame(minHeight: 40)
+        .frame(minHeight: 38)
         .contentShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
     }
 

--- a/MuesliKeyboard/KeyboardViewController.swift
+++ b/MuesliKeyboard/KeyboardViewController.swift
@@ -35,7 +35,7 @@ final class KeyboardViewController: UIInputViewController {
             hostingController.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             hostingController.view.topAnchor.constraint(equalTo: view.topAnchor),
             hostingController.view.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-            view.heightAnchor.constraint(greaterThanOrEqualToConstant: 292)
+            view.heightAnchor.constraint(greaterThanOrEqualToConstant: 246)
         ])
         hostingController.didMove(toParent: self)
     }

--- a/Shared/DictationModels.swift
+++ b/Shared/DictationModels.swift
@@ -194,9 +194,9 @@ struct KeyboardHandoffRecoveryPolicy: Sendable, Equatable {
     let runtimeFreshnessInterval: TimeInterval
 
     static let keyboardDefaults = KeyboardHandoffRecoveryPolicy(
-        staleStartInterval: 10,
+        staleStartInterval: 5,
         staleRecordingInterval: 45,
-        staleStopRequestInterval: 8,
+        staleStopRequestInterval: 5,
         staleTranscribingInterval: 120,
         runtimeFreshnessInterval: 8
     )
@@ -546,7 +546,9 @@ struct KeyboardRuntimeStatus: Codable, Sendable, Equatable {
     let activeRequestID: UUID?
     let phase: DictationPhase
     let message: String?
+    let sessionModeEnabled: Bool
     let supportsBackgroundStart: Bool
+    let canAcceptStartCommand: Bool
     let inputLevel: Double
     let updatedAt: Date
 
@@ -555,7 +557,9 @@ struct KeyboardRuntimeStatus: Codable, Sendable, Equatable {
         activeRequestID: UUID? = nil,
         phase: DictationPhase = .idle,
         message: String? = nil,
+        sessionModeEnabled: Bool = false,
         supportsBackgroundStart: Bool = false,
+        canAcceptStartCommand: Bool? = nil,
         inputLevel: Double = 0,
         updatedAt: Date = .now
     ) {
@@ -563,7 +567,9 @@ struct KeyboardRuntimeStatus: Codable, Sendable, Equatable {
         self.activeRequestID = activeRequestID
         self.phase = phase
         self.message = message
+        self.sessionModeEnabled = sessionModeEnabled
         self.supportsBackgroundStart = supportsBackgroundStart
+        self.canAcceptStartCommand = canAcceptStartCommand ?? (isActive && supportsBackgroundStart)
         self.inputLevel = min(max(inputLevel, 0), 1)
         self.updatedAt = updatedAt
     }
@@ -573,7 +579,9 @@ struct KeyboardRuntimeStatus: Codable, Sendable, Equatable {
         case activeRequestID
         case phase
         case message
+        case sessionModeEnabled
         case supportsBackgroundStart
+        case canAcceptStartCommand
         case inputLevel
         case updatedAt
     }
@@ -584,9 +592,21 @@ struct KeyboardRuntimeStatus: Codable, Sendable, Equatable {
         activeRequestID = try container.decodeIfPresent(UUID.self, forKey: .activeRequestID)
         phase = try container.decode(DictationPhase.self, forKey: .phase)
         message = try container.decodeIfPresent(String.self, forKey: .message)
+        sessionModeEnabled = try container.decodeIfPresent(Bool.self, forKey: .sessionModeEnabled) ?? false
         supportsBackgroundStart = try container.decodeIfPresent(Bool.self, forKey: .supportsBackgroundStart) ?? false
+        canAcceptStartCommand = try container.decodeIfPresent(Bool.self, forKey: .canAcceptStartCommand) ?? (isActive && supportsBackgroundStart)
         inputLevel = try container.decodeIfPresent(Double.self, forKey: .inputLevel) ?? 0
         updatedAt = try container.decode(Date.self, forKey: .updatedAt)
+    }
+}
+
+struct KeyboardSessionPreference: Codable, Sendable, Equatable {
+    let isEnabled: Bool
+    let updatedAt: Date
+
+    init(isEnabled: Bool, updatedAt: Date = .now) {
+        self.isEnabled = isEnabled
+        self.updatedAt = updatedAt
     }
 }
 

--- a/Shared/DictationModels.swift
+++ b/Shared/DictationModels.swift
@@ -194,9 +194,9 @@ struct KeyboardHandoffRecoveryPolicy: Sendable, Equatable {
     let runtimeFreshnessInterval: TimeInterval
 
     static let keyboardDefaults = KeyboardHandoffRecoveryPolicy(
-        staleStartInterval: 5,
+        staleStartInterval: 10,
         staleRecordingInterval: 45,
-        staleStopRequestInterval: 5,
+        staleStopRequestInterval: 8,
         staleTranscribingInterval: 120,
         runtimeFreshnessInterval: 8
     )
@@ -546,7 +546,6 @@ struct KeyboardRuntimeStatus: Codable, Sendable, Equatable {
     let activeRequestID: UUID?
     let phase: DictationPhase
     let message: String?
-    let sessionModeEnabled: Bool
     let supportsBackgroundStart: Bool
     let canAcceptStartCommand: Bool
     let inputLevel: Double
@@ -557,7 +556,6 @@ struct KeyboardRuntimeStatus: Codable, Sendable, Equatable {
         activeRequestID: UUID? = nil,
         phase: DictationPhase = .idle,
         message: String? = nil,
-        sessionModeEnabled: Bool = false,
         supportsBackgroundStart: Bool = false,
         canAcceptStartCommand: Bool? = nil,
         inputLevel: Double = 0,
@@ -567,7 +565,6 @@ struct KeyboardRuntimeStatus: Codable, Sendable, Equatable {
         self.activeRequestID = activeRequestID
         self.phase = phase
         self.message = message
-        self.sessionModeEnabled = sessionModeEnabled
         self.supportsBackgroundStart = supportsBackgroundStart
         self.canAcceptStartCommand = canAcceptStartCommand ?? (isActive && supportsBackgroundStart)
         self.inputLevel = min(max(inputLevel, 0), 1)
@@ -579,7 +576,6 @@ struct KeyboardRuntimeStatus: Codable, Sendable, Equatable {
         case activeRequestID
         case phase
         case message
-        case sessionModeEnabled
         case supportsBackgroundStart
         case canAcceptStartCommand
         case inputLevel
@@ -592,21 +588,10 @@ struct KeyboardRuntimeStatus: Codable, Sendable, Equatable {
         activeRequestID = try container.decodeIfPresent(UUID.self, forKey: .activeRequestID)
         phase = try container.decode(DictationPhase.self, forKey: .phase)
         message = try container.decodeIfPresent(String.self, forKey: .message)
-        sessionModeEnabled = try container.decodeIfPresent(Bool.self, forKey: .sessionModeEnabled) ?? false
         supportsBackgroundStart = try container.decodeIfPresent(Bool.self, forKey: .supportsBackgroundStart) ?? false
         canAcceptStartCommand = try container.decodeIfPresent(Bool.self, forKey: .canAcceptStartCommand) ?? (isActive && supportsBackgroundStart)
         inputLevel = try container.decodeIfPresent(Double.self, forKey: .inputLevel) ?? 0
         updatedAt = try container.decode(Date.self, forKey: .updatedAt)
-    }
-}
-
-struct KeyboardSessionPreference: Codable, Sendable, Equatable {
-    let isEnabled: Bool
-    let updatedAt: Date
-
-    init(isEnabled: Bool, updatedAt: Date = .now) {
-        self.isEnabled = isEnabled
-        self.updatedAt = updatedAt
     }
 }
 

--- a/Shared/SharedStore.swift
+++ b/Shared/SharedStore.swift
@@ -112,6 +112,14 @@ struct SharedStore: Sendable {
         try database().clearValue(key: .keyboardRuntimeStatus)
     }
 
+    func saveKeyboardSessionPreference(_ preference: KeyboardSessionPreference) throws {
+        try database().saveValue(preference, key: .keyboardSessionPreference)
+    }
+
+    func keyboardSessionPreference() throws -> KeyboardSessionPreference? {
+        try database().value(KeyboardSessionPreference.self, key: .keyboardSessionPreference)
+    }
+
     func saveKeyboardLiveTranscript(_ transcript: KeyboardLiveTranscript) throws {
         try database().saveValue(transcript, key: .keyboardLiveTranscript)
     }
@@ -314,6 +322,7 @@ private enum SharedStoreKey: String {
     case dictationStatus = "dictation_status"
     case keyboardExtensionStatus = "keyboard_extension_status"
     case keyboardRuntimeStatus = "keyboard_runtime_status"
+    case keyboardSessionPreference = "keyboard_session_preference"
     case keyboardLiveTranscript = "keyboard_live_transcript"
     case legacyJSONMigrated = "legacy_json_migrated_v1"
     case customWordsInitialized = "custom_words_initialized"

--- a/Shared/SharedStore.swift
+++ b/Shared/SharedStore.swift
@@ -112,14 +112,6 @@ struct SharedStore: Sendable {
         try database().clearValue(key: .keyboardRuntimeStatus)
     }
 
-    func saveKeyboardSessionPreference(_ preference: KeyboardSessionPreference) throws {
-        try database().saveValue(preference, key: .keyboardSessionPreference)
-    }
-
-    func keyboardSessionPreference() throws -> KeyboardSessionPreference? {
-        try database().value(KeyboardSessionPreference.self, key: .keyboardSessionPreference)
-    }
-
     func saveKeyboardLiveTranscript(_ transcript: KeyboardLiveTranscript) throws {
         try database().saveValue(transcript, key: .keyboardLiveTranscript)
     }
@@ -322,7 +314,6 @@ private enum SharedStoreKey: String {
     case dictationStatus = "dictation_status"
     case keyboardExtensionStatus = "keyboard_extension_status"
     case keyboardRuntimeStatus = "keyboard_runtime_status"
-    case keyboardSessionPreference = "keyboard_session_preference"
     case keyboardLiveTranscript = "keyboard_live_transcript"
     case legacyJSONMigrated = "legacy_json_migrated_v1"
     case customWordsInitialized = "custom_words_initialized"


### PR DESCRIPTION
**Summary**
- Keep keyboard session mode state in sync when arming fails or the session stops.
- Route keyboard session Live Activity updates through the keyboard session activity so it stays visible across the handoff flow.
- Refresh the settings copy and trim the keyboard extension layout to reduce its footprint.

**Testing**
- Not run (not requested)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli-ios/pr/14"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785639149&installation_id=136549638&pr_number=14&repository=Muesli-HQ%2Fmuesli-ios&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli-ios%2Fpull%2F14&signature=be14a59fd47ecc260bba1e6538a52515da45a063c19767c02ab5702db59e811f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/muesli-hq/muesli-ios/pull/14" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated “Keyboard Session Mode” messaging with more detailed, status-aware guidance and clearer off vs enabled instructions.

* **Bug Fixes**
  * Improved Live Activity handling so keyboard-based dictation routing stays correctly matched for updates and endings.
  * More resilient keyboard-session behavior: safer disable, recoverable error retry, and timeout handling that won’t prematurely stop active workflows.

* **Style**
  * Refreshed the keyboard UI for a more compact layout, including tighter spacing and a reduced hosting view height.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->