### PR TITLE
[codex] Add offline transcription progress watchdog

### DIFF
--- a/Muesli/DictationCoordinator.swift
+++ b/Muesli/DictationCoordinator.swift
@@ -168,9 +168,6 @@ final class DictationCoordinator {
     private var meetingChunkTranscriptions: [MeetingChunkTranscription] = []
     private var meetingChunksDirectory: URL?
     private var discardedMeetingSessionIDs = Set<UUID>()
-    private var timedOutTranscriptionRequestIDs = Set<UUID>()
-    private var timedOutTranscriptionJobIDs = Set<UUID>()
-    private var timedOutMeetingSessionIDs = Set<UUID>()
     private let meetingVadQueue = DispatchQueue(label: "com.phequals7.muesli.meeting-vad")
     private var transcriptionBackgroundTask: UIBackgroundTaskIdentifier = .invalid
     nonisolated(unsafe) private var audioRouteObserver: NSObjectProtocol?
@@ -1300,31 +1297,21 @@ final class DictationCoordinator {
         Task {
             do {
                 let audioURL = try recorder.stop()
-                let jobID = UUID()
-                let tracker = OfflineTranscriptionProgressTracker()
-                let progressHandler = offlineTranscriptionProgressHandler(tracker: tracker)
-                let watchdog = startOfflineTranscriptionWatchdog(
-                    tracker: tracker,
-                    timeout: offlineTranscriptionTimeout(for: audioURL)
+                let outcome = try await runOfflineTranscriptionJob(
+                    audioURL: audioURL
                 ) { [weak self] in
                     guard let self else { return }
-                    self.timedOutTranscriptionJobIDs.insert(jobID)
                     self.isOnboardingTestTranscribing = false
                     self.onboardingTestError = "Transcription stalled. Try again."
                     AppTelemetry.signal(
                         "onboarding_test_failed",
                         parameters: ["stage": "transcription_timeout"]
                     )
+                } operation: { [engine] progress in
+                    try await engine.transcribe(audioURL: audioURL, progress: progress)
                 }
-                defer {
-                    watchdog.cancel()
-                }
-
-                let text = postProcessTranscript(try await engine.transcribe(
-                    audioURL: audioURL,
-                    progress: progressHandler
-                ))
-                guard !timedOutTranscriptionJobIDs.contains(jobID) else { return }
+                guard case .completed(let rawText) = outcome else { return }
+                let text = postProcessTranscript(rawText)
                 isOnboardingTestTranscribing = false
                 onboardingTestError = nil
                 if text.isEmpty {
@@ -1717,28 +1704,29 @@ final class DictationCoordinator {
                     phase: .transcribingStarted,
                     message: "Recovering transcription"
                 )
-                let tracker = OfflineTranscriptionProgressTracker()
-                let progressHandler = offlineTranscriptionProgressHandler(tracker: tracker) { [weak self] update in
-                    guard let self, !self.timedOutTranscriptionRequestIDs.contains(request.id) else { return }
-                    let message = self.transcriptionStatusMessage(for: update)
-                    self.statusText = message
-                    try? self.store.saveStatus(.init(requestID: request.id, phase: .transcribing, message: message))
-                    self.saveKeyboardHandoff(requestID: request.id, phase: .transcribingStarted, message: message)
-                    self.saveKeyboardRuntimeStatus(
-                        isActive: true,
-                        activeRequestID: request.id,
-                        phase: .transcribing,
-                        message: message,
-                        supportsBackgroundStart: self.canStartKeyboardRequestsInBackground
-                    )
-                }
-                let watchdog = startOfflineTranscriptionWatchdog(
-                    tracker: tracker,
-                    timeout: offlineTranscriptionTimeout(for: audioURL)
+                let outcome = try await runOfflineTranscriptionJob(
+                    audioURL: audioURL,
+                    onProgress: { [weak self] update in
+                        guard let self else { return }
+                        let message = self.transcriptionStatusMessage(for: update)
+                        self.statusText = message
+                        try? self.store.saveStatus(.init(requestID: request.id, phase: .transcribing, message: message))
+                        self.saveKeyboardHandoff(requestID: request.id, phase: .transcribingStarted, message: message)
+                        self.saveKeyboardRuntimeStatus(
+                            isActive: true,
+                            activeRequestID: request.id,
+                            phase: .transcribing,
+                            message: message,
+                            supportsBackgroundStart: self.canStartKeyboardRequestsInBackground
+                        )
+                    }
                 ) { [weak self] in
                     guard let self else { return }
                     let message = "Transcription stalled. Open Muesli to try again."
-                    self.timedOutTranscriptionRequestIDs.insert(request.id)
+                    var failedSession = session
+                    failedSession.phase = .failed
+                    failedSession.errorMessage = message
+                    try? self.store.saveSession(failedSession)
                     self.activeRequest = nil
                     self.activeSession = nil
                     self.statusText = message
@@ -1751,22 +1739,16 @@ final class DictationCoordinator {
                         message: message,
                         supportsBackgroundStart: self.canStartKeyboardRequestsInBackground
                     )
-                    self.endTranscriptionBackgroundTask()
                     self.refreshHistory()
                     AppTelemetry.signal(
                         "keyboard_transcription_recovery_failed",
                         parameters: ["reason": "timeout"]
                     )
+                } operation: { [engine] progress in
+                    try await engine.transcribe(audioURL: audioURL, progress: progress)
                 }
-                defer {
-                    watchdog.cancel()
-                }
-
-                let text = postProcessTranscript(try await engine.transcribe(
-                    audioURL: audioURL,
-                    progress: progressHandler
-                ))
-                guard !timedOutTranscriptionRequestIDs.contains(request.id) else { return }
+                guard case .completed(let rawText) = outcome else { return }
+                let text = postProcessTranscript(rawText)
                 let savedTranscript = Transcript(
                     sessionID: session.id,
                     text: text,
@@ -1820,7 +1802,6 @@ final class DictationCoordinator {
                     ]
                 )
             } catch {
-                guard !timedOutTranscriptionRequestIDs.contains(request.id) else { return }
                 var failedSession = session
                 failedSession.phase = .failed
                 failedSession.errorMessage = error.localizedDescription
@@ -1936,10 +1917,6 @@ final class DictationCoordinator {
 
             do {
                 let usesRealtimeStreaming = realtimeDictationRecorder != nil
-                var transcriptionWatchdog: Task<Void, Never>?
-                defer {
-                    transcriptionWatchdog?.cancel()
-                }
                 let audioURL: URL
                 var text: String
 
@@ -1952,22 +1929,14 @@ final class DictationCoordinator {
                             message: "Transcribing"
                         )
                     }
-                    let tracker = OfflineTranscriptionProgressTracker()
-                    transcriptionWatchdog = startKeyboardTranscriptionWatchdog(
+                    let outcome = try await runKeyboardTranscriptionJob(
+                        audioURL: audioURL,
                         request: request,
                         session: session,
-                        audioURL: audioURL,
-                        startedFromKeyboard: startedFromKeyboard,
-                        tracker: tracker
+                        startedFromKeyboard: startedFromKeyboard
                     )
-                    text = postProcessTranscript(try await engine.transcribe(
-                        audioURL: audioURL,
-                        progress: keyboardTranscriptionProgressHandler(
-                            requestID: request.id,
-                            tracker: tracker,
-                            startedFromKeyboard: startedFromKeyboard
-                        )
-                    ))
+                    guard case .completed(let rawText) = outcome else { return }
+                    text = postProcessTranscript(rawText)
                 } else if usesRealtimeStreaming {
                     let stoppedAudio = realtimeDictationRecorder?.stop()
                     realtimeDictationRecorder = nil
@@ -1992,22 +1961,14 @@ final class DictationCoordinator {
                     }
                     text = postProcessTranscript(try await engine.finishRealtimeSession())
                     if text.isEmpty {
-                        let tracker = OfflineTranscriptionProgressTracker()
-                        transcriptionWatchdog = startKeyboardTranscriptionWatchdog(
+                        let outcome = try await runKeyboardTranscriptionJob(
+                            audioURL: audioURL,
                             request: request,
                             session: session,
-                            audioURL: audioURL,
-                            startedFromKeyboard: startedFromKeyboard,
-                            tracker: tracker
+                            startedFromKeyboard: startedFromKeyboard
                         )
-                        text = postProcessTranscript(try await engine.transcribe(
-                            audioURL: audioURL,
-                            progress: keyboardTranscriptionProgressHandler(
-                                requestID: request.id,
-                                tracker: tracker,
-                                startedFromKeyboard: startedFromKeyboard
-                            )
-                        ))
+                        guard case .completed(let rawText) = outcome else { return }
+                        text = postProcessTranscript(rawText)
                     }
                     liveDictationTranscript = text
                 } else {
@@ -2019,24 +1980,15 @@ final class DictationCoordinator {
                             message: "Transcribing"
                         )
                     }
-                    let tracker = OfflineTranscriptionProgressTracker()
-                    transcriptionWatchdog = startKeyboardTranscriptionWatchdog(
+                    let outcome = try await runKeyboardTranscriptionJob(
+                        audioURL: audioURL,
                         request: request,
                         session: session,
-                        audioURL: audioURL,
-                        startedFromKeyboard: startedFromKeyboard,
-                        tracker: tracker
+                        startedFromKeyboard: startedFromKeyboard
                     )
-                    text = postProcessTranscript(try await engine.transcribe(
-                        audioURL: audioURL,
-                        progress: keyboardTranscriptionProgressHandler(
-                            requestID: request.id,
-                            tracker: tracker,
-                            startedFromKeyboard: startedFromKeyboard
-                        )
-                    ))
+                    guard case .completed(let rawText) = outcome else { return }
+                    text = postProcessTranscript(rawText)
                 }
-                guard !timedOutTranscriptionRequestIDs.contains(request.id) else { return }
                 guard !isRecordingSessionCancelled(requestID: request.id) else {
                     if startedFromKeyboard {
                         saveKeyboardHandoff(requestID: request.id, phase: .cancelled, message: "Cancelled")
@@ -2143,7 +2095,6 @@ final class DictationCoordinator {
                     ]
                 )
             } catch {
-                guard !timedOutTranscriptionRequestIDs.contains(request.id) else { return }
                 if var session = activeSession ?? session {
                     session.phase = .failed
                     session.errorMessage = error.localizedDescription
@@ -2603,25 +2554,21 @@ final class DictationCoordinator {
 
             do {
                 let audioURL = try store.audioFileURL(fileName: audioFileName)
-                let tracker = OfflineTranscriptionProgressTracker()
-                let progressHandler = offlineTranscriptionProgressHandler(tracker: tracker) { [weak self] update in
-                    guard let self, !self.timedOutMeetingSessionIDs.contains(session.id) else { return }
-                    self.meetingStatusText = self.transcriptionStatusMessage(for: update)
-                }
-                let watchdog = startOfflineTranscriptionWatchdog(
-                    tracker: tracker,
-                    timeout: offlineTranscriptionTimeout(for: audioURL)
+                let outcome = try await runOfflineTranscriptionJob(
+                    audioURL: audioURL,
+                    onProgress: { [weak self] update in
+                        guard let self else { return }
+                        self.meetingStatusText = self.transcriptionStatusMessage(for: update)
+                    }
                 ) { [weak self] in
                     guard let self else { return }
                     let message = "Transcription stalled. Try again."
-                    self.timedOutMeetingSessionIDs.insert(session.id)
                     var failedSession = session
                     failedSession.phase = .failed
                     failedSession.errorMessage = message
                     try? self.store.saveSession(failedSession)
                     self.meetingStatusText = message
                     self.isMeetingTranscribing = false
-                    self.endTranscriptionBackgroundTask()
                     self.refreshHistory()
                     Task {
                         await self.liveActivityController.end(
@@ -2634,16 +2581,10 @@ final class DictationCoordinator {
                         "meeting_transcription_failed",
                         parameters: ["engine": self.engine.identifier, "error": "timeout"]
                     )
+                } operation: { [engine] progress in
+                    try await engine.transcribeDetailed(audioURL: audioURL, progress: progress)
                 }
-                defer {
-                    watchdog.cancel()
-                }
-
-                let detailedTranscription = try await engine.transcribeDetailed(
-                    audioURL: audioURL,
-                    progress: progressHandler
-                )
-                guard !timedOutMeetingSessionIDs.contains(session.id) else { return }
+                guard case .completed(let detailedTranscription) = outcome else { return }
                 let text = postProcessTranscript(detailedTranscription.text)
                 let finalTranscript = try await finalizeMeetingTranscript(
                     session: session,
@@ -2676,7 +2617,6 @@ final class DictationCoordinator {
                     "summarized": finalTranscript.transcript.summaryState == .completed ? "true" : "false"
                 ])
             } catch {
-                guard !timedOutMeetingSessionIDs.contains(session.id) else { return }
                 session.phase = .failed
                 session.errorMessage = error.localizedDescription
                 try? store.saveSession(session)
@@ -2898,110 +2838,142 @@ final class DictationCoordinator {
         return "\(update.message ?? fallback) \(Int((fraction * 100).rounded()))%"
     }
 
-    private func offlineTranscriptionProgressHandler(
-        tracker: OfflineTranscriptionProgressTracker,
-        onProgress: (@MainActor @Sendable (TranscriptionProgressUpdate) -> Void)? = nil
-    ) -> @Sendable (TranscriptionProgressUpdate) -> Void {
-        { update in
+    private func runOfflineTranscriptionJob<Output: Sendable>(
+        audioURL: URL,
+        onProgress: (@MainActor @Sendable (TranscriptionProgressUpdate) -> Void)? = nil,
+        onTimeout: @escaping @MainActor @Sendable () -> Void,
+        operation: @escaping @Sendable (@escaping @Sendable (TranscriptionProgressUpdate) -> Void) async throws -> Output
+    ) async throws -> OfflineTranscriptionJobOutcome<Output> {
+        let tracker = OfflineTranscriptionProgressTracker()
+        let timeout = offlineTranscriptionTimeout(for: audioURL)
+        let control = OfflineTranscriptionJobControl<Output>()
+        let progressHandler: @Sendable (TranscriptionProgressUpdate) -> Void = { update in
             Task {
                 await tracker.record(update)
             }
-            if let onProgress {
-                Task { @MainActor in
-                    onProgress(update)
-                }
+            guard let onProgress else { return }
+            Task { @MainActor in
+                guard !control.isFinished else { return }
+                onProgress(update)
             }
+        }
+
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                control.setContinuation(continuation)
+
+                let transcriptionTask = Task {
+                    do {
+                        let output = try await operation(progressHandler)
+                        control.resume(returning: .completed(output))
+                    } catch {
+                        control.resume(throwing: error)
+                    }
+                }
+                control.setTranscriptionTask(transcriptionTask)
+
+                let watchdogTask = Task.detached(priority: .utility) {
+                    while !Task.isCancelled {
+                        try? await Task.sleep(for: .seconds(2))
+                        guard !Task.isCancelled else { return }
+                        if await tracker.hasNoProgress(for: timeout) {
+                            await onTimeout()
+                            control.timeout()
+                            return
+                        }
+                    }
+                }
+                control.setWatchdogTask(watchdogTask)
+            }
+        } onCancel: {
+            control.cancel()
         }
     }
 
-    private func startOfflineTranscriptionWatchdog(
-        tracker: OfflineTranscriptionProgressTracker,
-        timeout: TimeInterval,
-        onTimeout: @escaping @MainActor @Sendable () -> Void
-    ) -> Task<Void, Never> {
-        Task.detached(priority: .utility) {
-            while !Task.isCancelled {
-                try? await Task.sleep(for: .seconds(2))
-                guard !Task.isCancelled else { return }
-                if await tracker.hasNoProgress(for: timeout) {
-                    await onTimeout()
-                    return
-                }
-            }
-        }
-    }
-
-    private func keyboardTranscriptionProgressHandler(
+    private func keyboardTranscriptionProgressUpdate(
         requestID: UUID,
-        tracker: OfflineTranscriptionProgressTracker,
-        startedFromKeyboard: Bool
-    ) -> @Sendable (TranscriptionProgressUpdate) -> Void {
-        offlineTranscriptionProgressHandler(tracker: tracker) { [weak self] update in
-            guard let self, !self.timedOutTranscriptionRequestIDs.contains(requestID) else { return }
-            let message = self.transcriptionStatusMessage(for: update)
-            self.statusText = message
-            try? self.store.saveStatus(.init(requestID: requestID, phase: .transcribing, message: message))
-            if startedFromKeyboard {
-                self.saveKeyboardHandoff(requestID: requestID, phase: .transcribingStarted, message: message)
-                self.saveKeyboardRuntimeStatus(
-                    isActive: true,
-                    activeRequestID: requestID,
-                    phase: .transcribing,
-                    message: message,
-                    supportsBackgroundStart: self.canStartKeyboardRequestsInBackground
-                )
-            }
-        }
-    }
-
-    private func startKeyboardTranscriptionWatchdog(
-        request: DictationRequest,
-        session: RecordingSession?,
-        audioURL: URL?,
         startedFromKeyboard: Bool,
-        tracker: OfflineTranscriptionProgressTracker
-    ) -> Task<Void, Never> {
-        startOfflineTranscriptionWatchdog(
-            tracker: tracker,
-            timeout: offlineTranscriptionTimeout(for: audioURL)
-        ) { [weak self] in
-            guard let self else { return }
-            let message = "Transcription stalled. Open Muesli to try again."
-            self.timedOutTranscriptionRequestIDs.insert(request.id)
-            if var failedSession = self.activeSession ?? session {
-                failedSession.phase = .failed
-                failedSession.errorMessage = message
-                try? self.store.saveSession(failedSession)
-            }
-            self.activeRequest = nil
-            self.activeSession = nil
-            self.liveDictationTranscript = ""
-            self.realtimeDictationCommittedText = ""
-            self.clearKeyboardLiveTranscript()
-            self.statusText = message
-            try? self.store.clearPendingRequest()
-            try? self.store.clearPendingCommand()
-            try? self.store.saveStatus(.init(requestID: request.id, phase: .failed, message: message))
-            if startedFromKeyboard {
-                self.saveKeyboardHandoff(requestID: request.id, phase: .failed, message: message)
-                self.saveKeyboardRuntimeStatus(
-                    isActive: self.canStartKeyboardRequestsInBackground,
-                    activeRequestID: nil,
-                    phase: .failed,
-                    message: message,
-                    supportsBackgroundStart: self.canStartKeyboardRequestsInBackground
-                )
-            }
-            self.endTranscriptionBackgroundTask()
-            self.refreshHistory()
-            AppTelemetry.signal(
-                "dictation_failed",
-                parameters: [
-                    "stage": "transcription_timeout",
-                    "engine": self.engine.identifier
-                ]
+        update: TranscriptionProgressUpdate
+    ) {
+        let message = transcriptionStatusMessage(for: update)
+        statusText = message
+        try? store.saveStatus(.init(requestID: requestID, phase: .transcribing, message: message))
+        if startedFromKeyboard {
+            saveKeyboardHandoff(requestID: requestID, phase: .transcribingStarted, message: message)
+            saveKeyboardRuntimeStatus(
+                isActive: true,
+                activeRequestID: requestID,
+                phase: .transcribing,
+                message: message,
+                supportsBackgroundStart: canStartKeyboardRequestsInBackground
             )
         }
+    }
+
+    private func runKeyboardTranscriptionJob(
+        audioURL: URL,
+        request: DictationRequest,
+        session: RecordingSession?,
+        startedFromKeyboard: Bool
+    ) async throws -> OfflineTranscriptionJobOutcome<String> {
+        try await runOfflineTranscriptionJob(
+            audioURL: audioURL,
+            onProgress: { [weak self] update in
+                self?.keyboardTranscriptionProgressUpdate(
+                    requestID: request.id,
+                    startedFromKeyboard: startedFromKeyboard,
+                    update: update
+                )
+            }
+        ) { [weak self] in
+            self?.handleKeyboardTranscriptionTimeout(
+                request: request,
+                session: session,
+                startedFromKeyboard: startedFromKeyboard
+            )
+        } operation: { [engine] progress in
+            try await engine.transcribe(audioURL: audioURL, progress: progress)
+        }
+    }
+
+    private func handleKeyboardTranscriptionTimeout(
+        request: DictationRequest,
+        session: RecordingSession?,
+        startedFromKeyboard: Bool
+    ) {
+        let message = "Transcription stalled. Open Muesli to try again."
+        if var failedSession = activeSession ?? session {
+            failedSession.phase = .failed
+            failedSession.errorMessage = message
+            try? store.saveSession(failedSession)
+        }
+        activeRequest = nil
+        activeSession = nil
+        liveDictationTranscript = ""
+        realtimeDictationCommittedText = ""
+        clearKeyboardLiveTranscript()
+        statusText = message
+        try? store.clearPendingRequest()
+        try? store.clearPendingCommand()
+        try? store.saveStatus(.init(requestID: request.id, phase: .failed, message: message))
+        if startedFromKeyboard {
+            saveKeyboardHandoff(requestID: request.id, phase: .failed, message: message)
+            saveKeyboardRuntimeStatus(
+                isActive: canStartKeyboardRequestsInBackground,
+                activeRequestID: nil,
+                phase: .failed,
+                message: message,
+                supportsBackgroundStart: canStartKeyboardRequestsInBackground
+            )
+        }
+        refreshHistory()
+        AppTelemetry.signal(
+            "dictation_failed",
+            parameters: [
+                "stage": "transcription_timeout",
+                "engine": engine.identifier
+            ]
+        )
     }
 
     private func cleanupNonRetainedAudio(for session: inout RecordingSession) {
@@ -3559,6 +3531,105 @@ private actor OfflineTranscriptionProgressTracker {
 
     func hasNoProgress(for timeout: TimeInterval, now: Date = .now) -> Bool {
         now.timeIntervalSince(lastProgressAt) >= timeout
+    }
+}
+
+private enum OfflineTranscriptionJobOutcome<Output: Sendable>: Sendable {
+    case completed(Output)
+    case timedOut
+}
+
+private final class OfflineTranscriptionJobControl<Output: Sendable>: @unchecked Sendable {
+    private let lock = NSLock()
+    private var continuation: CheckedContinuation<OfflineTranscriptionJobOutcome<Output>, Error>?
+    private var pendingCompletion: Result<OfflineTranscriptionJobOutcome<Output>, Error>?
+    private var transcriptionTask: Task<Void, Never>?
+    private var watchdogTask: Task<Void, Never>?
+    private var didFinish = false
+
+    var isFinished: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return didFinish
+    }
+
+    func setContinuation(_ continuation: CheckedContinuation<OfflineTranscriptionJobOutcome<Output>, Error>) {
+        lock.lock()
+        let pendingCompletion = pendingCompletion
+        if pendingCompletion == nil {
+            self.continuation = continuation
+        }
+        lock.unlock()
+
+        if let pendingCompletion {
+            continuation.resume(with: pendingCompletion)
+        }
+    }
+
+    func setTranscriptionTask(_ task: Task<Void, Never>) {
+        lock.lock()
+        if didFinish {
+            lock.unlock()
+            task.cancel()
+        } else {
+            transcriptionTask = task
+            lock.unlock()
+        }
+    }
+
+    func setWatchdogTask(_ task: Task<Void, Never>) {
+        lock.lock()
+        if didFinish {
+            lock.unlock()
+            task.cancel()
+        } else {
+            watchdogTask = task
+            lock.unlock()
+        }
+    }
+
+    func resume(returning outcome: OfflineTranscriptionJobOutcome<Output>) {
+        finish(.success(outcome), cancelTranscription: false)
+    }
+
+    func resume(throwing error: Error) {
+        finish(.failure(error), cancelTranscription: false)
+    }
+
+    func timeout() {
+        finish(.success(.timedOut), cancelTranscription: true)
+    }
+
+    func cancel() {
+        finish(.failure(CancellationError()), cancelTranscription: true)
+    }
+
+    private func finish(
+        _ result: Result<OfflineTranscriptionJobOutcome<Output>, Error>,
+        cancelTranscription: Bool
+    ) {
+        lock.lock()
+        guard !didFinish else {
+            lock.unlock()
+            return
+        }
+        didFinish = true
+        let continuation = continuation
+        self.continuation = nil
+        if continuation == nil {
+            pendingCompletion = result
+        }
+        let transcriptionTask = transcriptionTask
+        self.transcriptionTask = nil
+        let watchdogTask = watchdogTask
+        self.watchdogTask = nil
+        lock.unlock()
+
+        watchdogTask?.cancel()
+        if cancelTranscription {
+            transcriptionTask?.cancel()
+        }
+        continuation?.resume(with: result)
     }
 }
 

--- a/Muesli/DictationCoordinator.swift
+++ b/Muesli/DictationCoordinator.swift
@@ -1721,28 +1721,11 @@ final class DictationCoordinator {
                         )
                     }
                 ) { [weak self] in
-                    guard let self else { return }
-                    let message = "Transcription stalled. Open Muesli to try again."
-                    var failedSession = session
-                    failedSession.phase = .failed
-                    failedSession.errorMessage = message
-                    try? self.store.saveSession(failedSession)
-                    self.activeRequest = nil
-                    self.activeSession = nil
-                    self.statusText = message
-                    try? self.store.saveStatus(.init(requestID: request.id, phase: .failed, message: message))
-                    self.saveKeyboardHandoff(requestID: request.id, phase: .failed, message: message)
-                    self.saveKeyboardRuntimeStatus(
-                        isActive: self.canStartKeyboardRequestsInBackground,
-                        activeRequestID: nil,
-                        phase: .failed,
-                        message: message,
-                        supportsBackgroundStart: self.canStartKeyboardRequestsInBackground
-                    )
-                    self.refreshHistory()
-                    AppTelemetry.signal(
-                        "keyboard_transcription_recovery_failed",
-                        parameters: ["reason": "timeout"]
+                    self?.handleKeyboardTranscriptionTimeout(
+                        request: request,
+                        session: session,
+                        startedFromKeyboard: true,
+                        source: .recovery
                     )
                 } operation: { [engine] progress in
                     try await engine.transcribe(audioURL: audioURL, progress: progress)
@@ -2877,8 +2860,9 @@ final class DictationCoordinator {
                         try? await Task.sleep(for: .seconds(2))
                         guard !Task.isCancelled else { return }
                         if await tracker.hasNoProgress(for: timeout) {
+                            guard control.claimTimeout() else { return }
                             await onTimeout()
-                            control.timeout()
+                            control.completeTimeout()
                             return
                         }
                     }
@@ -2939,7 +2923,8 @@ final class DictationCoordinator {
     private func handleKeyboardTranscriptionTimeout(
         request: DictationRequest,
         session: RecordingSession?,
-        startedFromKeyboard: Bool
+        startedFromKeyboard: Bool,
+        source: KeyboardTranscriptionTimeoutSource = .activeDictation
     ) {
         let message = "Transcription stalled. Open Muesli to try again."
         if var failedSession = activeSession ?? session {
@@ -2976,13 +2961,21 @@ final class DictationCoordinator {
         }
         clearKeyboardSessionLiveActivityRoute(for: request.id)
         refreshHistory()
-        AppTelemetry.signal(
-            "dictation_failed",
-            parameters: [
-                "stage": "transcription_timeout",
-                "engine": engine.identifier
-            ]
-        )
+        switch source {
+        case .activeDictation:
+            AppTelemetry.signal(
+                "dictation_failed",
+                parameters: [
+                    "stage": "transcription_timeout",
+                    "engine": engine.identifier
+                ]
+            )
+        case .recovery:
+            AppTelemetry.signal(
+                "keyboard_transcription_recovery_failed",
+                parameters: ["reason": "timeout"]
+            )
+        }
     }
 
     private func cleanupNonRetainedAudio(for session: inout RecordingSession) {
@@ -3548,6 +3541,11 @@ private enum OfflineTranscriptionJobOutcome<Output: Sendable>: Sendable {
     case timedOut
 }
 
+private enum KeyboardTranscriptionTimeoutSource {
+    case activeDictation
+    case recovery
+}
+
 private final class OfflineTranscriptionJobControl<Output: Sendable>: @unchecked Sendable {
     private let lock = NSLock()
     private var continuation: CheckedContinuation<OfflineTranscriptionJobOutcome<Output>, Error>?
@@ -3605,12 +3603,42 @@ private final class OfflineTranscriptionJobControl<Output: Sendable>: @unchecked
         finish(.failure(error), cancelTranscription: false)
     }
 
-    func timeout() {
-        finish(.success(.timedOut), cancelTranscription: true)
+    func claimTimeout() -> Bool {
+        lock.lock()
+        guard !didFinish else {
+            lock.unlock()
+            return false
+        }
+        didFinish = true
+        let transcriptionTask = transcriptionTask
+        self.transcriptionTask = nil
+        let watchdogTask = watchdogTask
+        self.watchdogTask = nil
+        lock.unlock()
+
+        watchdogTask?.cancel()
+        transcriptionTask?.cancel()
+        return true
+    }
+
+    func completeTimeout() {
+        completeClaimedFinish(.success(.timedOut))
     }
 
     func cancel() {
         finish(.failure(CancellationError()), cancelTranscription: true)
+    }
+
+    private func completeClaimedFinish(_ result: Result<OfflineTranscriptionJobOutcome<Output>, Error>) {
+        lock.lock()
+        let continuation = continuation
+        self.continuation = nil
+        if continuation == nil {
+            pendingCompletion = result
+        }
+        lock.unlock()
+
+        continuation?.resume(with: result)
     }
 
     private func finish(

--- a/Muesli/DictationCoordinator.swift
+++ b/Muesli/DictationCoordinator.swift
@@ -2953,19 +2953,28 @@ final class DictationCoordinator {
         realtimeDictationCommittedText = ""
         clearKeyboardLiveTranscript()
         statusText = message
+        let completedDeferredStop = completeDeferredKeyboardSessionStopIfNeeded()
         try? store.clearPendingRequest()
         try? store.clearPendingCommand()
         try? store.saveStatus(.init(requestID: request.id, phase: .failed, message: message))
         if startedFromKeyboard {
             saveKeyboardHandoff(requestID: request.id, phase: .failed, message: message)
-            saveKeyboardRuntimeStatus(
-                isActive: canStartKeyboardRequestsInBackground,
-                activeRequestID: nil,
-                phase: .failed,
-                message: message,
-                supportsBackgroundStart: canStartKeyboardRequestsInBackground
-            )
+            if !completedDeferredStop {
+                saveKeyboardRuntimeStatus(
+                    isActive: canStartKeyboardRequestsInBackground,
+                    activeRequestID: nil,
+                    phase: .failed,
+                    message: message,
+                    supportsBackgroundStart: canStartKeyboardRequestsInBackground
+                )
+            }
         }
+        transitionKeyboardSession(.requestFinished)
+        if !completedDeferredStop {
+            resumeKeyboardSessionKeeperIfNeeded()
+            publishKeyboardSessionReadyIfAvailable()
+        }
+        clearKeyboardSessionLiveActivityRoute(for: request.id)
         refreshHistory()
         AppTelemetry.signal(
             "dictation_failed",

--- a/Muesli/DictationCoordinator.swift
+++ b/Muesli/DictationCoordinator.swift
@@ -135,6 +135,7 @@ final class DictationCoordinator {
     private static let onboardingCompletedKey = "muesli.onboarding.completed"
     private static let userNameKey = "muesli.onboarding.userName"
     private static let useCaseKey = "muesli.onboarding.useCase"
+    private static let offlineTranscriptionNoProgressTimeout: TimeInterval = 90
 
     private let store = SharedStore()
     private let engine = FluidAudioTranscriptionEngine()
@@ -167,6 +168,9 @@ final class DictationCoordinator {
     private var meetingChunkTranscriptions: [MeetingChunkTranscription] = []
     private var meetingChunksDirectory: URL?
     private var discardedMeetingSessionIDs = Set<UUID>()
+    private var timedOutTranscriptionRequestIDs = Set<UUID>()
+    private var timedOutTranscriptionJobIDs = Set<UUID>()
+    private var timedOutMeetingSessionIDs = Set<UUID>()
     private let meetingVadQueue = DispatchQueue(label: "com.phequals7.muesli.meeting-vad")
     private var transcriptionBackgroundTask: UIBackgroundTaskIdentifier = .invalid
     nonisolated(unsafe) private var audioRouteObserver: NSObjectProtocol?
@@ -1296,8 +1300,33 @@ final class DictationCoordinator {
         Task {
             do {
                 let audioURL = try recorder.stop()
-                let text = postProcessTranscript(try await engine.transcribe(audioURL: audioURL))
+                let jobID = UUID()
+                let tracker = OfflineTranscriptionProgressTracker()
+                let progressHandler = offlineTranscriptionProgressHandler(tracker: tracker)
+                let watchdog = startOfflineTranscriptionWatchdog(
+                    tracker: tracker,
+                    timeout: offlineTranscriptionTimeout(for: audioURL)
+                ) { [weak self] in
+                    guard let self else { return }
+                    self.timedOutTranscriptionJobIDs.insert(jobID)
+                    self.isOnboardingTestTranscribing = false
+                    self.onboardingTestError = "Transcription stalled. Try again."
+                    AppTelemetry.signal(
+                        "onboarding_test_failed",
+                        parameters: ["stage": "transcription_timeout"]
+                    )
+                }
+                defer {
+                    watchdog.cancel()
+                }
+
+                let text = postProcessTranscript(try await engine.transcribe(
+                    audioURL: audioURL,
+                    progress: progressHandler
+                ))
+                guard !timedOutTranscriptionJobIDs.contains(jobID) else { return }
                 isOnboardingTestTranscribing = false
+                onboardingTestError = nil
                 if text.isEmpty {
                     onboardingTestError = "No speech detected. Try again."
                     AppTelemetry.signal("onboarding_test_empty", parameters: ["engine": engine.identifier])
@@ -1688,7 +1717,56 @@ final class DictationCoordinator {
                     phase: .transcribingStarted,
                     message: "Recovering transcription"
                 )
-                let text = postProcessTranscript(try await engine.transcribe(audioURL: audioURL))
+                let tracker = OfflineTranscriptionProgressTracker()
+                let progressHandler = offlineTranscriptionProgressHandler(tracker: tracker) { [weak self] update in
+                    guard let self, !self.timedOutTranscriptionRequestIDs.contains(request.id) else { return }
+                    let message = self.transcriptionStatusMessage(for: update)
+                    self.statusText = message
+                    try? self.store.saveStatus(.init(requestID: request.id, phase: .transcribing, message: message))
+                    self.saveKeyboardHandoff(requestID: request.id, phase: .transcribingStarted, message: message)
+                    self.saveKeyboardRuntimeStatus(
+                        isActive: true,
+                        activeRequestID: request.id,
+                        phase: .transcribing,
+                        message: message,
+                        supportsBackgroundStart: self.canStartKeyboardRequestsInBackground
+                    )
+                }
+                let watchdog = startOfflineTranscriptionWatchdog(
+                    tracker: tracker,
+                    timeout: offlineTranscriptionTimeout(for: audioURL)
+                ) { [weak self] in
+                    guard let self else { return }
+                    let message = "Transcription stalled. Open Muesli to try again."
+                    self.timedOutTranscriptionRequestIDs.insert(request.id)
+                    self.activeRequest = nil
+                    self.activeSession = nil
+                    self.statusText = message
+                    try? self.store.saveStatus(.init(requestID: request.id, phase: .failed, message: message))
+                    self.saveKeyboardHandoff(requestID: request.id, phase: .failed, message: message)
+                    self.saveKeyboardRuntimeStatus(
+                        isActive: self.canStartKeyboardRequestsInBackground,
+                        activeRequestID: nil,
+                        phase: .failed,
+                        message: message,
+                        supportsBackgroundStart: self.canStartKeyboardRequestsInBackground
+                    )
+                    self.endTranscriptionBackgroundTask()
+                    self.refreshHistory()
+                    AppTelemetry.signal(
+                        "keyboard_transcription_recovery_failed",
+                        parameters: ["reason": "timeout"]
+                    )
+                }
+                defer {
+                    watchdog.cancel()
+                }
+
+                let text = postProcessTranscript(try await engine.transcribe(
+                    audioURL: audioURL,
+                    progress: progressHandler
+                ))
+                guard !timedOutTranscriptionRequestIDs.contains(request.id) else { return }
                 let savedTranscript = Transcript(
                     sessionID: session.id,
                     text: text,
@@ -1742,6 +1820,7 @@ final class DictationCoordinator {
                     ]
                 )
             } catch {
+                guard !timedOutTranscriptionRequestIDs.contains(request.id) else { return }
                 var failedSession = session
                 failedSession.phase = .failed
                 failedSession.errorMessage = error.localizedDescription
@@ -1857,6 +1936,10 @@ final class DictationCoordinator {
 
             do {
                 let usesRealtimeStreaming = realtimeDictationRecorder != nil
+                var transcriptionWatchdog: Task<Void, Never>?
+                defer {
+                    transcriptionWatchdog?.cancel()
+                }
                 let audioURL: URL
                 var text: String
 
@@ -1869,7 +1952,22 @@ final class DictationCoordinator {
                             message: "Transcribing"
                         )
                     }
-                    text = postProcessTranscript(try await engine.transcribe(audioURL: audioURL))
+                    let tracker = OfflineTranscriptionProgressTracker()
+                    transcriptionWatchdog = startKeyboardTranscriptionWatchdog(
+                        request: request,
+                        session: session,
+                        audioURL: audioURL,
+                        startedFromKeyboard: startedFromKeyboard,
+                        tracker: tracker
+                    )
+                    text = postProcessTranscript(try await engine.transcribe(
+                        audioURL: audioURL,
+                        progress: keyboardTranscriptionProgressHandler(
+                            requestID: request.id,
+                            tracker: tracker,
+                            startedFromKeyboard: startedFromKeyboard
+                        )
+                    ))
                 } else if usesRealtimeStreaming {
                     let stoppedAudio = realtimeDictationRecorder?.stop()
                     realtimeDictationRecorder = nil
@@ -1894,7 +1992,22 @@ final class DictationCoordinator {
                     }
                     text = postProcessTranscript(try await engine.finishRealtimeSession())
                     if text.isEmpty {
-                        text = postProcessTranscript(try await engine.transcribe(audioURL: audioURL))
+                        let tracker = OfflineTranscriptionProgressTracker()
+                        transcriptionWatchdog = startKeyboardTranscriptionWatchdog(
+                            request: request,
+                            session: session,
+                            audioURL: audioURL,
+                            startedFromKeyboard: startedFromKeyboard,
+                            tracker: tracker
+                        )
+                        text = postProcessTranscript(try await engine.transcribe(
+                            audioURL: audioURL,
+                            progress: keyboardTranscriptionProgressHandler(
+                                requestID: request.id,
+                                tracker: tracker,
+                                startedFromKeyboard: startedFromKeyboard
+                            )
+                        ))
                     }
                     liveDictationTranscript = text
                 } else {
@@ -1906,8 +2019,24 @@ final class DictationCoordinator {
                             message: "Transcribing"
                         )
                     }
-                    text = postProcessTranscript(try await engine.transcribe(audioURL: audioURL))
+                    let tracker = OfflineTranscriptionProgressTracker()
+                    transcriptionWatchdog = startKeyboardTranscriptionWatchdog(
+                        request: request,
+                        session: session,
+                        audioURL: audioURL,
+                        startedFromKeyboard: startedFromKeyboard,
+                        tracker: tracker
+                    )
+                    text = postProcessTranscript(try await engine.transcribe(
+                        audioURL: audioURL,
+                        progress: keyboardTranscriptionProgressHandler(
+                            requestID: request.id,
+                            tracker: tracker,
+                            startedFromKeyboard: startedFromKeyboard
+                        )
+                    ))
                 }
+                guard !timedOutTranscriptionRequestIDs.contains(request.id) else { return }
                 guard !isRecordingSessionCancelled(requestID: request.id) else {
                     if startedFromKeyboard {
                         saveKeyboardHandoff(requestID: request.id, phase: .cancelled, message: "Cancelled")
@@ -2014,6 +2143,7 @@ final class DictationCoordinator {
                     ]
                 )
             } catch {
+                guard !timedOutTranscriptionRequestIDs.contains(request.id) else { return }
                 if var session = activeSession ?? session {
                     session.phase = .failed
                     session.errorMessage = error.localizedDescription
@@ -2473,7 +2603,47 @@ final class DictationCoordinator {
 
             do {
                 let audioURL = try store.audioFileURL(fileName: audioFileName)
-                let detailedTranscription = try await engine.transcribeDetailed(audioURL: audioURL)
+                let tracker = OfflineTranscriptionProgressTracker()
+                let progressHandler = offlineTranscriptionProgressHandler(tracker: tracker) { [weak self] update in
+                    guard let self, !self.timedOutMeetingSessionIDs.contains(session.id) else { return }
+                    self.meetingStatusText = self.transcriptionStatusMessage(for: update)
+                }
+                let watchdog = startOfflineTranscriptionWatchdog(
+                    tracker: tracker,
+                    timeout: offlineTranscriptionTimeout(for: audioURL)
+                ) { [weak self] in
+                    guard let self else { return }
+                    let message = "Transcription stalled. Try again."
+                    self.timedOutMeetingSessionIDs.insert(session.id)
+                    var failedSession = session
+                    failedSession.phase = .failed
+                    failedSession.errorMessage = message
+                    try? self.store.saveSession(failedSession)
+                    self.meetingStatusText = message
+                    self.isMeetingTranscribing = false
+                    self.endTranscriptionBackgroundTask()
+                    self.refreshHistory()
+                    Task {
+                        await self.liveActivityController.end(
+                            phase: "Failed",
+                            detail: "Transcription stalled",
+                            session: session
+                        )
+                    }
+                    AppTelemetry.signal(
+                        "meeting_transcription_failed",
+                        parameters: ["engine": self.engine.identifier, "error": "timeout"]
+                    )
+                }
+                defer {
+                    watchdog.cancel()
+                }
+
+                let detailedTranscription = try await engine.transcribeDetailed(
+                    audioURL: audioURL,
+                    progress: progressHandler
+                )
+                guard !timedOutMeetingSessionIDs.contains(session.id) else { return }
                 let text = postProcessTranscript(detailedTranscription.text)
                 let finalTranscript = try await finalizeMeetingTranscript(
                     session: session,
@@ -2506,6 +2676,7 @@ final class DictationCoordinator {
                     "summarized": finalTranscript.transcript.summaryState == .completed ? "true" : "false"
                 ])
             } catch {
+                guard !timedOutMeetingSessionIDs.contains(session.id) else { return }
                 session.phase = .failed
                 session.errorMessage = error.localizedDescription
                 try? store.saveSession(session)
@@ -2703,6 +2874,134 @@ final class DictationCoordinator {
         recordingTimerTask?.cancel()
         recordingTimerTask = nil
         recordingElapsedTime = 0
+    }
+
+    private func offlineTranscriptionTimeout(for audioURL: URL?) -> TimeInterval {
+        guard let audioURL,
+              let audioFile = try? AVAudioFile(forReading: audioURL),
+              audioFile.fileFormat.sampleRate > 0
+        else {
+            return Self.offlineTranscriptionNoProgressTimeout
+        }
+
+        let duration = Double(audioFile.length) / audioFile.fileFormat.sampleRate
+        return min(max(Self.offlineTranscriptionNoProgressTimeout, duration * 2), 300)
+    }
+
+    private func transcriptionStatusMessage(
+        for update: TranscriptionProgressUpdate,
+        fallback: String = "Transcribing"
+    ) -> String {
+        guard let fraction = update.fractionCompleted, fraction > 0, fraction < 1 else {
+            return update.message ?? fallback
+        }
+        return "\(update.message ?? fallback) \(Int((fraction * 100).rounded()))%"
+    }
+
+    private func offlineTranscriptionProgressHandler(
+        tracker: OfflineTranscriptionProgressTracker,
+        onProgress: (@MainActor @Sendable (TranscriptionProgressUpdate) -> Void)? = nil
+    ) -> @Sendable (TranscriptionProgressUpdate) -> Void {
+        { update in
+            Task {
+                await tracker.record(update)
+            }
+            if let onProgress {
+                Task { @MainActor in
+                    onProgress(update)
+                }
+            }
+        }
+    }
+
+    private func startOfflineTranscriptionWatchdog(
+        tracker: OfflineTranscriptionProgressTracker,
+        timeout: TimeInterval,
+        onTimeout: @escaping @MainActor @Sendable () -> Void
+    ) -> Task<Void, Never> {
+        Task.detached(priority: .utility) {
+            while !Task.isCancelled {
+                try? await Task.sleep(for: .seconds(2))
+                guard !Task.isCancelled else { return }
+                if await tracker.hasNoProgress(for: timeout) {
+                    await onTimeout()
+                    return
+                }
+            }
+        }
+    }
+
+    private func keyboardTranscriptionProgressHandler(
+        requestID: UUID,
+        tracker: OfflineTranscriptionProgressTracker,
+        startedFromKeyboard: Bool
+    ) -> @Sendable (TranscriptionProgressUpdate) -> Void {
+        offlineTranscriptionProgressHandler(tracker: tracker) { [weak self] update in
+            guard let self, !self.timedOutTranscriptionRequestIDs.contains(requestID) else { return }
+            let message = self.transcriptionStatusMessage(for: update)
+            self.statusText = message
+            try? self.store.saveStatus(.init(requestID: requestID, phase: .transcribing, message: message))
+            if startedFromKeyboard {
+                self.saveKeyboardHandoff(requestID: requestID, phase: .transcribingStarted, message: message)
+                self.saveKeyboardRuntimeStatus(
+                    isActive: true,
+                    activeRequestID: requestID,
+                    phase: .transcribing,
+                    message: message,
+                    supportsBackgroundStart: self.canStartKeyboardRequestsInBackground
+                )
+            }
+        }
+    }
+
+    private func startKeyboardTranscriptionWatchdog(
+        request: DictationRequest,
+        session: RecordingSession?,
+        audioURL: URL?,
+        startedFromKeyboard: Bool,
+        tracker: OfflineTranscriptionProgressTracker
+    ) -> Task<Void, Never> {
+        startOfflineTranscriptionWatchdog(
+            tracker: tracker,
+            timeout: offlineTranscriptionTimeout(for: audioURL)
+        ) { [weak self] in
+            guard let self else { return }
+            let message = "Transcription stalled. Open Muesli to try again."
+            self.timedOutTranscriptionRequestIDs.insert(request.id)
+            if var failedSession = self.activeSession ?? session {
+                failedSession.phase = .failed
+                failedSession.errorMessage = message
+                try? self.store.saveSession(failedSession)
+            }
+            self.activeRequest = nil
+            self.activeSession = nil
+            self.liveDictationTranscript = ""
+            self.realtimeDictationCommittedText = ""
+            self.clearKeyboardLiveTranscript()
+            self.statusText = message
+            try? self.store.clearPendingRequest()
+            try? self.store.clearPendingCommand()
+            try? self.store.saveStatus(.init(requestID: request.id, phase: .failed, message: message))
+            if startedFromKeyboard {
+                self.saveKeyboardHandoff(requestID: request.id, phase: .failed, message: message)
+                self.saveKeyboardRuntimeStatus(
+                    isActive: self.canStartKeyboardRequestsInBackground,
+                    activeRequestID: nil,
+                    phase: .failed,
+                    message: message,
+                    supportsBackgroundStart: self.canStartKeyboardRequestsInBackground
+                )
+            }
+            self.endTranscriptionBackgroundTask()
+            self.refreshHistory()
+            AppTelemetry.signal(
+                "dictation_failed",
+                parameters: [
+                    "stage": "transcription_timeout",
+                    "engine": self.engine.identifier
+                ]
+            )
+        }
     }
 
     private func cleanupNonRetainedAudio(for session: inout RecordingSession) {
@@ -3248,6 +3547,18 @@ final class DictationCoordinator {
         realtimeDictationChunksDirectory = nil
         realtimeDictationCommittedText = ""
         liveDictationTranscript = ""
+    }
+}
+
+private actor OfflineTranscriptionProgressTracker {
+    private var lastProgressAt = Date()
+
+    func record(_ update: TranscriptionProgressUpdate) {
+        lastProgressAt = update.updatedAt
+    }
+
+    func hasNoProgress(for timeout: TimeInterval, now: Date = .now) -> Bool {
+        now.timeIntervalSince(lastProgressAt) >= timeout
     }
 }
 

--- a/Muesli/FluidAudioTranscriptionEngine.swift
+++ b/Muesli/FluidAudioTranscriptionEngine.swift
@@ -174,6 +174,13 @@ actor FluidAudioTranscriptionEngine: TranscriptionEngine {
         }
         progress?(1.0, "Preparing model for this iPhone...")
         let manager = AsrManager(config: .default)
+        let loadHeartbeat = Self.modelLoadHeartbeatTask(
+            progress: progress,
+            message: "Preparing model for this iPhone..."
+        )
+        defer {
+            loadHeartbeat?.cancel()
+        }
         try await manager.loadModels(models)
         self.manager = manager
         progress?(1.0, "\(model.shortName) ready")
@@ -218,7 +225,9 @@ actor FluidAudioTranscriptionEngine: TranscriptionEngine {
         audioURL: URL,
         progress: (@Sendable (TranscriptionProgressUpdate) -> Void)? = nil
     ) async throws -> DetailedTranscriptionResult {
-        let manager = try await loadedStreamingManager(progress: nil)
+        let manager = try await loadedStreamingManager { fraction, status in
+            progress?(.init(fractionCompleted: fraction, message: status))
+        }
         await manager.reset()
 
         let audioFile = try AVAudioFile(forReading: audioURL)
@@ -281,6 +290,20 @@ actor FluidAudioTranscriptionEngine: TranscriptionEngine {
             return "Downloading model • \(percent)%"
         case .compiling:
             return "Compiling CoreML model..."
+        }
+    }
+
+    private nonisolated static func modelLoadHeartbeatTask(
+        progress: (@Sendable (Double, String?) -> Void)?,
+        message: String
+    ) -> Task<Void, Never>? {
+        guard let progress else { return nil }
+        return Task.detached(priority: .utility) {
+            while !Task.isCancelled {
+                try? await Task.sleep(for: .seconds(10))
+                guard !Task.isCancelled else { return }
+                progress(1, message)
+            }
         }
     }
 

--- a/Muesli/FluidAudioTranscriptionEngine.swift
+++ b/Muesli/FluidAudioTranscriptionEngine.swift
@@ -49,19 +49,48 @@ actor FluidAudioTranscriptionEngine: TranscriptionEngine {
         }
     }
 
-    func transcribe(audioURL: URL) async throws -> String {
-        let result = try await transcribeDetailed(audioURL: audioURL)
+    func transcribe(
+        audioURL: URL,
+        progress: (@Sendable (TranscriptionProgressUpdate) -> Void)? = nil
+    ) async throws -> String {
+        let result = try await transcribeDetailed(audioURL: audioURL, progress: progress)
         return result.text
     }
 
-    func transcribeDetailed(audioURL: URL) async throws -> DetailedTranscriptionResult {
+    func transcribeDetailed(
+        audioURL: URL,
+        progress: (@Sendable (TranscriptionProgressUpdate) -> Void)? = nil
+    ) async throws -> DetailedTranscriptionResult {
         if selectedModel.supportsRealtimeStreaming {
-            return try await transcribeWithStreamingManager(audioURL: audioURL)
+            return try await transcribeWithStreamingManager(audioURL: audioURL, progress: progress)
         }
 
-        let manager = try await loadedManager(progress: nil)
+        let manager = try await loadedManager { fraction, status in
+            progress?(.init(fractionCompleted: fraction, message: status))
+        }
+        progress?(.init(fractionCompleted: 0, message: "Transcribing"))
+        let progressTask: Task<Void, Never>? = Self.shouldObserveOfflineProgress(for: audioURL)
+            ? Task {
+                let stream = await manager.transcriptionProgressStream
+                do {
+                    for try await fraction in stream {
+                        try Task.checkCancellation()
+                        progress?(.init(fractionCompleted: fraction, message: "Transcribing"))
+                    }
+                } catch is CancellationError {
+                    return
+                } catch {
+                    return
+                }
+            }
+            : nil
+        defer {
+            progressTask?.cancel()
+        }
+
         var decoderState = TdtDecoderState.make(decoderLayers: await manager.decoderLayerCount)
         let result = try await manager.transcribe(audioURL, decoderState: &decoderState)
+        progress?(.init(fractionCompleted: 1, message: "Transcription complete"))
         return DetailedTranscriptionResult(
             text: result.text.trimmingCharacters(in: .whitespacesAndNewlines),
             duration: result.duration,
@@ -185,7 +214,10 @@ actor FluidAudioTranscriptionEngine: TranscriptionEngine {
         return manager
     }
 
-    private func transcribeWithStreamingManager(audioURL: URL) async throws -> DetailedTranscriptionResult {
+    private func transcribeWithStreamingManager(
+        audioURL: URL,
+        progress: (@Sendable (TranscriptionProgressUpdate) -> Void)? = nil
+    ) async throws -> DetailedTranscriptionResult {
         let manager = try await loadedStreamingManager(progress: nil)
         await manager.reset()
 
@@ -209,10 +241,15 @@ actor FluidAudioTranscriptionEngine: TranscriptionEngine {
             try audioFile.read(into: buffer, frameCount: framesToRead)
             guard buffer.frameLength > 0 else { break }
             _ = try await manager.process(audioBuffer: buffer)
+            let fraction = audioFile.length > 0
+                ? Double(audioFile.framePosition) / Double(audioFile.length)
+                : nil
+            progress?(.init(fractionCompleted: fraction, message: "Processing audio"))
             try Task.checkCancellation()
         }
 
         let text = try await manager.finish()
+        progress?(.init(fractionCompleted: 1, message: "Transcription complete"))
         return DetailedTranscriptionResult(
             text: text.trimmingCharacters(in: .whitespacesAndNewlines),
             duration: duration,
@@ -245,6 +282,14 @@ actor FluidAudioTranscriptionEngine: TranscriptionEngine {
         case .compiling:
             return "Compiling CoreML model..."
         }
+    }
+
+    private nonisolated static func shouldObserveOfflineProgress(for audioURL: URL) -> Bool {
+        guard let audioFile = try? AVAudioFile(forReading: audioURL),
+              audioFile.fileFormat.sampleRate > 0 else {
+            return true
+        }
+        return Double(audioFile.length) / audioFile.fileFormat.sampleRate > 15
     }
 }
 

--- a/Muesli/LaunchWarmupView.swift
+++ b/Muesli/LaunchWarmupView.swift
@@ -40,11 +40,10 @@ struct LaunchWarmupContainer<Content: View>: View {
 
         while !Task.isCancelled {
             let elapsed = startedAt.duration(to: .now)
-            let minimumDisplaySatisfied = elapsed >= .milliseconds(1400)
-            let maximumDisplayReached = elapsed >= .seconds(20)
+            let maximumDisplayReached = elapsed >= .seconds(5)
             let warmupFinished = !coordinator.isModelPrewarmInProgress && !coordinator.modelPreparation.isPreparing
 
-            if minimumDisplaySatisfied && (warmupFinished || maximumDisplayReached) {
+            if warmupFinished || maximumDisplayReached {
                 break
             }
 

--- a/Shared/TranscriptionEngine.swift
+++ b/Shared/TranscriptionEngine.swift
@@ -1,16 +1,44 @@
 import Foundation
 
+struct TranscriptionProgressUpdate: Sendable, Equatable {
+    let fractionCompleted: Double?
+    let message: String?
+    let updatedAt: Date
+
+    init(
+        fractionCompleted: Double? = nil,
+        message: String? = nil,
+        updatedAt: Date = .now
+    ) {
+        self.fractionCompleted = fractionCompleted.map { min(max($0, 0), 1) }
+        self.message = message
+        self.updatedAt = updatedAt
+    }
+}
+
 protocol TranscriptionEngine: Sendable {
     var identifier: String { get }
-    func transcribe(audioURL: URL) async throws -> String
+    func transcribe(
+        audioURL: URL,
+        progress: (@Sendable (TranscriptionProgressUpdate) -> Void)?
+    ) async throws -> String
+}
+
+extension TranscriptionEngine {
+    func transcribe(audioURL: URL) async throws -> String {
+        try await transcribe(audioURL: audioURL, progress: nil)
+    }
 }
 
 struct PlaceholderSpeechEngine: TranscriptionEngine {
     let identifier = "placeholder"
 
-    func transcribe(audioURL: URL) async throws -> String {
+    func transcribe(
+        audioURL: URL,
+        progress: (@Sendable (TranscriptionProgressUpdate) -> Void)? = nil
+    ) async throws -> String {
         _ = audioURL
+        progress?(.init(fractionCompleted: 1, message: "Transcription ready"))
         return "Muesli iOS transcription engine is ready to be connected."
     }
 }
-


### PR DESCRIPTION
## Summary

Adds progress-aware offline transcription handling so keyboard and voice-note transcription jobs do not leave the UI stuck indefinitely when FluidAudio/CoreML stalls or stops reporting useful progress.

This PR also carries the launch warmup follow-up that caps the branded warmup overlay at 5 seconds while letting model warmup continue in the background.

## What changed

- Adds `TranscriptionProgressUpdate` plumbing to the shared transcription engine API.
- Wires FluidAudio offline/model-load progress into the iOS transcription engine.
- Adds offline transcription progress tracking and watchdog handling in `DictationCoordinator`.
- Applies terminal failure cleanup for keyboard transcription timeouts so the keyboard does not stay in disabled `Transcribing` forever.
- Guards late transcription success/error paths from overwriting timeout/cancel state.
- Caps `LaunchWarmupView` display to 5 seconds.

## Why

A TestFlight user hit a state where the keyboard stayed in `Transcribing` and the stop/action UI never recovered. The likely failure mode is an offline transcription await that does not complete under model/CoreML pressure. The fix keeps FluidAudio progress where available, but still gives the app-owned job boundary a watchdog so user-visible state can recover.

## Validation

- Built successfully on iOS Simulator via XcodeBuildMCP.
- Ran `MuesliTests`: 39/39 passing after the offline transcription changes.
- Rebuilt successfully after adding the warmup overlay cap commit.
- Simulator main-app voice-note flow: start recording -> stop -> saved note -> returned to `Ready`.
- Deterministic simulator audio test with `/Users/pranavhari/Desktop/hacks/muesli-mlx-swift-port/sambandam.wav` routed through `BlackHole 2ch` into Simulator audio input: transcription completed, saved a new note, returned to `Ready`, and did not trigger timeout/failure logs.

## Notes

This does not attempt to solve diarization or non-transcription hangups. It is scoped to offline transcription and keyboard/voice-note recovery behavior.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli-ios/pr/16"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785912726&installation_id=136549638&pr_number=16&repository=Muesli-HQ%2Fmuesli-ios&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli-ios%2Fpull%2F16&signature=80fdf97bafe7054b1cf1f8335da0a53e75b5b51bbaafb92d2a1a755d19a416cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional live transcription progress updates with status messaging while processing audio (offline and streaming).
  * Progress is now reported during model loading and during streaming transcription playback.

* **Bug Fixes**
  * Improved offline transcription reliability with stalled-progress detection and safer timeout cancellation.
  * Enhanced timeout handling and recovery for keyboard, onboarding, and meeting transcription, including more consistent UI/status persistence and timeout telemetry.

* **Other**
  * Warmup screens now finish sooner with a shorter maximum display time cap.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->