### PR TITLE
[codex] Add launch warmup screen and dashboard polish

### DIFF
--- a/Muesli/DictationCoordinator.swift
+++ b/Muesli/DictationCoordinator.swift
@@ -178,6 +178,13 @@ final class DictationCoordinator {
     private var stopKeyboardSessionAfterCurrentRequest = false
     var isKeyboardHandoffActive: Bool { keyboardSessionState.isKeyboardHandoffActive }
     var isKeyboardSessionArmed: Bool { keyboardSessionState.isArmed }
+    var isModelPrewarmInProgress: Bool { modelPrewarmTask != nil }
+    var shouldShowLaunchWarmup: Bool {
+        #if DEBUG
+        guard !Self.shouldSkipModelPrewarmForTesting() else { return false }
+        #endif
+        return hasCompletedOnboarding
+    }
     private var isKeyboardHotMicEngineReady: Bool {
         isKeyboardSessionArmed && keyboardSessionKeeper.canAcceptStartCommand
     }
@@ -1182,6 +1189,12 @@ final class DictationCoordinator {
         guard !isRecording, !isMeetingRecording else { return }
 
         let model = selectedTranscriptionModel
+        modelPreparation = ModelPreparationState(
+            phase: .preparing,
+            progress: nil,
+            status: "Warming up the transcription engine...",
+            detail: model.shortName
+        )
         let coordinator = self
         modelPrewarmTask = Task { [engine, model] in
             do {
@@ -1203,7 +1216,11 @@ final class DictationCoordinator {
                     "model_prewarm_started",
                     parameters: ["engine": model.engineIdentifier, "reason": reason]
                 )
-                try await engine.prepare()
+                try await engine.prepare { progress, status in
+                    Task { @MainActor in
+                        coordinator.applyModelPreparationProgress(progress, status: status)
+                    }
+                }
 
                 await MainActor.run {
                     coordinator.modelPrewarmTask = nil
@@ -1225,6 +1242,12 @@ final class DictationCoordinator {
             } catch {
                 await MainActor.run {
                     coordinator.modelPrewarmTask = nil
+                    coordinator.modelPreparation = ModelPreparationState(
+                        phase: .failed,
+                        progress: nil,
+                        status: "Warmup paused",
+                        detail: "Muesli will try again when you record"
+                    )
                     AppTelemetry.signal(
                         "model_prewarm_failed",
                         parameters: [

--- a/Muesli/DictationView.swift
+++ b/Muesli/DictationView.swift
@@ -67,6 +67,10 @@ struct DictationView: View {
                 guard isActive else { return }
                 updateDashboardStats()
             }
+            .onChange(of: sourceFilter) { _, _ in
+                guard isActive else { return }
+                updateDashboardStats()
+            }
             .onChange(of: scenePhase) { _, phase in
                 guard phase == .active, isActive else { return }
                 refreshVisibleStateIfNeeded()
@@ -103,30 +107,30 @@ struct DictationView: View {
                 value: stats.streak,
                 label: "streak",
                 systemImage: "flame.fill",
-                tint: Color(hex: 0xFF9F2D)
+                tint: sourceFilter.statTint(default: Color(hex: 0xFF9F2D))
             )
             DictationHomeStatTile(
                 value: stats.words,
                 label: "words",
                 systemImage: "waveform",
-                tint: MuesliTheme.accent
+                tint: sourceFilter.statTint(default: MuesliTheme.accent)
             )
             DictationHomeStatTile(
                 value: stats.wpm,
                 label: "WPM",
                 systemImage: "speedometer",
-                tint: MuesliTheme.success
+                tint: sourceFilter.statTint(default: MuesliTheme.success)
             )
             DictationHomeStatTile(
                 value: stats.meetings,
                 label: "meetings",
                 systemImage: "person.2",
-                tint: MuesliTheme.accent
+                tint: sourceFilter.statTint(default: MuesliTheme.accent)
             )
         }
         .accessibilityElement(children: .combine)
         .accessibilityLabel(
-            "Stats: \(stats.streak) day streak, \(stats.words) words, \(stats.wpm) words per minute, \(stats.meetings) meetings"
+            "\(sourceFilter.title) stats: \(stats.streak) day streak, \(stats.words) words, \(stats.wpm) words per minute, \(stats.meetings) meetings"
         )
     }
 
@@ -152,15 +156,8 @@ struct DictationView: View {
     }
 
     private func updateDashboardStats() {
-        #if DEBUG
-        if shouldUseMockDictations {
-            dashboardStats = DictationDashboardStats(words: "61.0k", wpm: "152", meetings: "135", streak: "3")
-            return
-        }
-        #endif
-
-        let history = displayHistory
-        let sessions = coordinator.recordingSessions
+        let history = statsHistory
+        let sessions = statsSessions
         dashboardStats = DictationDashboardStats(
             words: formattedCompactCount(totalDictationWords(in: history)),
             wpm: formattedAverageWPM(history: history, sessions: sessions),
@@ -590,6 +587,14 @@ struct DictationView: View {
         displayHistory.filter { sourceFilter.includes($0.syncOrigin) }
     }
 
+    private var statsHistory: [DictationResult] {
+        displayHistory.filter { sourceFilter.includes($0.syncOrigin) }
+    }
+
+    private var statsSessions: [RecordingSession] {
+        coordinator.recordingSessions.filter { sourceFilter.includes($0.syncOrigin) }
+    }
+
     private var displayHistory: [DictationResult] {
         #if DEBUG
         if shouldUseMockDictations {
@@ -819,16 +824,16 @@ private struct DictationHomeStatTile: View {
     let tint: Color
 
     var body: some View {
-        VStack(spacing: MuesliTheme.spacing8) {
+        VStack(spacing: MuesliTheme.spacing4) {
             Image(systemName: systemImage)
-                .font(.system(size: 18, weight: .semibold))
+                .font(.system(size: 16, weight: .semibold))
                 .symbolRenderingMode(.hierarchical)
                 .foregroundStyle(tint)
-                .frame(height: 20)
+                .frame(height: 17)
 
             VStack(spacing: 1) {
                 Text(value)
-                    .font(.system(size: 20, weight: .semibold, design: .rounded))
+                    .font(.system(size: 21, weight: .semibold, design: .rounded))
                     .monospacedDigit()
                     .minimumScaleFactor(0.76)
                     .lineLimit(1)
@@ -842,8 +847,9 @@ private struct DictationHomeStatTile: View {
             }
         }
         .frame(maxWidth: .infinity)
-        .frame(height: 72)
-        .padding(.horizontal, MuesliTheme.spacing8)
+        .frame(height: 68)
+        .padding(.horizontal, 6)
+        .padding(.vertical, 6)
         .background {
             RoundedRectangle(cornerRadius: MuesliTheme.cornerLarge, style: .continuous)
                 .fill(
@@ -1146,6 +1152,17 @@ private enum DictationSourceFilter: String, CaseIterable, Identifiable {
             origin == .fromMac
         }
     }
+
+    func statTint(default tint: Color) -> Color {
+        switch self {
+        case .all:
+            tint
+        case .thisIPhone:
+            MuesliTheme.accent
+        case .fromMac:
+            MuesliTheme.success
+        }
+    }
 }
 
 private enum DictationSyncOrigin: Equatable {
@@ -1186,6 +1203,25 @@ private enum DictationSyncOrigin: Equatable {
         case .fromMac:
             MuesliTheme.success
         }
+    }
+}
+
+private extension RecordingSession {
+    var syncOrigin: DictationSyncOrigin {
+        let normalizedSource = source?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        if let normalizedSource, normalizedSource == "ios" {
+            return .thisIPhone
+        }
+
+        if let normalizedSource, !normalizedSource.isEmpty {
+            return .fromMac
+        }
+
+        if normalizedSource == nil && engineIdentifier?.lowercased() == "icloud" {
+            return .fromMac
+        }
+
+        return .thisIPhone
     }
 }
 

--- a/Muesli/DictationView.swift
+++ b/Muesli/DictationView.swift
@@ -1208,16 +1208,16 @@ private enum DictationSyncOrigin: Equatable {
 
 private extension RecordingSession {
     var syncOrigin: DictationSyncOrigin {
-        let normalizedSource = source?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        let normalizedSource = source.normalizedSyncOriginSource
         if let normalizedSource, normalizedSource == "ios" {
             return .thisIPhone
         }
 
-        if let normalizedSource, !normalizedSource.isEmpty {
+        if normalizedSource != nil {
             return .fromMac
         }
 
-        if normalizedSource == nil && engineIdentifier?.lowercased() == "icloud" {
+        if engineIdentifier?.lowercased() == "icloud" {
             return .fromMac
         }
 
@@ -1227,22 +1227,32 @@ private extension RecordingSession {
 
 private extension DictationResult {
     var syncOrigin: DictationSyncOrigin {
-        let normalizedSource = source?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        let normalizedSource = source.normalizedSyncOriginSource
         if let normalizedSource, normalizedSource == "ios" {
             return .thisIPhone
         }
 
-        if let normalizedSource, !normalizedSource.isEmpty {
+        if normalizedSource != nil {
             return .fromMac
         }
 
         // Older synced rows were stored before source was persisted and used
         // the fallback engine label. Treat those as Mac-origin cloud imports.
-        if normalizedSource == nil && engineIdentifier.lowercased() == "icloud" {
+        if engineIdentifier.lowercased() == "icloud" {
             return .fromMac
         }
 
         return .thisIPhone
+    }
+}
+
+private extension Optional where Wrapped == String {
+    var normalizedSyncOriginSource: String? {
+        guard let source = self?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased(),
+              !source.isEmpty else {
+            return nil
+        }
+        return source
     }
 }
 

--- a/Muesli/LaunchWarmupView.swift
+++ b/Muesli/LaunchWarmupView.swift
@@ -1,0 +1,219 @@
+import SwiftUI
+
+struct LaunchWarmupContainer<Content: View>: View {
+    @Bindable var coordinator: DictationCoordinator
+    @State private var isShowingWarmup = true
+    @State private var didRunWarmup = false
+    @ViewBuilder let content: Content
+
+    var body: some View {
+        ZStack {
+            content
+
+            if isShowingWarmup && coordinator.shouldShowLaunchWarmup {
+                LaunchWarmupView(
+                    status: coordinator.modelPreparation.status,
+                    detail: coordinator.modelPreparation.detail,
+                    modelName: coordinator.selectedTranscriptionModel.shortName
+                )
+                .transition(.opacity)
+                .zIndex(1)
+            }
+        }
+        .task {
+            await runLaunchWarmup()
+        }
+    }
+
+    private func runLaunchWarmup() async {
+        guard !didRunWarmup else { return }
+        didRunWarmup = true
+
+        guard coordinator.shouldShowLaunchWarmup else {
+            isShowingWarmup = false
+            return
+        }
+
+        let startedAt = ContinuousClock.now
+        coordinator.prewarmModelIfNeeded(reason: "launch_screen")
+
+        while !Task.isCancelled {
+            let elapsed = startedAt.duration(to: .now)
+            let minimumDisplaySatisfied = elapsed >= .milliseconds(1400)
+            let maximumDisplayReached = elapsed >= .seconds(20)
+            let warmupFinished = !coordinator.isModelPrewarmInProgress && !coordinator.modelPreparation.isPreparing
+
+            if minimumDisplaySatisfied && (warmupFinished || maximumDisplayReached) {
+                break
+            }
+
+            try? await Task.sleep(for: .milliseconds(120))
+        }
+
+        guard !Task.isCancelled else { return }
+        await MainActor.run {
+            withAnimation(.easeOut(duration: 0.32)) {
+                isShowingWarmup = false
+            }
+        }
+    }
+}
+
+private struct LaunchWarmupView: View {
+    let status: String
+    let detail: String
+    let modelName: String
+
+    @State private var isAnimating = false
+
+    var body: some View {
+        ZStack {
+            background
+                .ignoresSafeArea()
+
+            brandMark
+                .offset(y: -18)
+
+            VStack {
+                Spacer()
+                warmupStatus
+                    .padding(.bottom, 78)
+            }
+
+            VStack {
+                Spacer()
+                Text(versionText)
+                    .font(MuesliTheme.caption())
+                    .foregroundStyle(.white.opacity(0.24))
+                    .padding(.bottom, 18)
+            }
+            .ignoresSafeArea(.keyboard)
+        }
+        .task {
+            withAnimation(.linear(duration: 1.15).repeatForever(autoreverses: false)) {
+                isAnimating = true
+            }
+        }
+    }
+
+    private var background: some View {
+        LinearGradient(
+            colors: [
+                Color(hex: 0x030711),
+                Color(hex: 0x07111F),
+                Color(hex: 0x02040A)
+            ],
+            startPoint: .topLeading,
+            endPoint: .bottomTrailing
+        )
+        .overlay {
+            LinearGradient(
+                colors: [
+                    MuesliTheme.brandBlue.opacity(0.16),
+                    .clear,
+                    MuesliTheme.syncGreen.opacity(0.10)
+                ],
+                startPoint: .top,
+                endPoint: .bottom
+            )
+        }
+    }
+
+    private var brandMark: some View {
+        VStack(spacing: MuesliTheme.spacing16) {
+            Image("MuesliAppIcon")
+                .resizable()
+                .scaledToFit()
+                .frame(width: 74, height: 74)
+                .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+                .shadow(color: MuesliTheme.brandBlue.opacity(0.48), radius: 24, x: 0, y: 0)
+
+            Text("muesli")
+                .font(.system(.largeTitle, design: .rounded, weight: .semibold))
+                .foregroundStyle(.white.opacity(0.94))
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("muesli")
+    }
+
+    private var warmupStatus: some View {
+        VStack(spacing: MuesliTheme.spacing16) {
+            HStack(spacing: MuesliTheme.spacing12) {
+                ProgressView()
+                    .controlSize(.small)
+                    .tint(MuesliTheme.syncGreen)
+
+                Text(displayStatus)
+                    .font(MuesliTheme.callout())
+                    .foregroundStyle(.white.opacity(0.68))
+                    .lineLimit(2)
+                    .multilineTextAlignment(.center)
+            }
+            .padding(.horizontal, MuesliTheme.spacing20)
+
+            WarmupPulseLine(isAnimating: isAnimating)
+                .frame(width: 176, height: 3)
+                .accessibilityHidden(true)
+
+            Text(displayDetail)
+                .font(MuesliTheme.caption())
+                .foregroundStyle(.white.opacity(0.38))
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(displayStatus). \(displayDetail). \(versionText)")
+    }
+
+    private var displayStatus: String {
+        let trimmedStatus = status.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmedStatus.localizedCaseInsensitiveContains("ready") {
+            return "Transcription engine ready"
+        }
+        return "Warming up the transcription engine..."
+    }
+
+    private var displayDetail: String {
+        let trimmedDetail = detail.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmedDetail.isEmpty || trimmedDetail.localizedCaseInsensitiveContains("not downloaded") {
+            let trimmedStatus = status.trimmingCharacters(in: .whitespacesAndNewlines)
+            return trimmedStatus.isEmpty ? modelName : trimmedStatus
+        }
+        return trimmedDetail
+    }
+
+    private var versionText: String {
+        let bundle = Bundle.main
+        let version = bundle.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "0.1"
+        let build = bundle.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? ""
+        return build.isEmpty ? "v\(version)" : "v\(version) (\(build))"
+    }
+}
+
+private struct WarmupPulseLine: View {
+    let isAnimating: Bool
+
+    var body: some View {
+        GeometryReader { geometry in
+            let width = max(geometry.size.width, 1)
+            ZStack(alignment: .leading) {
+                Capsule()
+                    .fill(.white.opacity(0.10))
+
+                Capsule()
+                    .fill(
+                        LinearGradient(
+                            colors: [
+                                MuesliTheme.brandBlue.opacity(0.25),
+                                MuesliTheme.syncGreen,
+                                MuesliTheme.brandBlue.opacity(0.25)
+                            ],
+                            startPoint: .leading,
+                            endPoint: .trailing
+                        )
+                    )
+                    .frame(width: width * 0.36)
+                    .offset(x: isAnimating ? width * 0.64 : 0)
+            }
+        }
+        .clipShape(Capsule())
+    }
+}

--- a/Muesli/LaunchWarmupView.swift
+++ b/Muesli/LaunchWarmupView.swift
@@ -92,14 +92,17 @@ private struct LaunchWarmupView: View {
             }
             .ignoresSafeArea(.keyboard)
         }
-        .task {
-            guard phase.isLaunchWarmupActive else { return }
+        .task(id: phase) {
+            updateAnimation(for: phase)
+        }
+    }
+
+    private func updateAnimation(for phase: ModelPreparationPhase) {
+        if phase.isLaunchWarmupActive {
             withAnimation(.linear(duration: 1.15).repeatForever(autoreverses: false)) {
                 isAnimating = true
             }
-        }
-        .onChange(of: phase) { _, newPhase in
-            guard !newPhase.isLaunchWarmupActive else { return }
+        } else {
             isAnimating = false
         }
     }

--- a/Muesli/LaunchWarmupView.swift
+++ b/Muesli/LaunchWarmupView.swift
@@ -12,6 +12,7 @@ struct LaunchWarmupContainer<Content: View>: View {
 
             if isShowingWarmup && coordinator.shouldShowLaunchWarmup {
                 LaunchWarmupView(
+                    phase: coordinator.modelPreparation.phase,
                     status: coordinator.modelPreparation.status,
                     detail: coordinator.modelPreparation.detail,
                     modelName: coordinator.selectedTranscriptionModel.shortName
@@ -60,6 +61,7 @@ struct LaunchWarmupContainer<Content: View>: View {
 }
 
 private struct LaunchWarmupView: View {
+    let phase: ModelPreparationPhase
     let status: String
     let detail: String
     let modelName: String
@@ -86,13 +88,19 @@ private struct LaunchWarmupView: View {
                     .font(MuesliTheme.caption())
                     .foregroundStyle(.white.opacity(0.24))
                     .padding(.bottom, 18)
+                    .accessibilityHidden(true)
             }
             .ignoresSafeArea(.keyboard)
         }
         .task {
+            guard phase.isLaunchWarmupActive else { return }
             withAnimation(.linear(duration: 1.15).repeatForever(autoreverses: false)) {
                 isAnimating = true
             }
+        }
+        .onChange(of: phase) { _, newPhase in
+            guard !newPhase.isLaunchWarmupActive else { return }
+            isAnimating = false
         }
     }
 
@@ -139,9 +147,14 @@ private struct LaunchWarmupView: View {
     private var warmupStatus: some View {
         VStack(spacing: MuesliTheme.spacing16) {
             HStack(spacing: MuesliTheme.spacing12) {
-                ProgressView()
-                    .controlSize(.small)
-                    .tint(MuesliTheme.syncGreen)
+                if phase == .failed {
+                    Image(systemName: "pause.circle")
+                        .foregroundStyle(.white.opacity(0.68))
+                } else {
+                    ProgressView()
+                        .controlSize(.small)
+                        .tint(MuesliTheme.syncGreen)
+                }
 
                 Text(displayStatus)
                     .font(MuesliTheme.callout())
@@ -168,6 +181,9 @@ private struct LaunchWarmupView: View {
         if trimmedStatus.localizedCaseInsensitiveContains("ready") {
             return "Transcription engine ready"
         }
+        if phase == .failed {
+            return trimmedStatus.isEmpty ? "Warmup paused" : trimmedStatus
+        }
         return "Warming up the transcription engine..."
     }
 
@@ -185,6 +201,12 @@ private struct LaunchWarmupView: View {
         let version = bundle.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "0.1"
         let build = bundle.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? ""
         return build.isEmpty ? "v\(version)" : "v\(version) (\(build))"
+    }
+}
+
+private extension ModelPreparationPhase {
+    var isLaunchWarmupActive: Bool {
+        self == .downloading || self == .preparing
     }
 }
 

--- a/Muesli/MuesliApp.swift
+++ b/Muesli/MuesliApp.swift
@@ -12,7 +12,9 @@ struct MuesliApp: App {
 
     var body: some Scene {
         WindowGroup {
-            RootView(coordinator: coordinator)
+            LaunchWarmupContainer(coordinator: coordinator) {
+                RootView(coordinator: coordinator)
+            }
                 .onOpenURL { url in
                     coordinator.handleOpenURL(url)
                 }

--- a/Shared/DictationModels.swift
+++ b/Shared/DictationModels.swift
@@ -310,6 +310,7 @@ struct RecordingSession: Codable, Sendable, Equatable, Identifiable {
     var keepsAudioRecording: Bool
     var transcriptID: UUID?
     var engineIdentifier: String?
+    var source: String?
     var errorMessage: String?
 
     init(
@@ -325,6 +326,7 @@ struct RecordingSession: Codable, Sendable, Equatable, Identifiable {
         keepsAudioRecording: Bool = false,
         transcriptID: UUID? = nil,
         engineIdentifier: String? = nil,
+        source: String? = nil,
         errorMessage: String? = nil
     ) {
         self.id = id
@@ -339,6 +341,7 @@ struct RecordingSession: Codable, Sendable, Equatable, Identifiable {
         self.keepsAudioRecording = keepsAudioRecording
         self.transcriptID = transcriptID
         self.engineIdentifier = engineIdentifier
+        self.source = source
         self.errorMessage = errorMessage
     }
 
@@ -360,6 +363,7 @@ struct RecordingSession: Codable, Sendable, Equatable, Identifiable {
         case keepsAudioRecording
         case transcriptID
         case engineIdentifier
+        case source
         case errorMessage
     }
 
@@ -377,6 +381,7 @@ struct RecordingSession: Codable, Sendable, Equatable, Identifiable {
         keepsAudioRecording = try container.decodeIfPresent(Bool.self, forKey: .keepsAudioRecording) ?? false
         transcriptID = try container.decodeIfPresent(UUID.self, forKey: .transcriptID)
         engineIdentifier = try container.decodeIfPresent(String.self, forKey: .engineIdentifier)
+        source = try container.decodeIfPresent(String.self, forKey: .source)
         errorMessage = try container.decodeIfPresent(String.self, forKey: .errorMessage)
     }
 }

--- a/Shared/SharedStore.swift
+++ b/Shared/SharedStore.swift
@@ -636,7 +636,7 @@ private struct SharedStoreDatabase {
             let dictationRows = try queryRows(
                 """
                 SELECT cloud_record_name, text, engine_identifier, created_at, updated_at,
-                       deleted_at, session_id, cloud_change_tag
+                       deleted_at, session_id, cloud_change_tag, payload
                 FROM result_history
                 WHERE sync_dirty = 1 AND cloud_record_name IS NOT NULL
                 ORDER BY updated_at DESC
@@ -646,7 +646,9 @@ private struct SharedStoreDatabase {
             ) { statement in
                 try bind(limit, to: statement, at: 1)
             } read: { statement in
-                SyncTextRecord(
+                let payload = sqliteColumnData(statement, 8)
+                let result = payload.flatMap { try? decoder.decode(DictationResult.self, from: $0) }
+                return SyncTextRecord(
                     id: sqliteColumnString(statement, 0) ?? UUID().uuidString,
                     kind: .dictation,
                     title: nil,
@@ -654,7 +656,7 @@ private struct SharedStoreDatabase {
                     speakerTranscript: nil,
                     summaryText: nil,
                     manualNotes: nil,
-                    source: "ios",
+                    source: Self.syncSource(result?.source),
                     engineIdentifier: sqliteColumnString(statement, 2),
                     createdAt: Date(timeIntervalSince1970: sqlite3_column_double(statement, 3)),
                     updatedAt: Date(timeIntervalSince1970: sqlite3_column_double(statement, 4)),
@@ -675,7 +677,7 @@ private struct SharedStoreDatabase {
                 """
                 SELECT s.cloud_record_name, s.id, s.title, s.kind, s.phase, s.created_at,
                        s.started_at, s.ended_at, s.engine_identifier, s.error_message,
-                       s.updated_at, s.deleted_at, s.cloud_change_tag,
+                       s.updated_at, s.deleted_at, s.cloud_change_tag, s.payload,
                        t.text, t.speaker_transcript, t.summary_text, t.summary_backend,
                        t.summary_model, t.updated_at, t.deleted_at
                 FROM recording_sessions s
@@ -693,18 +695,20 @@ private struct SharedStoreDatabase {
             } read: { statement in
                 let started = Self.optionalDate(statement, 6)
                 let ended = Self.optionalDate(statement, 7)
-                let text = sqliteColumnString(statement, 13) ?? ""
-                let summary = sqliteColumnString(statement, 15)
-                let updated = max(sqlite3_column_double(statement, 10), sqlite3_column_double(statement, 18))
+                let text = sqliteColumnString(statement, 14) ?? ""
+                let summary = sqliteColumnString(statement, 16)
+                let updated = max(sqlite3_column_double(statement, 10), sqlite3_column_double(statement, 19))
+                let payload = sqliteColumnData(statement, 13)
+                let session = payload.flatMap { try? decoder.decode(RecordingSession.self, from: $0) }
                 return SyncTextRecord(
                     id: sqliteColumnString(statement, 0) ?? UUID().uuidString,
                     kind: .meeting,
                     title: sqliteColumnString(statement, 2),
                     text: text,
-                    speakerTranscript: sqliteColumnString(statement, 14),
+                    speakerTranscript: sqliteColumnString(statement, 15),
                     summaryText: summary,
                     manualNotes: nil,
-                    source: "ios",
+                    source: Self.syncSource(session?.source),
                     engineIdentifier: sqliteColumnString(statement, 8),
                     createdAt: Date(timeIntervalSince1970: sqlite3_column_double(statement, 5)),
                     updatedAt: Date(timeIntervalSince1970: updated),
@@ -712,7 +716,7 @@ private struct SharedStoreDatabase {
                     endedAt: ended,
                     durationSeconds: started.map { (ended ?? Date()).timeIntervalSince($0) } ?? 0,
                     wordCount: Self.wordCount(text + " " + (summary ?? "")),
-                    isDeleted: sqlite3_column_type(statement, 11) != SQLITE_NULL || sqlite3_column_type(statement, 19) != SQLITE_NULL,
+                    isDeleted: sqlite3_column_type(statement, 11) != SQLITE_NULL || sqlite3_column_type(statement, 20) != SQLITE_NULL,
                     cloudChangeTag: sqliteColumnString(statement, 12)
                 )
             }
@@ -727,7 +731,7 @@ private struct SharedStoreDatabase {
             let dictationRows = try queryRows(
                 """
                 SELECT cloud_record_name, text, engine_identifier, created_at, updated_at,
-                       deleted_at, session_id, cloud_change_tag
+                       deleted_at, session_id, cloud_change_tag, payload
                 FROM result_history
                 WHERE cloud_record_name IS NOT NULL
                 ORDER BY updated_at DESC
@@ -737,7 +741,9 @@ private struct SharedStoreDatabase {
             ) { statement in
                 try bind(limit, to: statement, at: 1)
             } read: { statement in
-                SyncTextRecord(
+                let payload = sqliteColumnData(statement, 8)
+                let result = payload.flatMap { try? decoder.decode(DictationResult.self, from: $0) }
+                return SyncTextRecord(
                     id: sqliteColumnString(statement, 0) ?? UUID().uuidString,
                     kind: .dictation,
                     title: nil,
@@ -745,7 +751,7 @@ private struct SharedStoreDatabase {
                     speakerTranscript: nil,
                     summaryText: nil,
                     manualNotes: nil,
-                    source: "ios",
+                    source: Self.syncSource(result?.source),
                     engineIdentifier: sqliteColumnString(statement, 2),
                     createdAt: Date(timeIntervalSince1970: sqlite3_column_double(statement, 3)),
                     updatedAt: Date(timeIntervalSince1970: sqlite3_column_double(statement, 4)),
@@ -766,7 +772,7 @@ private struct SharedStoreDatabase {
                 """
                 SELECT s.cloud_record_name, s.id, s.title, s.kind, s.phase, s.created_at,
                        s.started_at, s.ended_at, s.engine_identifier, s.error_message,
-                       s.updated_at, s.deleted_at, s.cloud_change_tag,
+                       s.updated_at, s.deleted_at, s.cloud_change_tag, s.payload,
                        t.text, t.speaker_transcript, t.summary_text, t.summary_backend,
                        t.summary_model, t.updated_at, t.deleted_at
                 FROM recording_sessions s
@@ -783,18 +789,20 @@ private struct SharedStoreDatabase {
             } read: { statement in
                 let started = Self.optionalDate(statement, 6)
                 let ended = Self.optionalDate(statement, 7)
-                let text = sqliteColumnString(statement, 13) ?? ""
-                let summary = sqliteColumnString(statement, 15)
-                let updated = max(sqlite3_column_double(statement, 10), sqlite3_column_double(statement, 18))
+                let text = sqliteColumnString(statement, 14) ?? ""
+                let summary = sqliteColumnString(statement, 16)
+                let updated = max(sqlite3_column_double(statement, 10), sqlite3_column_double(statement, 19))
+                let payload = sqliteColumnData(statement, 13)
+                let session = payload.flatMap { try? decoder.decode(RecordingSession.self, from: $0) }
                 return SyncTextRecord(
                     id: sqliteColumnString(statement, 0) ?? UUID().uuidString,
                     kind: .meeting,
                     title: sqliteColumnString(statement, 2),
                     text: text,
-                    speakerTranscript: sqliteColumnString(statement, 14),
+                    speakerTranscript: sqliteColumnString(statement, 15),
                     summaryText: summary,
                     manualNotes: nil,
-                    source: "ios",
+                    source: Self.syncSource(session?.source),
                     engineIdentifier: sqliteColumnString(statement, 8),
                     createdAt: Date(timeIntervalSince1970: sqlite3_column_double(statement, 5)),
                     updatedAt: Date(timeIntervalSince1970: updated),
@@ -802,7 +810,7 @@ private struct SharedStoreDatabase {
                     endedAt: ended,
                     durationSeconds: started.map { (ended ?? Date()).timeIntervalSince($0) } ?? 0,
                     wordCount: Self.wordCount(text + " " + (summary ?? "")),
-                    isDeleted: sqlite3_column_type(statement, 11) != SQLITE_NULL || sqlite3_column_type(statement, 19) != SQLITE_NULL,
+                    isDeleted: sqlite3_column_type(statement, 11) != SQLITE_NULL || sqlite3_column_type(statement, 20) != SQLITE_NULL,
                     cloudChangeTag: sqliteColumnString(statement, 12)
                 )
             }
@@ -1864,6 +1872,14 @@ private struct SharedStoreDatabase {
 
     private static func wordCount(_ text: String) -> Int {
         text.split(whereSeparator: \.isWhitespace).count
+    }
+
+    private static func syncSource(_ source: String?, fallback: String = "ios") -> String {
+        guard let normalized = source?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !normalized.isEmpty else {
+            return fallback
+        }
+        return normalized
     }
 
     private static let schemaSQL = """

--- a/Shared/SharedStore.swift
+++ b/Shared/SharedStore.swift
@@ -1550,6 +1550,7 @@ private struct SharedStoreDatabase {
             keepsAudioRecording: false,
             transcriptID: transcriptID,
             engineIdentifier: record.engineIdentifier,
+            source: record.source,
             errorMessage: nil
         )
         let transcript = Transcript(

--- a/Tests/MuesliTests/SharedStoreTests.swift
+++ b/Tests/MuesliTests/SharedStoreTests.swift
@@ -316,6 +316,26 @@ final class SharedStoreTests: XCTestCase {
         XCTAssertGreaterThan(try sqliteDouble("SELECT updated_at FROM result_history LIMIT 1", in: directory), 0)
     }
 
+    func testDirtyDictationSyncRecordPreservesPayloadSource() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let store = SharedStore(containerURL: directory)
+        let result = DictationResult(
+            id: UUID(),
+            requestID: UUID(),
+            text: "synced mac edit",
+            createdAt: Date(timeIntervalSince1970: 123),
+            engineIdentifier: "icloud",
+            source: "macos"
+        )
+
+        try store.saveResult(result)
+
+        let record = try XCTUnwrap(try store.textRecordsNeedingSync().first { $0.kind == .dictation })
+        XCTAssertEqual(record.source, "macos")
+    }
+
     func testSyncedDictationPreservesLocalSessionLink() throws {
         let directory = try makeTemporaryDirectory()
         defer { try? FileManager.default.removeItem(at: directory) }
@@ -540,6 +560,39 @@ final class SharedStoreTests: XCTestCase {
         XCTAssertEqual(try sqliteString("SELECT summary_model FROM transcripts LIMIT 1", in: directory), "gpt-5.4-mini")
         XCTAssertEqual(try sqliteString("SELECT cloud_record_name FROM transcripts LIMIT 1", in: directory), transcript.id.uuidString)
         XCTAssertEqual(try sqliteInt("SELECT sync_dirty FROM transcripts LIMIT 1", in: directory), 1)
+    }
+
+    func testDirtyMeetingSyncRecordPreservesPayloadSource() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let store = SharedStore(containerURL: directory)
+        let session = RecordingSession(
+            id: UUID(),
+            requestID: UUID(),
+            kind: .meeting,
+            title: "Mac meeting",
+            createdAt: Date(timeIntervalSince1970: 100),
+            startedAt: Date(timeIntervalSince1970: 90),
+            endedAt: Date(timeIntervalSince1970: 150),
+            phase: .completed,
+            transcriptID: UUID(),
+            engineIdentifier: "icloud",
+            source: "macos"
+        )
+        let transcript = Transcript(
+            id: try XCTUnwrap(session.transcriptID),
+            sessionID: session.id,
+            text: "meeting transcript",
+            createdAt: Date(timeIntervalSince1970: 151),
+            engineIdentifier: "icloud"
+        )
+
+        try store.saveSession(session)
+        try store.saveTranscript(transcript)
+
+        let record = try XCTUnwrap(try store.textRecordsNeedingSync().first { $0.kind == .meeting })
+        XCTAssertEqual(record.source, "macos")
     }
 
     func testRecordingSessionDecodesLegacyPayloadWithoutAudioRetentionFlag() throws {


### PR DESCRIPTION
## Summary
- Add a branded launch warmup screen that prewarms the selected transcription engine behind a blue/black/neon Muesli splash.
- Publish model prewarm progress/failure state so the launch screen can show meaningful warmup/download/compile status.
- Tighten the Voice Notes dashboard stat tiles so icons sit closer to values and stay inside their cards.
- Make dashboard stats update with the selected source filter: All, This iPhone, or From Mac.
- Preserve synced meeting provenance with an optional RecordingSession source field so meeting stats can be filtered by origin.

## Validation
- Built the Muesli simulator target with CODE_SIGNING_ALLOWED=NO.
- Ran the full simulator test suite: 39 passed, 0 failed.
- Verified in simulator with mock dictations that stats update across All, This iPhone, and From Mac.
- Captured simulator screenshots for the launch warmup layout and stats tile layout.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli-ios/pr/15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785804414&installation_id=136549638&pr_number=15&repository=Muesli-HQ%2Fmuesli-ios&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli-ios%2Fpull%2F15&signature=aba0771b0545ec478ef441c029be25388059935aca3c80ec9b55cab02cbbde80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a launch warmup overlay during model preparation with branded visuals, progress/paused state, and version details.
  * Updated dictation dashboard stats to be filter-aware, including per-filter tinting and improved accessibility labels.

* **Bug Fixes**
  * Improved warmup handling by explicitly marking the “warming up” phase and showing paused/failed messaging when warmup stops, prompting a retry.
  * Preserved session payload source during syncing so dashboards and filters stay accurate.

* **Tests**
  * Added sync-preservation tests for both dirty dictation and meeting records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->