### PR TITLE
Revamp meetings flow and audio controls

### DIFF
--- a/Muesli/DictationCoordinator.swift
+++ b/Muesli/DictationCoordinator.swift
@@ -713,7 +713,7 @@ final class DictationCoordinator {
     @discardableResult
     func deleteMeetingAudio(for session: RecordingSession) -> Bool {
         do {
-            guard var storedSession = try? store.activeRecordingSession(id: session.id),
+            guard var storedSession = try store.activeRecordingSession(id: session.id),
                   storedSession.kind == .meeting,
                   let audioFileName = storedSession.audioFileName
             else {

--- a/Muesli/DictationCoordinator.swift
+++ b/Muesli/DictationCoordinator.swift
@@ -2282,6 +2282,13 @@ final class DictationCoordinator {
                 refreshAudioInputRoute()
                 vadController.start()
 
+                guard !discardedMeetingSessionIDs.contains(session.id) else {
+                    vadController.stop()
+                    streamingRecorder.cancel()
+                    abortDiscardedMeetingStartup(session)
+                    return
+                }
+
                 meetingRecorder = streamingRecorder
                 meetingVadController = vadController
                 meetingChunksDirectory = chunksDirectory

--- a/Muesli/DictationCoordinator.swift
+++ b/Muesli/DictationCoordinator.swift
@@ -257,6 +257,7 @@ final class DictationCoordinator {
     var liveDictationTranscript = ""
     var dictationHistory: [DictationResult] = []
     var recordingSessions: [RecordingSession] = []
+    private var transcriptCache: [UUID: Transcript] = [:]
     var isMeetingRecording = false
     var isMeetingTranscribing = false
     var activeMeetingTitle = "Untitled Meeting"
@@ -618,10 +619,25 @@ final class DictationCoordinator {
         do {
             dictationHistory = try store.resultsHistory()
             recordingSessions = try store.recordingSessions()
+            transcriptCache = transcriptsBySessionID(try store.transcripts())
             lastTranscript = dictationHistory.first?.text ?? lastTranscript
         } catch {
             statusText = error.localizedDescription
         }
+    }
+
+    private func transcriptsBySessionID(_ transcripts: [Transcript]) -> [UUID: Transcript] {
+        transcripts.reduce(into: [:]) { cache, transcript in
+            cache[transcript.sessionID] = transcript
+        }
+    }
+
+    private func cacheTranscript(_ transcript: Transcript) {
+        transcriptCache[transcript.sessionID] = transcript
+    }
+
+    private func removeCachedTranscript(for sessionID: UUID) {
+        transcriptCache.removeValue(forKey: sessionID)
     }
 
     private func postProcessTranscript(_ text: String) -> String {
@@ -643,6 +659,7 @@ final class DictationCoordinator {
                     try? store.deleteAudioFile(fileName: audioFileName)
                 }
                 try? store.deleteTranscript(for: session.id)
+                removeCachedTranscript(for: session.id)
                 try? store.deleteRecordingSession(id: session.id)
                 recordingSessions.removeAll { $0.id == session.id }
             }
@@ -698,6 +715,7 @@ final class DictationCoordinator {
                 try? store.deleteAudioFile(fileName: audioFileName)
             }
             try store.deleteTranscript(for: session.id)
+            removeCachedTranscript(for: session.id)
             try store.deleteRecordingSession(id: session.id)
             recordingSessions.removeAll { $0.id == session.id }
             clipboardStatusText = "Deleted"
@@ -1157,7 +1175,7 @@ final class DictationCoordinator {
     }
 
     func transcript(for session: RecordingSession) -> Transcript? {
-        try? store.transcript(for: session.id)
+        transcriptCache[session.id]
     }
 
     func saveOnboardingProfile(name: String, useCase: OnboardingUseCase) {
@@ -1802,6 +1820,7 @@ final class DictationCoordinator {
                     engineIdentifier: engine.identifier
                 )
                 try store.saveTranscript(savedTranscript)
+                cacheTranscript(savedTranscript)
 
                 var completedSession = session
                 completedSession.phase = .completed
@@ -2066,6 +2085,7 @@ final class DictationCoordinator {
                         engineIdentifier: engine.identifier
                     )
                     try store.saveTranscript(savedTranscript)
+                    cacheTranscript(savedTranscript)
                     completedSession.phase = .completed
                     completedSession.audioFileName = completedSession.audioFileName ?? audioURL.lastPathComponent
                     completedSession.transcriptID = savedTranscript.id
@@ -2396,6 +2416,7 @@ final class DictationCoordinator {
             try? store.deleteAudioFile(fileName: audioFileName)
         }
         try? store.deleteTranscript(for: session.id)
+        removeCachedTranscript(for: session.id)
         try? store.deleteRecordingSession(id: session.id)
         recordingSessions.removeAll { $0.id == session.id }
         refreshHistory()
@@ -2506,7 +2527,12 @@ final class DictationCoordinator {
             diarizationState: .processing,
             summaryState: MuesliPreferences.meetingSummariesEnabled ? .processing : .notStarted
         )
-        try? store.saveTranscript(transcript)
+        do {
+            try store.saveTranscript(transcript)
+        } catch {
+            return
+        }
+        cacheTranscript(transcript)
         session.transcriptID = transcript.id
         session.engineIdentifier = engine.identifier
         _ = try? saveActiveMeetingSession(session)
@@ -2555,6 +2581,7 @@ final class DictationCoordinator {
                 )
                 guard shouldContinueMeetingFinalization(sessionID: session.id) else {
                     try? store.deleteTranscript(for: session.id)
+                    removeCachedTranscript(for: session.id)
                     meetingStatusText = "Ready"
                     cleanupMeetingChunks()
                     return
@@ -2823,6 +2850,7 @@ final class DictationCoordinator {
             summaryErrorMessage: summaryErrorMessage
         )
         try store.saveTranscript(transcript)
+        cacheTranscript(transcript)
         return FinalizedMeetingTranscript(transcript: transcript, resolvedTitle: resolvedTitle)
     }
 
@@ -2852,6 +2880,7 @@ final class DictationCoordinator {
             try? store.deleteAudioFile(fileName: audioFileName)
         }
         try? store.deleteTranscript(for: session.id)
+        removeCachedTranscript(for: session.id)
         try? store.deleteRecordingSession(id: session.id)
         activeSession = nil
         meetingRecorder = nil

--- a/Muesli/DictationCoordinator.swift
+++ b/Muesli/DictationCoordinator.swift
@@ -2335,14 +2335,7 @@ final class DictationCoordinator {
         session.endedAt = .now
 
         guard session.audioFileName != nil else {
-            session.phase = .failed
-            session.errorMessage = "Muesli found a recording session without an active recorder or saved audio."
-            try? store.saveSession(session)
-            meetingStatusText = session.errorMessage ?? "Recording recovery failed"
-            refreshHistory()
-            AppTelemetry.signal("meeting_recording_recovery_failed", parameters: [
-                "reason": "missing_audio"
-            ])
+            stopMeetingStartup(session)
             return
         }
 
@@ -2358,6 +2351,20 @@ final class DictationCoordinator {
         refreshHistory()
         AppTelemetry.signal("meeting_recording_recovered_for_transcription")
         transcribeSession(session)
+    }
+
+    private func stopMeetingStartup(_ session: RecordingSession) {
+        MuesliHaptics.dictationStop()
+        discardedMeetingSessionIDs.insert(session.id)
+        abortDiscardedMeetingStartup(session)
+        Task {
+            await liveActivityController.end(
+                phase: "Stopped",
+                detail: "Meeting recording stopped before audio capture",
+                session: session
+            )
+        }
+        AppTelemetry.signal("meeting_recording_startup_stopped")
     }
 
     func cancelCurrentMeetingRecording() {

--- a/Muesli/DictationCoordinator.swift
+++ b/Muesli/DictationCoordinator.swift
@@ -710,6 +710,44 @@ final class DictationCoordinator {
         }
     }
 
+    @discardableResult
+    func deleteMeetingAudio(for session: RecordingSession) -> Bool {
+        do {
+            guard var storedSession = try? store.activeRecordingSession(id: session.id),
+                  storedSession.kind == .meeting,
+                  let audioFileName = storedSession.audioFileName
+            else {
+                clipboardStatusText = "Audio already removed"
+                clearClipboardStatusSoon()
+                return true
+            }
+
+            try store.deleteAudioFile(fileName: audioFileName)
+            storedSession.audioFileName = nil
+            storedSession.keepsAudioRecording = false
+            try store.saveSession(storedSession)
+
+            if activeSession?.id == storedSession.id {
+                activeSession = storedSession
+            }
+            if let index = recordingSessions.firstIndex(where: { $0.id == storedSession.id }) {
+                recordingSessions[index] = storedSession
+            } else {
+                refreshHistory()
+            }
+
+            clipboardStatusText = "Audio deleted"
+            AppTelemetry.signal("meeting_audio_deleted")
+            clearClipboardStatusSoon()
+            scheduleICloudSyncAfterLocalChange(reason: "meeting_audio_deleted")
+            return true
+        } catch {
+            clipboardStatusText = "Audio delete failed"
+            clearClipboardStatusSoon()
+            return false
+        }
+    }
+
     func updateMeetingTitle(sessionID: UUID, title: String) {
         do {
             guard var session = try store.activeRecordingSession(id: sessionID),
@@ -2182,7 +2220,7 @@ final class DictationCoordinator {
             ? "Untitled Meeting"
             : title.trimmingCharacters(in: .whitespacesAndNewlines)
         var session = RecordingSession(kind: .meeting, title: activeMeetingTitle)
-        session.keepsAudioRecording = true
+        session.keepsAudioRecording = MuesliPreferences.keepMeetingAudioRecordingsEnabled
         activeSession = session
         if !recordingSessions.contains(where: { $0.id == session.id }) {
             recordingSessions.insert(session, at: 0)
@@ -2375,7 +2413,7 @@ final class DictationCoordinator {
                 scheduleMeetingChunkTranscription(finalChunk, sessionID: session.id)
             }
             session.audioFileName = session.audioFileName ?? stoppedAudio?.retainedAudioURL?.lastPathComponent
-            session.keepsAudioRecording = true
+            session.keepsAudioRecording = MuesliPreferences.keepMeetingAudioRecordingsEnabled
             session.endedAt = .now
             session.phase = .transcribing
             try store.saveSession(session)
@@ -2513,6 +2551,7 @@ final class DictationCoordinator {
                 session.transcriptID = finalTranscript.transcript.id
                 session.engineIdentifier = engine.identifier
                 session.errorMessage = nil
+                cleanupNonRetainedAudio(for: &session)
                 guard try saveActiveMeetingSession(session) else {
                     meetingStatusText = "Ready"
                     cleanupMeetingChunks()
@@ -2544,6 +2583,7 @@ final class DictationCoordinator {
 
                 session.phase = .failed
                 session.errorMessage = error.localizedDescription
+                cleanupNonRetainedAudio(for: &session)
                 _ = try? saveActiveMeetingSession(session)
                 cleanupMeetingChunks()
                 meetingStatusText = error.localizedDescription
@@ -2568,7 +2608,6 @@ final class DictationCoordinator {
         var session = session
         session.phase = .transcribing
         session.errorMessage = nil
-        session.keepsAudioRecording = true
         try? store.saveSession(session)
         refreshHistory()
         isMeetingTranscribing = true
@@ -2603,6 +2642,7 @@ final class DictationCoordinator {
                     var failedSession = session
                     failedSession.phase = .failed
                     failedSession.errorMessage = message
+                    self.cleanupNonRetainedAudio(for: &failedSession)
                     try? self.store.saveSession(failedSession)
                     self.meetingStatusText = message
                     self.isMeetingTranscribing = false
@@ -2641,6 +2681,7 @@ final class DictationCoordinator {
                 session.transcriptID = finalTranscript.transcript.id
                 session.engineIdentifier = engine.identifier
                 session.errorMessage = nil
+                cleanupNonRetainedAudio(for: &session)
                 try store.saveSession(session)
                 scheduleICloudSyncAfterLocalChange(reason: "meeting_completed")
                 meetingStatusText = "Ready"
@@ -2659,6 +2700,7 @@ final class DictationCoordinator {
             } catch {
                 session.phase = .failed
                 session.errorMessage = error.localizedDescription
+                cleanupNonRetainedAudio(for: &session)
                 try? store.saveSession(session)
                 meetingStatusText = error.localizedDescription
                 refreshHistory()

--- a/Muesli/DictationCoordinator.swift
+++ b/Muesli/DictationCoordinator.swift
@@ -681,7 +681,8 @@ final class DictationCoordinator {
     @discardableResult
     func deleteDictationAudio(for result: DictationResult) -> Bool {
         do {
-            guard var session = recordingSession(for: result),
+            guard let sessionID = result.sessionID,
+                  var session = try store.activeRecordingSession(id: sessionID),
                   let audioFileName = session.audioFileName
             else {
                 clipboardStatusText = "Audio already removed"
@@ -792,7 +793,13 @@ final class DictationCoordinator {
 
     func updateMeetingManualNotes(sessionID: UUID, notes: String) {
         do {
-            try store.updateMeetingManualNotes(sessionID: sessionID, manualNotes: notes)
+            guard try store.updateMeetingManualNotes(sessionID: sessionID, manualNotes: notes) else {
+                clipboardStatusText = "Notes save failed"
+                clearClipboardStatusSoon()
+                refreshHistory()
+                return
+            }
+
             if activeSession?.id == sessionID {
                 activeSession?.manualNotes = notes
             }

--- a/Muesli/DictationCoordinator.swift
+++ b/Muesli/DictationCoordinator.swift
@@ -154,6 +154,13 @@ struct MeetingLifecycleState: Equatable {
         if case .cancelling = phase { true } else { false }
     }
 
+    func isStarting(sessionID: UUID) -> Bool {
+        if case .starting(let id) = phase {
+            return id == sessionID
+        }
+        return false
+    }
+
     var isRecordingVisible: Bool {
         switch phase {
         case .starting, .recording, .stopping:
@@ -2495,6 +2502,7 @@ final class DictationCoordinator {
             guard isCurrentMeetingLifecycle(sessionID: session.id) else { return }
             session.phase = .failed
             session.errorMessage = error.localizedDescription
+            cleanupNonRetainedAudio(for: &session)
             try? store.saveSession(session)
             activeSession = nil
             meetingStatusText = error.localizedDescription
@@ -2514,13 +2522,18 @@ final class DictationCoordinator {
         guard var session = activeSession ?? persistedRecordingMeetingSession,
               session.kind == .meeting
         else { return }
-        session.endedAt = .now
+
+        if meetingLifecycleState.isStarting(sessionID: session.id) {
+            stopMeetingStartup(session)
+            return
+        }
 
         guard session.audioFileName != nil else {
             stopMeetingStartup(session)
             return
         }
 
+        session.endedAt = .now
         isMeetingRecording = false
         isMeetingTranscribing = false
         meetingRecorder = nil

--- a/Muesli/DictationCoordinator.swift
+++ b/Muesli/DictationCoordinator.swift
@@ -192,7 +192,6 @@ enum MeetingLifecycleReducer {
             guard state.activeSessionID == id else { return state }
             return MeetingLifecycleState(phase: .stopping(id))
         case .transcriptionStarted(let id):
-            guard state.activeSessionID == nil || state.activeSessionID == id else { return state }
             return MeetingLifecycleState(phase: .transcribing(id))
         case .cancelRequested(let id):
             guard state.activeSessionID == nil || state.activeSessionID == id else { return state }
@@ -353,7 +352,11 @@ final class DictationCoordinator {
     var clipboardStatusText: String?
 
     var hasMeetingRecordingInProgress: Bool {
-        meetingLifecycleState.isRecordingVisible || isMeetingRecording || activeSession?.kind == .meeting || persistedRecordingMeetingSession != nil
+        meetingLifecycleState.isRecordingVisible
+            || isMeetingRecording
+            || isMeetingTranscribing
+            || activeSession?.kind == .meeting
+            || persistedRecordingMeetingSession != nil
     }
 
     var activeMeetingSessionID: UUID? {
@@ -854,7 +857,8 @@ final class DictationCoordinator {
         }
     }
 
-    func deleteMeeting(_ session: RecordingSession) {
+    @discardableResult
+    func deleteMeeting(_ session: RecordingSession) -> Bool {
         do {
             if let audioFileName = session.audioFileName {
                 try? store.deleteAudioFile(fileName: audioFileName)
@@ -867,9 +871,11 @@ final class DictationCoordinator {
             AppTelemetry.signal("meeting_deleted")
             clearClipboardStatusSoon()
             scheduleICloudSyncAfterLocalChange(reason: "meeting_deleted")
+            return true
         } catch {
             clipboardStatusText = "Delete failed"
             clearClipboardStatusSoon()
+            return false
         }
     }
 
@@ -2503,6 +2509,7 @@ final class DictationCoordinator {
             session.phase = .failed
             session.errorMessage = error.localizedDescription
             cleanupNonRetainedAudio(for: &session)
+            clearMissingRetainedAudioReference(for: &session)
             try? store.saveSession(session)
             activeSession = nil
             meetingStatusText = error.localizedDescription
@@ -3332,6 +3339,16 @@ final class DictationCoordinator {
         else { return }
 
         try? store.deleteAudioFile(fileName: audioFileName)
+        session.audioFileName = nil
+    }
+
+    private func clearMissingRetainedAudioReference(for session: inout RecordingSession) {
+        guard session.keepsAudioRecording,
+              let audioFileName = session.audioFileName,
+              let audioURL = try? store.audioFileURL(fileName: audioFileName),
+              !FileManager.default.fileExists(atPath: audioURL.path)
+        else { return }
+
         session.audioFileName = nil
     }
 

--- a/Muesli/DictationCoordinator.swift
+++ b/Muesli/DictationCoordinator.swift
@@ -266,6 +266,13 @@ final class DictationCoordinator {
         isMeetingRecording || activeSession?.kind == .meeting || persistedRecordingMeetingSession != nil
     }
 
+    var activeMeetingSessionID: UUID? {
+        if activeSession?.kind == .meeting {
+            return activeSession?.id
+        }
+        return persistedRecordingMeetingSession?.id
+    }
+
     var effectiveMeetingStatusText: String {
         if isMeetingRecording || persistedRecordingMeetingSession != nil {
             "Recording"

--- a/Muesli/DictationCoordinator.swift
+++ b/Muesli/DictationCoordinator.swift
@@ -129,6 +129,87 @@ private enum KeyboardSessionReducer {
     }
 }
 
+struct MeetingLifecycleState: Equatable {
+    enum Phase: Equatable {
+        case idle
+        case starting(UUID)
+        case recording(UUID)
+        case stopping(UUID)
+        case transcribing(UUID)
+        case cancelling(UUID)
+    }
+
+    var phase: Phase = .idle
+
+    var activeSessionID: UUID? {
+        switch phase {
+        case .idle:
+            nil
+        case .starting(let id), .recording(let id), .stopping(let id), .transcribing(let id), .cancelling(let id):
+            id
+        }
+    }
+
+    var isCancelling: Bool {
+        if case .cancelling = phase { true } else { false }
+    }
+
+    var isRecordingVisible: Bool {
+        switch phase {
+        case .starting, .recording, .stopping:
+            true
+        case .idle, .transcribing, .cancelling:
+            false
+        }
+    }
+}
+
+enum MeetingLifecycleEvent {
+    case startRequested(UUID)
+    case recordingStarted(UUID)
+    case stopRequested(UUID)
+    case transcriptionStarted(UUID)
+    case cancelRequested(UUID)
+    case finished(UUID)
+}
+
+enum MeetingLifecycleReducer {
+    static func reduce(_ state: MeetingLifecycleState, event: MeetingLifecycleEvent) -> MeetingLifecycleState {
+        switch event {
+        case .startRequested(let id):
+            return MeetingLifecycleState(phase: .starting(id))
+        case .recordingStarted(let id):
+            guard state.activeSessionID == id else { return state }
+            return MeetingLifecycleState(phase: .recording(id))
+        case .stopRequested(let id):
+            guard state.activeSessionID == id else { return state }
+            return MeetingLifecycleState(phase: .stopping(id))
+        case .transcriptionStarted(let id):
+            guard state.activeSessionID == nil || state.activeSessionID == id else { return state }
+            return MeetingLifecycleState(phase: .transcribing(id))
+        case .cancelRequested(let id):
+            guard state.activeSessionID == nil || state.activeSessionID == id else { return state }
+            return MeetingLifecycleState(phase: .cancelling(id))
+        case .finished(let id):
+            guard state.activeSessionID == id else { return state }
+            return MeetingLifecycleState()
+        }
+    }
+}
+
+struct MeetingLifecycleRunner {
+    let sessionID: UUID
+    var startupTask: Task<Void, Never>?
+    var finalizationTask: Task<Void, Never>?
+
+    mutating func cancelAll() {
+        startupTask?.cancel()
+        finalizationTask?.cancel()
+        startupTask = nil
+        finalizationTask = nil
+    }
+}
+
 @MainActor
 @Observable
 final class DictationCoordinator {
@@ -167,7 +248,8 @@ final class DictationCoordinator {
     private var meetingChunkTasks: [Task<MeetingChunkTranscription?, Never>] = []
     private var meetingChunkTranscriptions: [MeetingChunkTranscription] = []
     private var meetingChunksDirectory: URL?
-    private var discardedMeetingSessionIDs = Set<UUID>()
+    private var meetingLifecycleState = MeetingLifecycleState()
+    private var meetingLifecycleRunner: MeetingLifecycleRunner?
     private let meetingVadQueue = DispatchQueue(label: "com.phequals7.muesli.meeting-vad")
     private var transcriptionBackgroundTask: UIBackgroundTaskIdentifier = .invalid
     nonisolated(unsafe) private var audioRouteObserver: NSObjectProtocol?
@@ -264,7 +346,7 @@ final class DictationCoordinator {
     var clipboardStatusText: String?
 
     var hasMeetingRecordingInProgress: Bool {
-        isMeetingRecording || activeSession?.kind == .meeting || persistedRecordingMeetingSession != nil
+        meetingLifecycleState.isRecordingVisible || isMeetingRecording || activeSession?.kind == .meeting || persistedRecordingMeetingSession != nil
     }
 
     var activeMeetingSessionID: UUID? {
@@ -341,6 +423,61 @@ final class DictationCoordinator {
 
     private func transitionKeyboardSession(_ event: KeyboardSessionEvent) {
         keyboardSessionState = KeyboardSessionReducer.reduce(keyboardSessionState, event: event)
+    }
+
+    private func transitionMeetingLifecycle(_ event: MeetingLifecycleEvent) {
+        meetingLifecycleState = MeetingLifecycleReducer.reduce(meetingLifecycleState, event: event)
+    }
+
+    private func beginMeetingLifecycle(sessionID: UUID, event: MeetingLifecycleEvent) {
+        meetingLifecycleRunner?.cancelAll()
+        meetingLifecycleRunner = MeetingLifecycleRunner(sessionID: sessionID)
+        transitionMeetingLifecycle(event)
+    }
+
+    private func setMeetingStartupTask(_ task: Task<Void, Never>, sessionID: UUID) {
+        guard meetingLifecycleRunner?.sessionID == sessionID else {
+            task.cancel()
+            return
+        }
+        meetingLifecycleRunner?.startupTask = task
+    }
+
+    private func setMeetingFinalizationTask(_ task: Task<Void, Never>, sessionID: UUID) {
+        guard meetingLifecycleRunner?.sessionID == sessionID else {
+            task.cancel()
+            return
+        }
+        meetingLifecycleRunner?.finalizationTask = task
+    }
+
+    private func cancelMeetingLifecycle(sessionID: UUID) {
+        guard meetingLifecycleRunner?.sessionID == sessionID || meetingLifecycleState.activeSessionID == sessionID else {
+            return
+        }
+        meetingLifecycleRunner?.cancelAll()
+        transitionMeetingLifecycle(.cancelRequested(sessionID))
+    }
+
+    private func finishMeetingLifecycle(sessionID: UUID) {
+        guard meetingLifecycleRunner?.sessionID == sessionID || meetingLifecycleState.activeSessionID == sessionID else {
+            return
+        }
+        meetingLifecycleRunner = nil
+        transitionMeetingLifecycle(.finished(sessionID))
+    }
+
+    private func isCurrentMeetingLifecycle(sessionID: UUID) -> Bool {
+        meetingLifecycleState.activeSessionID == sessionID
+            && !meetingLifecycleState.isCancelling
+            && meetingLifecycleRunner?.sessionID == sessionID
+    }
+
+    private func ensureMeetingLifecycleActive(sessionID: UUID) throws {
+        try Task.checkCancellation()
+        guard isCurrentMeetingLifecycle(sessionID: sessionID) else {
+            throw CancellationError()
+        }
     }
 
     func handleOpenURL(_ url: URL) {
@@ -2253,108 +2390,119 @@ final class DictationCoordinator {
             recordingSessions.insert(session, at: 0)
         }
         meetingStatusText = "Preparing"
+        beginMeetingLifecycle(sessionID: session.id, event: .startRequested(session.id))
 
-        Task {
-            do {
-                guard !discardedMeetingSessionIDs.contains(session.id) else {
-                    abortDiscardedMeetingStartup(session)
-                    return
-                }
-
-                let audioURL = try store.newAudioFileURL(sessionID: session.id)
-                let chunksDirectory = try meetingChunkDirectory(for: session.id)
-                try? FileManager.default.removeItem(at: chunksDirectory)
-                session.audioFileName = audioURL.lastPathComponent
-                session.startedAt = .now
-                try store.saveSession(session)
-
-                guard !discardedMeetingSessionIDs.contains(session.id) else {
-                    abortDiscardedMeetingStartup(session)
-                    return
-                }
-
-                try await recorder.requestPermission()
-
-                guard !discardedMeetingSessionIDs.contains(session.id) else {
-                    abortDiscardedMeetingStartup(session)
-                    return
-                }
-
-                if keyboardSessionKeeper.isRunning {
-                    keyboardSessionKeeper.stop(deactivateSession: true)
-                    transitionKeyboardSession(.requestFinished)
-                    try? store.clearKeyboardRuntimeStatus()
-                    try? await Task.sleep(for: .milliseconds(150))
-                }
-
-                let vadManager = try await VadManager()
-                let vadController = StreamingVadController(vadManager: vadManager)
-                let streamingRecorder = StreamingMeetingRecorder()
-                vadController.onChunkBoundary = { [weak self] in
-                    Task { @MainActor [weak self] in
-                        self?.rotateActiveMeetingChunk()
-                    }
-                }
-                streamingRecorder.onAudioSamples = { [vadController, meetingVadQueue] samples in
-                    meetingVadQueue.async {
-                        vadController.processAudio(samples)
-                    }
-                }
-
-                try streamingRecorder.start(
-                    chunksDirectory: chunksDirectory,
-                    retainedAudioURL: audioURL,
-                    routeStage: "meeting recording"
-                )
-                refreshAudioInputRoute()
-                vadController.start()
-
-                guard !discardedMeetingSessionIDs.contains(session.id) else {
-                    vadController.stop()
-                    streamingRecorder.cancel()
-                    abortDiscardedMeetingStartup(session)
-                    return
-                }
-
-                meetingRecorder = streamingRecorder
-                meetingVadController = vadController
-                meetingChunksDirectory = chunksDirectory
-                meetingChunkTasks.removeAll(keepingCapacity: true)
-                meetingChunkTranscriptions.removeAll(keepingCapacity: true)
-                activeSession = session
-                isMeetingRecording = true
-                meetingStatusText = "Recording"
-                startMeetingMetering()
-                prewarmModelIfNeeded(reason: "meeting_recording")
-                refreshHistory()
-                AppTelemetry.signal("meeting_recording_started")
-                Task {
-                    await liveActivityController.start(
-                        session: session,
-                        requestID: nil,
-                        phase: "Recording",
-                        detail: "Meeting recording active"
-                    )
-                }
-            } catch {
-                guard !discardedMeetingSessionIDs.contains(session.id) else {
-                    cleanupMeetingChunks()
-                    meetingStatusText = "Ready"
-                    refreshHistory()
-                    return
-                }
-
-                session.phase = .failed
-                session.errorMessage = error.localizedDescription
-                try? store.saveSession(session)
-                activeSession = nil
-                meetingStatusText = error.localizedDescription
-                stopMetering()
-                refreshHistory()
-                AppTelemetry.signal("meeting_recording_failed", parameters: ["stage": "recording"])
-            }
+        let task = Task { @MainActor [weak self] in
+            guard let self else { return }
+            await self.runMeetingStartup(session)
         }
+        setMeetingStartupTask(task, sessionID: session.id)
         return session.id
+    }
+
+    private func runMeetingStartup(_ initialSession: RecordingSession) async {
+        var session = initialSession
+
+        do {
+            try ensureMeetingLifecycleActive(sessionID: session.id)
+
+            let audioURL = try store.newAudioFileURL(sessionID: session.id)
+            let chunksDirectory = try meetingChunkDirectory(for: session.id)
+            try? FileManager.default.removeItem(at: chunksDirectory)
+            session.audioFileName = audioURL.lastPathComponent
+            session.startedAt = .now
+            try store.saveSession(session)
+            activeSession = session
+            if let index = recordingSessions.firstIndex(where: { $0.id == session.id }) {
+                recordingSessions[index] = session
+            }
+
+            try ensureMeetingLifecycleActive(sessionID: session.id)
+
+            try await recorder.requestPermission()
+
+            try ensureMeetingLifecycleActive(sessionID: session.id)
+
+            if keyboardSessionKeeper.isRunning {
+                keyboardSessionKeeper.stop(deactivateSession: true)
+                transitionKeyboardSession(.requestFinished)
+                try? store.clearKeyboardRuntimeStatus()
+                try? await Task.sleep(for: .milliseconds(150))
+            }
+
+            try ensureMeetingLifecycleActive(sessionID: session.id)
+
+            let vadManager = try await VadManager()
+
+            try ensureMeetingLifecycleActive(sessionID: session.id)
+
+            let vadController = StreamingVadController(vadManager: vadManager)
+            let streamingRecorder = StreamingMeetingRecorder()
+            vadController.onChunkBoundary = { [weak self] in
+                Task { @MainActor [weak self] in
+                    self?.rotateActiveMeetingChunk()
+                }
+            }
+            streamingRecorder.onAudioSamples = { [vadController, meetingVadQueue] samples in
+                meetingVadQueue.async {
+                    vadController.processAudio(samples)
+                }
+            }
+
+            try ensureMeetingLifecycleActive(sessionID: session.id)
+
+            try streamingRecorder.start(
+                chunksDirectory: chunksDirectory,
+                retainedAudioURL: audioURL,
+                routeStage: "meeting recording"
+            )
+            do {
+                try ensureMeetingLifecycleActive(sessionID: session.id)
+            } catch {
+                vadController.stop()
+                streamingRecorder.cancel()
+                throw error
+            }
+
+            refreshAudioInputRoute()
+            vadController.start()
+
+            meetingRecorder = streamingRecorder
+            meetingVadController = vadController
+            meetingChunksDirectory = chunksDirectory
+            meetingChunkTasks.removeAll(keepingCapacity: true)
+            meetingChunkTranscriptions.removeAll(keepingCapacity: true)
+            activeSession = session
+            isMeetingRecording = true
+            meetingStatusText = "Recording"
+            transitionMeetingLifecycle(.recordingStarted(session.id))
+            startMeetingMetering()
+            prewarmModelIfNeeded(reason: "meeting_recording")
+            refreshHistory()
+            AppTelemetry.signal("meeting_recording_started")
+            Task {
+                await liveActivityController.start(
+                    session: session,
+                    requestID: nil,
+                    phase: "Recording",
+                    detail: "Meeting recording active"
+                )
+            }
+        } catch is CancellationError {
+            guard isCurrentMeetingLifecycle(sessionID: session.id) else { return }
+            abortCancelledMeeting(session)
+        } catch {
+            guard isCurrentMeetingLifecycle(sessionID: session.id) else { return }
+            session.phase = .failed
+            session.errorMessage = error.localizedDescription
+            try? store.saveSession(session)
+            activeSession = nil
+            meetingStatusText = error.localizedDescription
+            stopMetering()
+            finishMeetingLifecycle(sessionID: session.id)
+            refreshHistory()
+            AppTelemetry.signal("meeting_recording_failed", parameters: ["stage": "recording"])
+        }
     }
 
     func stopCurrentMeetingRecording() {
@@ -2389,8 +2537,8 @@ final class DictationCoordinator {
 
     private func stopMeetingStartup(_ session: RecordingSession) {
         MuesliHaptics.dictationStop()
-        discardedMeetingSessionIDs.insert(session.id)
-        abortDiscardedMeetingStartup(session)
+        cancelMeetingLifecycle(sessionID: session.id)
+        abortCancelledMeeting(session)
         Task {
             await liveActivityController.end(
                 phase: "Stopped",
@@ -2404,6 +2552,7 @@ final class DictationCoordinator {
     func cancelCurrentMeetingRecording() {
         guard isMeetingRecording || meetingRecorder != nil || activeSession?.kind == .meeting || persistedRecordingMeetingSession != nil else { return }
         guard let session = activeSession ?? persistedRecordingMeetingSession, session.kind == .meeting else { return }
+        let latestSession = (try? store.recordingSession(id: session.id)) ?? session
 
         MuesliHaptics.dictationStop()
         isMeetingRecording = false
@@ -2416,22 +2565,23 @@ final class DictationCoordinator {
         meetingRecorder = nil
         meetingVadController = nil
         activeSession = nil
-        discardedMeetingSessionIDs.insert(session.id)
+        cancelMeetingLifecycle(sessionID: latestSession.id)
         cleanupMeetingChunks(cancelTasks: true)
 
-        if let audioFileName = session.audioFileName {
+        if let audioFileName = latestSession.audioFileName {
             try? store.deleteAudioFile(fileName: audioFileName)
         }
-        try? store.deleteTranscript(for: session.id)
-        removeCachedTranscript(for: session.id)
-        try? store.deleteRecordingSession(id: session.id)
-        recordingSessions.removeAll { $0.id == session.id }
+        try? store.deleteTranscript(for: latestSession.id)
+        removeCachedTranscript(for: latestSession.id)
+        try? store.deleteRecordingSession(id: latestSession.id)
+        recordingSessions.removeAll { $0.id == latestSession.id }
+        finishMeetingLifecycle(sessionID: latestSession.id)
         refreshHistory()
         Task {
             await liveActivityController.end(
                 phase: "Discarded",
                 detail: "Meeting recording discarded",
-                session: session
+                session: latestSession
             )
         }
         AppTelemetry.signal("meeting_recording_discarded")
@@ -2441,6 +2591,7 @@ final class DictationCoordinator {
         guard isMeetingRecording || meetingRecorder != nil else { return }
         guard var session = activeSession ?? persistedRecordingMeetingSession, session.kind == .meeting else { return }
         MuesliHaptics.dictationStop()
+        transitionMeetingLifecycle(.stopRequested(session.id))
         isMeetingRecording = false
         isMeetingTranscribing = true
         stopMetering()
@@ -2460,6 +2611,7 @@ final class DictationCoordinator {
             session.phase = .transcribing
             try store.saveSession(session)
             activeSession = nil
+            transitionMeetingLifecycle(.transcriptionStarted(session.id))
             refreshHistory()
             Task {
                 await liveActivityController.update(
@@ -2480,6 +2632,7 @@ final class DictationCoordinator {
             activeSession = nil
             isMeetingTranscribing = false
             meetingStatusText = error.localizedDescription
+            finishMeetingLifecycle(sessionID: session.id)
             refreshHistory()
             AppTelemetry.signal("meeting_recording_failed", parameters: ["stage": "stop"])
         }
@@ -2519,7 +2672,7 @@ final class DictationCoordinator {
         let merged = MeetingChunkTranscriptMerger.merge(meetingChunkTranscriptions)
         let text = postProcessTranscript(merged.text)
         guard !text.isEmpty else { return }
-        guard !discardedMeetingSessionIDs.contains(sessionID),
+        guard isCurrentMeetingLifecycle(sessionID: sessionID),
               var session = try? store.activeRecordingSession(id: sessionID),
               session.kind == .meeting,
               session.phase != .cancelled
@@ -2548,7 +2701,8 @@ final class DictationCoordinator {
 
     private func finalizeStreamingMeeting(_ session: RecordingSession) {
         beginTranscriptionBackgroundTask()
-        Task {
+        let task = Task { @MainActor [weak self] in
+            guard let self else { return }
             defer {
                 endTranscriptionBackgroundTask()
                 isMeetingTranscribing = false
@@ -2556,6 +2710,7 @@ final class DictationCoordinator {
 
             var session = session
             do {
+                try ensureMeetingLifecycleActive(sessionID: session.id)
                 meetingStatusText = "Transcribing"
                 for task in meetingChunkTasks {
                     if let transcription = await task.value,
@@ -2564,11 +2719,7 @@ final class DictationCoordinator {
                     }
                 }
                 meetingChunkTasks.removeAll(keepingCapacity: false)
-                guard shouldContinueMeetingFinalization(sessionID: session.id) else {
-                    meetingStatusText = "Ready"
-                    cleanupMeetingChunks()
-                    return
-                }
+                try ensureMeetingLifecycleActive(sessionID: session.id)
 
                 let mergedTranscription = MeetingChunkTranscriptMerger.merge(meetingChunkTranscriptions)
                 let text = postProcessTranscript(mergedTranscription.text)
@@ -2586,13 +2737,7 @@ final class DictationCoordinator {
                     ),
                     audioURL: audioURL
                 )
-                guard shouldContinueMeetingFinalization(sessionID: session.id) else {
-                    try? store.deleteTranscript(for: session.id)
-                    removeCachedTranscript(for: session.id)
-                    meetingStatusText = "Ready"
-                    cleanupMeetingChunks()
-                    return
-                }
+                try ensureMeetingLifecycleActive(sessionID: session.id)
 
                 session.phase = .completed
                 session.title = finalTranscript.resolvedTitle
@@ -2621,8 +2766,16 @@ final class DictationCoordinator {
                     "summarized": finalTranscript.transcript.summaryState == .completed ? "true" : "false",
                     "chunked": "true"
                 ])
+                finishMeetingLifecycle(sessionID: session.id)
+            } catch is CancellationError {
+                if isCurrentMeetingLifecycle(sessionID: session.id) {
+                    finishMeetingLifecycle(sessionID: session.id)
+                }
+                cleanupMeetingChunks()
+                meetingStatusText = "Ready"
+                refreshHistory()
             } catch {
-                guard shouldContinueMeetingFinalization(sessionID: session.id) else {
+                guard isCurrentMeetingLifecycle(sessionID: session.id) else {
                     cleanupMeetingChunks()
                     meetingStatusText = "Ready"
                     refreshHistory()
@@ -2646,8 +2799,10 @@ final class DictationCoordinator {
                     "error": String(describing: type(of: error)),
                     "chunked": "true"
                 ])
+                finishMeetingLifecycle(sessionID: session.id)
             }
         }
+        setMeetingFinalizationTask(task, sessionID: session.id)
     }
 
     func transcribeSession(_ session: RecordingSession) {
@@ -2658,6 +2813,7 @@ final class DictationCoordinator {
         session.errorMessage = nil
         try? store.saveSession(session)
         refreshHistory()
+        beginMeetingLifecycle(sessionID: session.id, event: .transcriptionStarted(session.id))
         isMeetingTranscribing = true
         meetingStatusText = "Transcribing"
         Task {
@@ -2670,13 +2826,15 @@ final class DictationCoordinator {
         }
 
         beginTranscriptionBackgroundTask()
-        Task {
+        let task = Task { @MainActor [weak self] in
+            guard let self else { return }
             defer {
                 endTranscriptionBackgroundTask()
                 isMeetingTranscribing = false
             }
 
             do {
+                try ensureMeetingLifecycleActive(sessionID: session.id)
                 let audioURL = try store.audioFileURL(fileName: audioFileName)
                 let outcome = try await runOfflineTranscriptionJob(
                     audioURL: audioURL,
@@ -2706,10 +2864,12 @@ final class DictationCoordinator {
                         "meeting_transcription_failed",
                         parameters: ["engine": self.engine.identifier, "error": "timeout"]
                     )
+                    self.finishMeetingLifecycle(sessionID: session.id)
                 } operation: { [engine] progress in
                     try await engine.transcribeDetailed(audioURL: audioURL, progress: progress)
                 }
                 guard case .completed(let detailedTranscription) = outcome else { return }
+                try ensureMeetingLifecycleActive(sessionID: session.id)
                 let text = postProcessTranscript(detailedTranscription.text)
                 if let latestSession = try? store.recordingSession(id: session.id) {
                     session.manualNotes = latestSession.manualNotes
@@ -2724,13 +2884,14 @@ final class DictationCoordinator {
                     ),
                     audioURL: audioURL
                 )
+                try ensureMeetingLifecycleActive(sessionID: session.id)
                 session.phase = .completed
                 session.title = finalTranscript.resolvedTitle
                 session.transcriptID = finalTranscript.transcript.id
                 session.engineIdentifier = engine.identifier
                 session.errorMessage = nil
                 cleanupNonRetainedAudio(for: &session)
-                try store.saveSession(session)
+                guard try saveActiveMeetingSession(session) else { return }
                 scheduleICloudSyncAfterLocalChange(reason: "meeting_completed")
                 meetingStatusText = "Ready"
                 refreshHistory()
@@ -2745,7 +2906,15 @@ final class DictationCoordinator {
                     "diarized": finalTranscript.transcript.diarizationState == .completed ? "true" : "false",
                     "summarized": finalTranscript.transcript.summaryState == .completed ? "true" : "false"
                 ])
+                finishMeetingLifecycle(sessionID: session.id)
+            } catch is CancellationError {
+                if isCurrentMeetingLifecycle(sessionID: session.id) {
+                    finishMeetingLifecycle(sessionID: session.id)
+                }
+                meetingStatusText = "Ready"
+                refreshHistory()
             } catch {
+                guard isCurrentMeetingLifecycle(sessionID: session.id) else { return }
                 session.phase = .failed
                 session.errorMessage = error.localizedDescription
                 cleanupNonRetainedAudio(for: &session)
@@ -2761,8 +2930,10 @@ final class DictationCoordinator {
                     "engine": engine.identifier,
                     "error": String(describing: type(of: error))
                 ])
+                finishMeetingLifecycle(sessionID: session.id)
             }
         }
+        setMeetingFinalizationTask(task, sessionID: session.id)
     }
 
     private struct FinalizedMeetingTranscript {
@@ -2781,15 +2952,19 @@ final class DictationCoordinator {
         var diarizationErrorMessage: String?
 
         if let audioURL {
+            try ensureMeetingLifecycleActive(sessionID: session.id)
             meetingStatusText = "Diarizing"
             do {
                 let diarizationSegments = try await engine.diarize(audioURL: audioURL)
+                try ensureMeetingLifecycleActive(sessionID: session.id)
                 speakerTranscript = MeetingTranscriptFormatter.speakerTranscript(
                     transcription: detailedTranscription,
                     diarizationSegments: diarizationSegments,
                     meetingStart: session.startedAt ?? session.createdAt
                 )
                 diarizationState = .completed
+            } catch is CancellationError {
+                throw CancellationError()
             } catch {
                 speakerTranscript = nil
                 diarizationState = .failed
@@ -2798,6 +2973,7 @@ final class DictationCoordinator {
                     "error": String(describing: type(of: error))
                 ])
             }
+            try ensureMeetingLifecycleActive(sessionID: session.id)
         }
 
         var summaryText: String?
@@ -2808,6 +2984,7 @@ final class DictationCoordinator {
         var resolvedTitle = session.title
 
         if MuesliPreferences.meetingSummariesEnabled {
+            try ensureMeetingLifecycleActive(sessionID: session.id)
             meetingStatusText = "Summarizing"
             let summarySource = speakerTranscript?.isEmpty == false ? speakerTranscript! : text
             do {
@@ -2816,6 +2993,7 @@ final class DictationCoordinator {
                     meetingTitle: session.title ?? session.kind.title,
                     manualNotesToRetain: session.manualNotes
                 )
+                try ensureMeetingLifecycleActive(sessionID: session.id)
                 summaryText = summary.notes
                 summaryState = .completed
                 summaryBackend = summary.backend.rawValue
@@ -2823,6 +3001,8 @@ final class DictationCoordinator {
                 if !summary.title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
                     resolvedTitle = summary.title
                 }
+            } catch is CancellationError {
+                throw CancellationError()
             } catch {
                 summaryText = MeetingSummaryClient.failureNotes(
                     transcript: summarySource,
@@ -2841,6 +3021,7 @@ final class DictationCoordinator {
                     "error": String(describing: type(of: error))
                 ])
             }
+            try ensureMeetingLifecycleActive(sessionID: session.id)
         }
 
         let transcript = Transcript(
@@ -2856,6 +3037,7 @@ final class DictationCoordinator {
             summaryModel: summaryModel,
             summaryErrorMessage: summaryErrorMessage
         )
+        try ensureMeetingLifecycleActive(sessionID: session.id)
         try store.saveTranscript(transcript)
         cacheTranscript(transcript)
         return FinalizedMeetingTranscript(transcript: transcript, resolvedTitle: resolvedTitle)
@@ -2881,7 +3063,8 @@ final class DictationCoordinator {
         meetingChunkTranscriptions.removeAll(keepingCapacity: false)
     }
 
-    private func abortDiscardedMeetingStartup(_ session: RecordingSession) {
+    private func abortCancelledMeeting(_ session: RecordingSession) {
+        let session = (try? store.recordingSession(id: session.id)) ?? session
         cleanupMeetingChunks(cancelTasks: true)
         if let audioFileName = session.audioFileName {
             try? store.deleteAudioFile(fileName: audioFileName)
@@ -2895,6 +3078,7 @@ final class DictationCoordinator {
         isMeetingRecording = false
         isMeetingTranscribing = false
         meetingStatusText = "Ready"
+        finishMeetingLifecycle(sessionID: session.id)
         refreshHistory()
     }
 
@@ -2906,7 +3090,7 @@ final class DictationCoordinator {
     }
 
     private func shouldContinueMeetingFinalization(sessionID: UUID) -> Bool {
-        guard !discardedMeetingSessionIDs.contains(sessionID),
+        guard isCurrentMeetingLifecycle(sessionID: sessionID),
               (try? store.activeRecordingSession(id: sessionID)) != nil
         else { return false }
         return true

--- a/Muesli/DictationCoordinator.swift
+++ b/Muesli/DictationCoordinator.swift
@@ -727,6 +727,25 @@ final class DictationCoordinator {
         }
     }
 
+    func updateMeetingManualNotes(sessionID: UUID, notes: String) {
+        do {
+            try store.updateMeetingManualNotes(sessionID: sessionID, manualNotes: notes)
+            if activeSession?.id == sessionID {
+                activeSession?.manualNotes = notes
+            }
+            if let index = recordingSessions.firstIndex(where: { $0.id == sessionID }) {
+                recordingSessions[index].manualNotes = notes
+            } else {
+                refreshHistory()
+            }
+            scheduleICloudSyncAfterLocalChange(reason: "meeting_manual_notes_updated")
+            AppTelemetry.signal("meeting_manual_notes_updated")
+        } catch {
+            clipboardStatusText = "Notes save failed"
+            clearClipboardStatusSoon()
+        }
+    }
+
     func copyTranscript(_ transcript: Transcript) {
         UIPasteboard.general.string = transcript.text
         clipboardStatusText = "Copied"
@@ -2143,8 +2162,9 @@ final class DictationCoordinator {
         }
     }
 
-    func startMeetingRecording(title: String = "Untitled Meeting") {
-        guard !isRecording, !isMeetingRecording, !isMeetingTranscribing, activeSession?.kind != .meeting, statusText != "Transcribing" else { return }
+    @discardableResult
+    func startMeetingRecording(title: String = "Untitled Meeting") -> UUID? {
+        guard !isRecording, !isMeetingRecording, !isMeetingTranscribing, activeSession?.kind != .meeting, statusText != "Transcribing" else { return nil }
         MuesliHaptics.dictationStart()
         activeMeetingTitle = title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
             ? "Untitled Meeting"
@@ -2152,6 +2172,9 @@ final class DictationCoordinator {
         var session = RecordingSession(kind: .meeting, title: activeMeetingTitle)
         session.keepsAudioRecording = true
         activeSession = session
+        if !recordingSessions.contains(where: { $0.id == session.id }) {
+            recordingSessions.insert(session, at: 0)
+        }
         meetingStatusText = "Preparing"
 
         Task {
@@ -2240,6 +2263,7 @@ final class DictationCoordinator {
                 AppTelemetry.signal("meeting_recording_failed", parameters: ["stage": "recording"])
             }
         }
+        return session.id
     }
 
     func stopCurrentMeetingRecording() {
@@ -2436,6 +2460,9 @@ final class DictationCoordinator {
 
                 let mergedTranscription = MeetingChunkTranscriptMerger.merge(meetingChunkTranscriptions)
                 let text = postProcessTranscript(mergedTranscription.text)
+                if let latestSession = try? store.recordingSession(id: session.id) {
+                    session.manualNotes = latestSession.manualNotes
+                }
                 let audioURL = try session.audioFileName.map { try store.audioFileURL(fileName: $0) }
                 let finalTranscript = try await finalizeMeetingTranscript(
                     session: session,
@@ -2569,6 +2596,9 @@ final class DictationCoordinator {
                 }
                 guard case .completed(let detailedTranscription) = outcome else { return }
                 let text = postProcessTranscript(detailedTranscription.text)
+                if let latestSession = try? store.recordingSession(id: session.id) {
+                    session.manualNotes = latestSession.manualNotes
+                }
                 let finalTranscript = try await finalizeMeetingTranscript(
                     session: session,
                     text: text,
@@ -2666,7 +2696,8 @@ final class DictationCoordinator {
             do {
                 let summary = try await MeetingSummaryClient.summarize(
                     transcript: summarySource,
-                    meetingTitle: session.title ?? session.kind.title
+                    meetingTitle: session.title ?? session.kind.title,
+                    manualNotesToRetain: session.manualNotes
                 )
                 summaryText = summary.notes
                 summaryState = .completed
@@ -2679,7 +2710,8 @@ final class DictationCoordinator {
                 summaryText = MeetingSummaryClient.failureNotes(
                     transcript: summarySource,
                     meetingTitle: session.title ?? session.kind.title,
-                    error: error
+                    error: error,
+                    manualNotes: session.manualNotes
                 )
                 summaryState = .failed
                 summaryBackend = MuesliPreferences.meetingSummaryBackend.rawValue

--- a/Muesli/DictationCoordinator.swift
+++ b/Muesli/DictationCoordinator.swift
@@ -192,7 +192,7 @@ final class DictationCoordinator {
     private var canStartKeyboardRequestsInBackground: Bool {
         isKeyboardHotMicEngineReady
             && !isRecording
-            && !isMeetingRecording
+            && !hasMeetingRecordingInProgress
             && activeRequest == nil
             && statusText != "Transcribing"
     }
@@ -943,7 +943,7 @@ final class DictationCoordinator {
     func startKeyboardSessionMode() async {
         guard !isKeyboardSessionArmed else {
             prewarmModelIfNeeded(reason: "keyboard_session")
-            if !isRecording, !isMeetingRecording, activeRequest == nil {
+            if !isRecording, !hasMeetingRecordingInProgress, activeRequest == nil {
                 _ = await ensureKeyboardSessionKeeperRunning(publishReady: true)
             }
             let isReady = canStartKeyboardRequestsInBackground
@@ -1206,7 +1206,7 @@ final class DictationCoordinator {
         guard hasCompletedOnboarding else { return }
         guard modelPrewarmTask == nil else { return }
         guard modelPreparationTask == nil, !modelPreparation.isPreparing else { return }
-        guard !isRecording, !isMeetingRecording else { return }
+        guard !isRecording, !hasMeetingRecordingInProgress else { return }
 
         let model = selectedTranscriptionModel
         modelPreparation = ModelPreparationState(
@@ -1546,7 +1546,7 @@ final class DictationCoordinator {
     }
 
     private func startRecording(for request: DictationRequest, source: String) {
-        guard !isRecording, !isMeetingRecording, statusText != "Transcribing" else {
+        guard !isRecording, !hasMeetingRecordingInProgress, statusText != "Transcribing" else {
             if source == "keyboard" {
                 if refreshActiveKeyboardRequestIfNeeded(request) {
                     return
@@ -2164,7 +2164,12 @@ final class DictationCoordinator {
 
     @discardableResult
     func startMeetingRecording(title: String = "Untitled Meeting") -> UUID? {
-        guard !isRecording, !isMeetingRecording, !isMeetingTranscribing, activeSession?.kind != .meeting, statusText != "Transcribing" else { return nil }
+        guard !isRecording,
+              !hasMeetingRecordingInProgress,
+              !isMeetingTranscribing,
+              activeRequest == nil,
+              statusText != "Transcribing"
+        else { return nil }
         MuesliHaptics.dictationStart()
         activeMeetingTitle = title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
             ? "Untitled Meeting"
@@ -2201,6 +2206,13 @@ final class DictationCoordinator {
                 guard !discardedMeetingSessionIDs.contains(session.id) else {
                     abortDiscardedMeetingStartup(session)
                     return
+                }
+
+                if keyboardSessionKeeper.isRunning {
+                    keyboardSessionKeeper.stop(deactivateSession: true)
+                    transitionKeyboardSession(.requestFinished)
+                    try? store.clearKeyboardRuntimeStatus()
+                    try? await Task.sleep(for: .milliseconds(150))
                 }
 
                 let vadManager = try await VadManager()
@@ -2272,7 +2284,9 @@ final class DictationCoordinator {
             return
         }
 
-        guard var session = persistedRecordingMeetingSession else { return }
+        guard var session = activeSession ?? persistedRecordingMeetingSession,
+              session.kind == .meeting
+        else { return }
         session.endedAt = .now
 
         guard session.audioFileName != nil else {
@@ -2287,6 +2301,12 @@ final class DictationCoordinator {
             return
         }
 
+        isMeetingRecording = false
+        isMeetingTranscribing = false
+        meetingRecorder = nil
+        meetingVadController = nil
+        activeSession = nil
+        stopMetering()
         session.phase = .transcriptionQueued
         session.errorMessage = nil
         try? store.saveSession(session)
@@ -2536,7 +2556,7 @@ final class DictationCoordinator {
     }
 
     func transcribeSession(_ session: RecordingSession) {
-        guard !isRecording, !isMeetingRecording, !isMeetingTranscribing else { return }
+        guard !isRecording, !hasMeetingRecordingInProgress, !isMeetingTranscribing else { return }
         guard let audioFileName = session.audioFileName else { return }
         var session = session
         session.phase = .transcribing
@@ -3121,7 +3141,7 @@ final class DictationCoordinator {
         if isKeyboardSessionArmed,
            !keyboardSessionKeeper.isRunning,
            !isRecording,
-           !isMeetingRecording,
+           !hasMeetingRecordingInProgress,
            activeRequest == nil
         {
             _ = await ensureKeyboardSessionKeeperRunning(publishReady: false)
@@ -3160,7 +3180,7 @@ final class DictationCoordinator {
             return
         }
 
-        guard !isRecording, !isMeetingRecording, statusText != "Transcribing" else {
+        guard !isRecording, !hasMeetingRecordingInProgress, statusText != "Transcribing" else {
             saveKeyboardHandoff(
                 requestID: command.requestID,
                 phase: .failed,
@@ -3223,12 +3243,12 @@ final class DictationCoordinator {
     private func ensureKeyboardSessionKeeperRunning(publishReady: Bool = true) async -> Bool {
         guard MuesliPreferences.keyboardSessionModeEnabled, isKeyboardSessionArmed else { return false }
         if keyboardSessionKeeper.canAcceptStartCommand {
-            if publishReady, !isRecording, !isMeetingRecording, activeRequest == nil {
+            if publishReady, !isRecording, !hasMeetingRecordingInProgress, activeRequest == nil {
                 publishKeyboardSessionReadyIfAvailable()
             }
             return true
         }
-        guard !isRecording, !isMeetingRecording else { return false }
+        guard !isRecording, !hasMeetingRecordingInProgress else { return false }
         if keyboardSessionKeeper.isRunning {
             let becameReady = await keyboardSessionKeeper.waitUntilCanAcceptStartCommand(timeout: 0.75)
             if becameReady {
@@ -3399,7 +3419,7 @@ final class DictationCoordinator {
 
             guard !self.keyboardSessionState.isWorkflowActive,
                   !self.isRecording,
-                  !self.isMeetingRecording,
+                  !self.hasMeetingRecordingInProgress,
                   self.activeRequest == nil
             else {
                 self.scheduleKeyboardSessionRetry(attempt: retryAttempt)
@@ -3411,7 +3431,11 @@ final class DictationCoordinator {
     }
 
     private func resumeKeyboardSessionKeeperIfNeeded() {
-        guard MuesliPreferences.keyboardSessionModeEnabled, isKeyboardSessionArmed, !isRecording, !isMeetingRecording else { return }
+        guard MuesliPreferences.keyboardSessionModeEnabled,
+              isKeyboardSessionArmed,
+              !isRecording,
+              !hasMeetingRecordingInProgress
+        else { return }
         Task { @MainActor [weak self] in
             guard let self else { return }
             await self.ensureKeyboardSessionKeeperRunning()

--- a/Muesli/DictationView.swift
+++ b/Muesli/DictationView.swift
@@ -1039,7 +1039,7 @@ private struct VoiceNoteRecordButtonLabel: View {
     }
 }
 
-private struct ICloudSyncStatusButton: View {
+struct ICloudSyncStatusButton: View {
     let isEnabled: Bool
     let isSyncing: Bool
     let hasError: Bool

--- a/Muesli/DictationView.swift
+++ b/Muesli/DictationView.swift
@@ -1142,7 +1142,7 @@ private enum DictationSourceFilter: String, CaseIterable, Identifiable {
         }
     }
 
-    func includes(_ origin: DictationSyncOrigin) -> Bool {
+    func includes(_ origin: SyncOrigin) -> Bool {
         switch self {
         case .all:
             true
@@ -1165,10 +1165,7 @@ private enum DictationSourceFilter: String, CaseIterable, Identifiable {
     }
 }
 
-private enum DictationSyncOrigin: Equatable {
-    case thisIPhone
-    case fromMac
-
+private extension SyncOrigin {
     var title: String {
         switch self {
         case .thisIPhone:
@@ -1207,52 +1204,14 @@ private enum DictationSyncOrigin: Equatable {
 }
 
 private extension RecordingSession {
-    var syncOrigin: DictationSyncOrigin {
-        let normalizedSource = source.normalizedSyncOriginSource
-        if let normalizedSource, normalizedSource == "ios" {
-            return .thisIPhone
-        }
-
-        if normalizedSource != nil {
-            return .fromMac
-        }
-
-        if engineIdentifier?.lowercased() == "icloud" {
-            return .fromMac
-        }
-
-        return .thisIPhone
+    var syncOrigin: SyncOrigin {
+        SyncOrigin.classify(source: source, engineIdentifier: engineIdentifier)
     }
 }
 
 private extension DictationResult {
-    var syncOrigin: DictationSyncOrigin {
-        let normalizedSource = source.normalizedSyncOriginSource
-        if let normalizedSource, normalizedSource == "ios" {
-            return .thisIPhone
-        }
-
-        if normalizedSource != nil {
-            return .fromMac
-        }
-
-        // Older synced rows were stored before source was persisted and used
-        // the fallback engine label. Treat those as Mac-origin cloud imports.
-        if engineIdentifier.lowercased() == "icloud" {
-            return .fromMac
-        }
-
-        return .thisIPhone
-    }
-}
-
-private extension Optional where Wrapped == String {
-    var normalizedSyncOriginSource: String? {
-        guard let source = self?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased(),
-              !source.isEmpty else {
-            return nil
-        }
-        return source
+    var syncOrigin: SyncOrigin {
+        SyncOrigin.classify(source: source, engineIdentifier: engineIdentifier)
     }
 }
 
@@ -1372,7 +1331,7 @@ private struct DictationHistoryRow: View {
         .frame(maxWidth: .infinity, alignment: .leading)
     }
 
-    private var origin: DictationSyncOrigin {
+    private var origin: SyncOrigin {
         result.syncOrigin
     }
 
@@ -1599,7 +1558,7 @@ private struct AudioFileDocument: FileDocument {
 }
 
 private struct DictationOriginChip: View {
-    let origin: DictationSyncOrigin
+    let origin: SyncOrigin
 
     var body: some View {
         Label {

--- a/Muesli/DictationView.swift
+++ b/Muesli/DictationView.swift
@@ -1203,18 +1203,6 @@ private extension SyncOrigin {
     }
 }
 
-private extension RecordingSession {
-    var syncOrigin: SyncOrigin {
-        SyncOrigin.classify(source: source, engineIdentifier: engineIdentifier)
-    }
-}
-
-private extension DictationResult {
-    var syncOrigin: SyncOrigin {
-        SyncOrigin.classify(source: source, engineIdentifier: engineIdentifier)
-    }
-}
-
 private struct DictationSourceFilterPicker: View {
     @Binding var selection: DictationSourceFilter
 

--- a/Muesli/ICloudTextSyncEngine.swift
+++ b/Muesli/ICloudTextSyncEngine.swift
@@ -568,6 +568,7 @@ final class ICloudTextSyncEngine {
         cloud["speakerTranscript"] = record.speakerTranscript as NSString?
         cloud["summaryText"] = record.summaryText as NSString?
         cloud["manualNotes"] = record.manualNotes as NSString?
+        cloud["manualNotesUpdatedAt"] = record.manualNotesUpdatedAt as NSDate?
         cloud["source"] = record.source as NSString?
         cloud["localSource"] = record.localSource as NSString?
         cloud["engineIdentifier"] = record.engineIdentifier as NSString?
@@ -602,6 +603,7 @@ final class ICloudTextSyncEngine {
             engineIdentifier: record["engineIdentifier"] as? String,
             createdAt: createdAt,
             updatedAt: updatedAt,
+            manualNotesUpdatedAt: record["manualNotesUpdatedAt"] as? Date,
             startedAt: record["startedAt"] as? Date,
             endedAt: record["endedAt"] as? Date,
             durationSeconds: (record["durationSeconds"] as? NSNumber)?.doubleValue ?? 0,
@@ -650,6 +652,7 @@ final class ICloudTextSyncEngine {
             "speakerTranscript",
             "summaryText",
             "manualNotes",
+            "manualNotesUpdatedAt",
             "source",
             "engineIdentifier",
             "createdAt",

--- a/Muesli/ICloudTextSyncEngine.swift
+++ b/Muesli/ICloudTextSyncEngine.swift
@@ -569,6 +569,7 @@ final class ICloudTextSyncEngine {
         cloud["summaryText"] = record.summaryText as NSString?
         cloud["manualNotes"] = record.manualNotes as NSString?
         cloud["source"] = record.source as NSString?
+        cloud["localSource"] = record.localSource as NSString?
         cloud["engineIdentifier"] = record.engineIdentifier as NSString?
         cloud["createdAt"] = record.createdAt as NSDate
         cloud["updatedAt"] = record.updatedAt as NSDate
@@ -597,6 +598,7 @@ final class ICloudTextSyncEngine {
             summaryText: record["summaryText"] as? String,
             manualNotes: record["manualNotes"] as? String,
             source: record["source"] as? String,
+            localSource: record["localSource"] as? String,
             engineIdentifier: record["engineIdentifier"] as? String,
             createdAt: createdAt,
             updatedAt: updatedAt,

--- a/Muesli/MeetingSummaryClient.swift
+++ b/Muesli/MeetingSummaryClient.swift
@@ -52,7 +52,11 @@ enum MeetingSummaryClient {
         }
     }
 
-    static func summarize(transcript: String, meetingTitle: String) async throws -> MeetingSummaryResult {
+    static func summarize(
+        transcript: String,
+        meetingTitle: String,
+        manualNotesToRetain: String? = nil
+    ) async throws -> MeetingSummaryResult {
         let backend = MuesliPreferences.meetingSummaryBackend
         switch backend {
         case .openRouter:
@@ -60,6 +64,7 @@ enum MeetingSummaryClient {
             let notes = try await summarizeWithOpenRouter(
                 transcript: transcript,
                 meetingTitle: meetingTitle,
+                manualNotesToRetain: manualNotesToRetain,
                 model: model
             )
             let title = await generateTitleWithOpenRouter(transcript: transcript, model: model) ?? meetingTitle
@@ -69,6 +74,7 @@ enum MeetingSummaryClient {
             let notes = try await summarizeWithChatGPT(
                 transcript: transcript,
                 meetingTitle: meetingTitle,
+                manualNotesToRetain: manualNotesToRetain,
                 model: model
             )
             let title = await generateTitleWithChatGPT(transcript: transcript, model: model) ?? meetingTitle
@@ -76,8 +82,20 @@ enum MeetingSummaryClient {
         }
     }
 
-    static func failureNotes(transcript: String, meetingTitle: String, error: Error) -> String {
+    static func failureNotes(
+        transcript: String,
+        meetingTitle: String,
+        error: Error,
+        manualNotes: String? = nil
+    ) -> String {
+        let trimmedManualNotes = manualNotes?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let writtenNotesSection = trimmedManualNotes.isEmpty ? "" : """
+
+        ## Written Notes
+
+        \(trimmedManualNotes)
         """
+        return """
         ## Summary failed
 
         Meeting: \(meetingTitle)
@@ -85,6 +103,7 @@ enum MeetingSummaryClient {
         Muesli could not generate structured meeting notes.
 
         \(error.localizedDescription)
+        \(writtenNotesSection)
 
         ## Raw Transcript
 
@@ -95,6 +114,7 @@ enum MeetingSummaryClient {
     private static func summarizeWithOpenRouter(
         transcript: String,
         meetingTitle: String,
+        manualNotesToRetain: String?,
         model: String
     ) async throws -> String {
         let apiKey = storedOpenRouterAPIKey()
@@ -107,7 +127,11 @@ enum MeetingSummaryClient {
             apiKey: apiKey,
             model: model,
             systemPrompt: baseSummaryInstructions,
-            userPrompt: summaryPrompt(transcript: transcript, meetingTitle: meetingTitle),
+            userPrompt: summaryPrompt(
+                transcript: transcript,
+                meetingTitle: meetingTitle,
+                manualNotesToRetain: manualNotesToRetain
+            ),
             maxTokens: maxOutputTokens,
             extraHeaders: ["X-OpenRouter-Title": "Muesli"]
         )
@@ -116,12 +140,17 @@ enum MeetingSummaryClient {
     private static func summarizeWithChatGPT(
         transcript: String,
         meetingTitle: String,
+        manualNotesToRetain: String?,
         model: String
     ) async throws -> String {
         do {
             let text = try await callWHAM(
                 systemPrompt: baseSummaryInstructions,
-                userPrompt: summaryPrompt(transcript: transcript, meetingTitle: meetingTitle),
+                userPrompt: summaryPrompt(
+                    transcript: transcript,
+                    meetingTitle: meetingTitle,
+                    manualNotesToRetain: manualNotesToRetain
+                ),
                 model: model
             )
             guard !text.isEmpty else {
@@ -136,8 +165,18 @@ enum MeetingSummaryClient {
         }
     }
 
-    private static func summaryPrompt(transcript: String, meetingTitle: String) -> String {
+    private static func summaryPrompt(
+        transcript: String,
+        meetingTitle: String,
+        manualNotesToRetain: String?
+    ) -> String {
         let template = MuesliPreferences.meetingTemplate
+        let trimmedManualNotes = manualNotesToRetain?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let manualNotesSection = trimmedManualNotes.isEmpty ? "" : """
+
+        User-written notes to retain:
+        \(trimmedManualNotes)
+        """
         return """
         Meeting title: \(meetingTitle)
 
@@ -145,6 +184,7 @@ enum MeetingSummaryClient {
 
         Template guidance:
         \(template.instructions)
+        \(manualNotesSection)
 
         Raw transcript:
         \(transcript)

--- a/Muesli/MeetingSummaryClient.swift
+++ b/Muesli/MeetingSummaryClient.swift
@@ -88,13 +88,11 @@ enum MeetingSummaryClient {
         error: Error,
         manualNotes: String? = nil
     ) -> String {
-        let trimmedManualNotes = manualNotes?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        let writtenNotesSection = trimmedManualNotes.isEmpty ? "" : """
-
-        ## Written Notes
-
-        \(trimmedManualNotes)
-        """
+        let writtenNotesSection = optionalNotesSection(
+            header: "## Written Notes",
+            notes: manualNotes,
+            separatesHeaderAndBody: true
+        )
         return """
         ## Summary failed
 
@@ -171,12 +169,10 @@ enum MeetingSummaryClient {
         manualNotesToRetain: String?
     ) -> String {
         let template = MuesliPreferences.meetingTemplate
-        let trimmedManualNotes = manualNotesToRetain?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        let manualNotesSection = trimmedManualNotes.isEmpty ? "" : """
-
-        User-written notes to retain:
-        \(trimmedManualNotes)
-        """
+        let manualNotesSection = optionalNotesSection(
+            header: "User-written notes to retain:",
+            notes: manualNotesToRetain
+        )
         return """
         Meeting title: \(meetingTitle)
 
@@ -188,6 +184,20 @@ enum MeetingSummaryClient {
 
         Raw transcript:
         \(transcript)
+        """
+    }
+
+    private static func optionalNotesSection(
+        header: String,
+        notes: String?,
+        separatesHeaderAndBody: Bool = false
+    ) -> String {
+        let trimmedNotes = notes?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        guard !trimmedNotes.isEmpty else { return "" }
+        let separator = separatesHeaderAndBody ? "\n\n" : "\n"
+        return """
+
+        \(header)\(separator)\(trimmedNotes)
         """
     }
 

--- a/Muesli/MeetingsView.swift
+++ b/Muesli/MeetingsView.swift
@@ -106,6 +106,9 @@ struct MeetingsView: View {
                         onDelete: {
                             coordinator.deleteMeeting(session)
                         },
+                        onDeleteAudio: {
+                            coordinator.deleteMeetingAudio(for: session)
+                        },
                         onRename: { title in
                             coordinator.updateMeetingTitle(sessionID: session.id, title: title)
                         },
@@ -785,6 +788,7 @@ private struct MeetingSessionDetailView: View {
     let onDiscardRecording: () -> Void
     let onCopy: (String, MeetingContentTab) -> Void
     let onDelete: () -> Void
+    let onDeleteAudio: () -> Void
     let onRename: (String) -> Void
     let onManualNotesChange: (String) -> Void
     @Environment(\.dismiss) private var dismiss
@@ -958,17 +962,21 @@ private struct MeetingSessionDetailView: View {
                         Spacer()
 
                         if isActiveRecording {
-                            Button(action: onStopRecording) {
-                                Image(systemName: "stop.fill")
-                                    .font(.system(size: 14, weight: .bold))
-                                    .foregroundStyle(.white)
-                                    .frame(width: 42, height: 42)
-                                    .background(MuesliTheme.destructive.opacity(0.86))
+                            Button(role: .destructive, action: onDiscardRecording) {
+                                Image(systemName: "trash")
+                                    .font(.system(size: 15, weight: .semibold))
+                                    .foregroundStyle(MuesliTheme.destructive)
+                                    .frame(width: 38, height: 38)
+                                    .background(MuesliTheme.destructive.opacity(0.10))
                                     .clipShape(Circle())
+                                    .overlay(
+                                        Circle()
+                                            .strokeBorder(MuesliTheme.destructive.opacity(0.26), lineWidth: 1)
+                                    )
                             }
                             .buttonStyle(.plain)
-                            .accessibilityLabel("Stop meeting")
-                            .accessibilityIdentifier("meetingDetail.stopButton")
+                            .accessibilityLabel("Discard meeting")
+                            .accessibilityIdentifier("meetingDetail.discardButton")
                         }
                     }
 
@@ -991,22 +999,18 @@ private struct MeetingSessionDetailView: View {
                     )
 
                     if isActiveRecording {
-                        Button(role: .destructive, action: onDiscardRecording) {
-                            Label("Discard Meeting", systemImage: "trash")
+                        Button(action: onStopRecording) {
+                            Label("Stop Meeting", systemImage: "stop.fill")
                                 .font(MuesliTheme.headline())
-                                .foregroundStyle(MuesliTheme.destructive)
+                                .foregroundStyle(.white)
                                 .frame(maxWidth: .infinity)
-                                .frame(height: 44)
-                                .background(MuesliTheme.destructive.opacity(0.06))
-                                .overlay(
-                                    RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall)
-                                        .strokeBorder(MuesliTheme.destructive.opacity(0.32), lineWidth: 1)
-                                )
+                                .frame(height: 48)
+                                .background(MuesliTheme.destructive.opacity(0.88))
                                 .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
                                 .contentShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
                         }
                         .buttonStyle(.plain)
-                        .accessibilityIdentifier("meetingDetail.discardButton")
+                        .accessibilityIdentifier("meetingDetail.stopButton")
                     }
                 }
                 .padding(MuesliTheme.spacing16)
@@ -1139,20 +1143,34 @@ private struct MeetingSessionDetailView: View {
 
                     SavedAudioPlayerView(audioURL: audioURL)
 
-                    Button {
-                        sharePayload = MeetingSharePayload(items: [audioURL])
-                        AppTelemetry.signal("meeting_audio_shared")
-                    } label: {
-                        Label("Export Audio to Files", systemImage: "square.and.arrow.up")
-                            .font(MuesliTheme.headline())
-                            .frame(maxWidth: .infinity)
-                            .frame(height: 44)
-                            .foregroundStyle(MuesliTheme.accent)
-                            .background(MuesliTheme.accentSubtle)
-                            .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
-                            .contentShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+                    HStack(spacing: MuesliTheme.spacing8) {
+                        Button {
+                            sharePayload = MeetingSharePayload(items: [audioURL])
+                            AppTelemetry.signal("meeting_audio_shared")
+                        } label: {
+                            Label("Export Audio", systemImage: "square.and.arrow.up")
+                                .font(MuesliTheme.headline())
+                                .frame(maxWidth: .infinity)
+                                .frame(height: 44)
+                                .foregroundStyle(MuesliTheme.accent)
+                                .background(MuesliTheme.accentSubtle)
+                                .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+                                .contentShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+                        }
+                        .buttonStyle(.plain)
+
+                        Button(role: .destructive, action: onDeleteAudio) {
+                            Image(systemName: "trash")
+                                .font(.system(size: 16, weight: .semibold))
+                                .foregroundStyle(MuesliTheme.destructive)
+                                .frame(width: 48, height: 44)
+                                .background(MuesliTheme.destructive.opacity(0.08))
+                                .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+                                .contentShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+                        }
+                        .buttonStyle(.plain)
+                        .accessibilityLabel("Delete meeting audio")
                     }
-                    .buttonStyle(.plain)
                 }
                 .padding(MuesliTheme.spacing16)
             }
@@ -2231,6 +2249,6 @@ private extension RecordingSessionPhase {
 
 private extension RecordingSession {
     var hasRetainedAudio: Bool {
-        kind == .meeting && audioFileName != nil
+        kind == .meeting && keepsAudioRecording && audioFileName != nil
     }
 }

--- a/Muesli/MeetingsView.swift
+++ b/Muesli/MeetingsView.swift
@@ -7,10 +7,45 @@ struct MeetingsView: View {
     var isActive = true
     @State private var meetingTitle = ""
     @State private var sessionPendingDelete: RecordingSession?
+    @State private var navigationPath: [UUID] = []
+    @State private var searchText = ""
+    @State private var selectedFilter: MeetingBrowserFilter = .all
+    @State private var selectedSort: MeetingSortOrder = .newest
     @AppStorage(MuesliPreferences.meetingTemplateKey) private var selectedMeetingTemplate = MeetingTemplatePreset.general.rawValue
 
     private var meetingSessions: [RecordingSession] {
-        coordinator.recordingSessions.filter { $0.kind == .meeting }
+        coordinator.recordingSessions
+            .filter { $0.kind == .meeting }
+            .sorted { lhs, rhs in
+                switch selectedSort {
+                case .newest:
+                    lhs.createdAt > rhs.createdAt
+                case .oldest:
+                    lhs.createdAt < rhs.createdAt
+                }
+            }
+    }
+
+    private var filteredMeetingSessions: [RecordingSession] {
+        let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return meetingSessions.filter { session in
+            guard selectedFilter.includes(session) else { return false }
+            guard !query.isEmpty else { return true }
+            let transcript = coordinator.transcript(for: session)
+            let haystack = [
+                session.title ?? "",
+                session.phase.title,
+                session.sourceDisplayName,
+                session.manualNotes ?? "",
+                transcript?.summaryText ?? "",
+                transcript?.speakerTranscript ?? "",
+                transcript?.text ?? "",
+                session.errorMessage ?? ""
+            ]
+            .joined(separator: " ")
+            .lowercased()
+            return haystack.contains(query)
+        }
     }
 
     private var meetingTemplate: MeetingTemplatePreset {
@@ -18,7 +53,7 @@ struct MeetingsView: View {
     }
 
     var body: some View {
-        NavigationStack {
+        NavigationStack(path: $navigationPath) {
             ScrollView {
                 VStack(alignment: .leading, spacing: MuesliTheme.spacing20) {
                     header
@@ -56,6 +91,9 @@ struct MeetingsView: View {
                         },
                         onRename: { title in
                             coordinator.updateMeetingTitle(sessionID: session.id, title: title)
+                        },
+                        onManualNotesChange: { notes in
+                            coordinator.updateMeetingManualNotes(sessionID: session.id, notes: notes)
                         }
                     )
                 } else {
@@ -157,7 +195,10 @@ struct MeetingsView: View {
                         if coordinator.hasMeetingRecordingInProgress {
                             coordinator.stopCurrentMeetingRecording()
                         } else {
-                            coordinator.startMeetingRecording(title: meetingTitle)
+                            if let sessionID = coordinator.startMeetingRecording(title: meetingTitle) {
+                                navigationPath.append(sessionID)
+                                meetingTitle = ""
+                            }
                         }
                     } label: {
                         Label(
@@ -271,11 +312,15 @@ struct MeetingsView: View {
                 }
             }
 
+            browserControls
+
             if meetingSessions.isEmpty {
                 emptyState
+            } else if filteredMeetingSessions.isEmpty {
+                emptySearchState
             } else {
                 LazyVStack(spacing: MuesliTheme.spacing12) {
-                    ForEach(meetingSessions) { session in
+                    ForEach(filteredMeetingSessions) { session in
                         MuesliSwipeActionRow(
                             leadingAction: .init(
                                 title: "Delete",
@@ -310,6 +355,74 @@ struct MeetingsView: View {
         }
     }
 
+    private var browserControls: some View {
+        VStack(spacing: MuesliTheme.spacing12) {
+            HStack(spacing: MuesliTheme.spacing8) {
+                Image(systemName: "magnifyingglass")
+                    .font(.system(size: 15, weight: .semibold))
+                    .foregroundStyle(MuesliTheme.textTertiary)
+                TextField("Search meetings", text: $searchText)
+                    .font(MuesliTheme.body())
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled()
+                    .foregroundStyle(MuesliTheme.textPrimary)
+                if !searchText.isEmpty {
+                    Button {
+                        searchText = ""
+                    } label: {
+                        Image(systemName: "xmark.circle.fill")
+                            .font(.system(size: 16, weight: .semibold))
+                            .foregroundStyle(MuesliTheme.textTertiary)
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("Clear meeting search")
+                }
+            }
+            .padding(.horizontal, MuesliTheme.spacing12)
+            .frame(height: 42)
+            .muesliGlassSurface(cornerRadius: MuesliTheme.cornerMedium)
+
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: MuesliTheme.spacing8) {
+                    ForEach(MeetingBrowserFilter.allCases) { filter in
+                        Button {
+                            selectedFilter = filter
+                        } label: {
+                            Label(filter.label, systemImage: filter.systemImage)
+                                .font(MuesliTheme.captionMedium())
+                                .foregroundStyle(selectedFilter == filter ? MuesliTheme.backgroundBase : MuesliTheme.textSecondary)
+                                .padding(.horizontal, MuesliTheme.spacing12)
+                                .frame(height: 34)
+                                .background(selectedFilter == filter ? MuesliTheme.accent : MuesliTheme.surfacePrimary)
+                                .clipShape(Capsule())
+                        }
+                        .buttonStyle(.plain)
+                    }
+
+                    Menu {
+                        ForEach(MeetingSortOrder.allCases) { sort in
+                            Button {
+                                selectedSort = sort
+                            } label: {
+                                Label(sort.label, systemImage: selectedSort == sort ? "checkmark" : sort.systemImage)
+                            }
+                        }
+                    } label: {
+                        Label(selectedSort.label, systemImage: "arrow.up.arrow.down")
+                            .font(MuesliTheme.captionMedium())
+                            .foregroundStyle(MuesliTheme.textSecondary)
+                            .padding(.horizontal, MuesliTheme.spacing12)
+                            .frame(height: 34)
+                            .background(MuesliTheme.surfacePrimary)
+                            .clipShape(Capsule())
+                    }
+                    .buttonStyle(.plain)
+                }
+                .padding(.vertical, 2)
+            }
+        }
+    }
+
     private func refreshVisibleStateIfNeeded() {
         guard isActive else { return }
         coordinator.refreshHistory()
@@ -330,6 +443,24 @@ struct MeetingsView: View {
                     .font(MuesliTheme.body())
                     .foregroundStyle(MuesliTheme.textSecondary)
                     .fixedSize(horizontal: false, vertical: true)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(MuesliTheme.spacing16)
+        }
+    }
+
+    private var emptySearchState: some View {
+        MuesliSurface {
+            VStack(alignment: .leading, spacing: MuesliTheme.spacing12) {
+                Image(systemName: "line.3.horizontal.decrease.circle")
+                    .font(.system(size: 22, weight: .semibold))
+                    .foregroundStyle(MuesliTheme.textTertiary)
+                Text("No matches")
+                    .font(MuesliTheme.headline())
+                    .foregroundStyle(MuesliTheme.textPrimary)
+                Text("Adjust the search or filter to find another meeting.")
+                    .font(MuesliTheme.body())
+                    .foregroundStyle(MuesliTheme.textSecondary)
             }
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(MuesliTheme.spacing16)
@@ -368,6 +499,9 @@ struct MeetingsView: View {
         if let summary = transcript.summaryText?.trimmingCharacters(in: .whitespacesAndNewlines), !summary.isEmpty {
             return summary
         }
+        if let manualNotes = session.manualNotes?.trimmingCharacters(in: .whitespacesAndNewlines), !manualNotes.isEmpty {
+            return manualNotes
+        }
         if let speakerTranscript = transcript.speakerTranscript?.trimmingCharacters(in: .whitespacesAndNewlines), !speakerTranscript.isEmpty {
             return speakerTranscript
         }
@@ -375,6 +509,86 @@ struct MeetingsView: View {
             return transcript.text
         }
         return session.errorMessage ?? session.phase.description
+    }
+}
+
+private enum MeetingBrowserFilter: String, CaseIterable, Identifiable {
+    case all
+    case thisIPhone
+    case fromMac
+    case processing
+    case needsAttention
+
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .all:
+            "All"
+        case .thisIPhone:
+            "This iPhone"
+        case .fromMac:
+            "From Mac"
+        case .processing:
+            "Processing"
+        case .needsAttention:
+            "Needs Review"
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .all:
+            "tray.full"
+        case .thisIPhone:
+            "iphone"
+        case .fromMac:
+            "desktopcomputer"
+        case .processing:
+            "waveform.badge.magnifyingglass"
+        case .needsAttention:
+            "exclamationmark.triangle"
+        }
+    }
+
+    func includes(_ session: RecordingSession) -> Bool {
+        switch self {
+        case .all:
+            true
+        case .thisIPhone:
+            session.isFromThisIPhone
+        case .fromMac:
+            session.isFromMac
+        case .processing:
+            session.phase == .recording || session.phase == .transcriptionQueued || session.phase == .transcribing
+        case .needsAttention:
+            session.phase == .failed || session.phase == .cancelled
+        }
+    }
+}
+
+private enum MeetingSortOrder: String, CaseIterable, Identifiable {
+    case newest
+    case oldest
+
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .newest:
+            "Newest"
+        case .oldest:
+            "Oldest"
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .newest:
+            "arrow.down"
+        case .oldest:
+            "arrow.up"
+        }
     }
 }
 
@@ -396,6 +610,9 @@ private struct MeetingSessionRow: View {
                         Text(session.phase.title)
                             .font(MuesliTheme.caption())
                             .foregroundStyle(session.phase.tint)
+                        Label(session.sourceDisplayName, systemImage: session.sourceSystemImage)
+                            .font(MuesliTheme.caption())
+                            .foregroundStyle(MuesliTheme.textTertiary)
                         if session.hasRetainedAudio {
                             Label("Audio saved", systemImage: "waveform.path.ecg.rectangle")
                                 .font(MuesliTheme.caption())
@@ -430,6 +647,9 @@ private struct MeetingSessionRow: View {
         if let summary = transcript?.summaryText?.trimmingCharacters(in: .whitespacesAndNewlines), !summary.isEmpty {
             return summary.replacingOccurrences(of: "\n", with: " ")
         }
+        if let manualNotes = session.manualNotes?.trimmingCharacters(in: .whitespacesAndNewlines), !manualNotes.isEmpty {
+            return manualNotes.replacingOccurrences(of: "\n", with: " ")
+        }
         if let speakerTranscript = transcript?.speakerTranscript?.trimmingCharacters(in: .whitespacesAndNewlines), !speakerTranscript.isEmpty {
             return speakerTranscript.replacingOccurrences(of: "\n", with: " ")
         }
@@ -462,6 +682,7 @@ private struct MeetingSessionDetailView: View {
     let onCopy: (String, MeetingContentTab) -> Void
     let onDelete: () -> Void
     let onRename: (String) -> Void
+    let onManualNotesChange: (String) -> Void
     @Environment(\.dismiss) private var dismiss
     @State private var selectedContent: MeetingContentTab = .notes
     @State private var sharePayload: MeetingSharePayload?
@@ -469,11 +690,15 @@ private struct MeetingSessionDetailView: View {
     @State private var editedTitle: String?
     @State private var titleDraft = ""
     @State private var isEditingTitle = false
+    @State private var manualNotesDraft = ""
+    @State private var manualNotesSaveState: ManualNotesSaveState = .saved
+    @State private var manualNotesSaveTask: Task<Void, Never>?
 
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: MuesliTheme.spacing20) {
                 detailHeader
+                manualNotesSection
                 retainedAudioSection
                 detailActions
                 contentSection
@@ -511,6 +736,17 @@ private struct MeetingSessionDetailView: View {
             Button("Cancel", role: .cancel) {}
         } message: {
             Text("This removes the meeting, transcript, notes, and any retained audio from local history.")
+        }
+        .onAppear {
+            manualNotesDraft = session.manualNotes ?? ""
+        }
+        .onChange(of: session.manualNotes ?? "") { _, newValue in
+            guard manualNotesSaveState != .saving else { return }
+            manualNotesDraft = newValue
+        }
+        .onDisappear {
+            manualNotesSaveTask?.cancel()
+            persistManualNotesIfChanged()
         }
     }
 
@@ -572,6 +808,41 @@ private struct MeetingSessionDetailView: View {
                         detailBadge("Notes", systemImage: "sparkles")
                     }
                 }
+            }
+            .padding(MuesliTheme.spacing16)
+        }
+    }
+
+    @ViewBuilder
+    private var manualNotesSection: some View {
+        MuesliSurface(cornerRadius: MuesliTheme.cornerLarge, tint: MuesliTheme.accent) {
+            VStack(alignment: .leading, spacing: MuesliTheme.spacing12) {
+                HStack(alignment: .firstTextBaseline) {
+                    Label("Live Notes", systemImage: "square.and.pencil")
+                        .font(MuesliTheme.title3())
+                        .foregroundStyle(MuesliTheme.textPrimary)
+                    Spacer()
+                    Text(manualNotesSaveState.label)
+                        .font(MuesliTheme.captionMedium())
+                        .foregroundStyle(manualNotesSaveState.tint)
+                }
+
+                TextEditor(text: $manualNotesDraft)
+                    .font(MuesliTheme.body())
+                    .foregroundStyle(MuesliTheme.textPrimary)
+                    .scrollContentBackground(.hidden)
+                    .frame(minHeight: session.phase == .recording ? 220 : 140)
+                    .padding(MuesliTheme.spacing8)
+                    .background(MuesliTheme.surfacePrimary)
+                    .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall, style: .continuous))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall, style: .continuous)
+                            .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
+                    )
+                    .accessibilityLabel("Meeting live notes")
+                    .onChange(of: manualNotesDraft) { _, _ in
+                        scheduleManualNotesSave()
+                    }
             }
             .padding(MuesliTheme.spacing16)
         }
@@ -755,6 +1026,28 @@ private struct MeetingSessionDetailView: View {
         AppTelemetry.signal("meeting_\(kind.telemetryName)_shared")
     }
 
+    private func scheduleManualNotesSave() {
+        guard manualNotesDraft != (session.manualNotes ?? "") else {
+            manualNotesSaveState = .saved
+            return
+        }
+        manualNotesSaveState = .saving
+        manualNotesSaveTask?.cancel()
+        let draft = manualNotesDraft
+        manualNotesSaveTask = Task { @MainActor in
+            try? await Task.sleep(nanoseconds: 650_000_000)
+            guard !Task.isCancelled else { return }
+            onManualNotesChange(draft)
+            manualNotesSaveState = .saved
+        }
+    }
+
+    private func persistManualNotesIfChanged() {
+        guard manualNotesDraft != (session.manualNotes ?? "") else { return }
+        onManualNotesChange(manualNotesDraft)
+        manualNotesSaveState = .saved
+    }
+
     private var displayTitle: String {
         resolvedTitle(editedTitle ?? session.title ?? session.kind.title)
     }
@@ -875,6 +1168,29 @@ private struct MeetingShareSheet: UIViewControllerRepresentable {
     func updateUIViewController(_ uiViewController: UIActivityViewController, context: Context) {}
 }
 
+private enum ManualNotesSaveState {
+    case saved
+    case saving
+
+    var label: String {
+        switch self {
+        case .saved:
+            "Saved"
+        case .saving:
+            "Saving"
+        }
+    }
+
+    var tint: Color {
+        switch self {
+        case .saved:
+            MuesliTheme.success
+        case .saving:
+            MuesliTheme.textTertiary
+        }
+    }
+}
+
 private enum MeetingExportFormatter {
     static func text(
         for kind: MeetingShareKind,
@@ -893,12 +1209,30 @@ private enum MeetingExportFormatter {
     }
 
     private static func notes(session: RecordingSession, transcript: Transcript, titleOverride: String?) -> String {
-        """
+        let generatedNotes = transcript.summaryText?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let writtenNotes = session.manualNotes?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let body: String
+        if !generatedNotes.isEmpty, !writtenNotes.isEmpty {
+            body = """
+            \(generatedNotes)
+
+            ## Written Notes
+            \(writtenNotes)
+            """
+        } else if !generatedNotes.isEmpty {
+            body = generatedNotes
+        } else if !writtenNotes.isEmpty {
+            body = writtenNotes
+        } else {
+            body = "No meeting notes available."
+        }
+
+        return """
         # \(titleOverride ?? title(for: session))
 
         \(dateString(for: session))
 
-        \(transcript.summaryText?.trimmingCharacters(in: .whitespacesAndNewlines) ?? "No meeting notes available.")
+        \(body)
         """
     }
 
@@ -917,6 +1251,7 @@ private enum MeetingExportFormatter {
 
     private static func fullMeeting(session: RecordingSession, transcript: Transcript, titleOverride: String?) -> String {
         let notes = transcript.summaryText?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let manualNotes = session.manualNotes?.trimmingCharacters(in: .whitespacesAndNewlines)
         let speakers = transcript.speakerTranscript?.trimmingCharacters(in: .whitespacesAndNewlines)
         return """
         # \(titleOverride ?? title(for: session))
@@ -925,6 +1260,9 @@ private enum MeetingExportFormatter {
 
         ## Notes
         \(notes?.isEmpty == false ? notes! : "None available.")
+
+        ## Written Notes
+        \(manualNotes?.isEmpty == false ? manualNotes! : "None available.")
 
         ## Speaker Transcript
         \(speakers?.isEmpty == false ? speakers! : "None available.")
@@ -944,6 +1282,28 @@ private enum MeetingExportFormatter {
         formatter.dateStyle = .medium
         formatter.timeStyle = .short
         return "Recorded \(formatter.string(from: session.createdAt))"
+    }
+}
+
+private extension RecordingSession {
+    var normalizedSource: String {
+        source?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() ?? ""
+    }
+
+    var isFromMac: Bool {
+        normalizedSource.contains("mac")
+    }
+
+    var isFromThisIPhone: Bool {
+        !isFromMac
+    }
+
+    var sourceDisplayName: String {
+        isFromMac ? "From Mac" : "This iPhone"
+    }
+
+    var sourceSystemImage: String {
+        isFromMac ? "desktopcomputer" : "iphone"
     }
 }
 

--- a/Muesli/MeetingsView.swift
+++ b/Muesli/MeetingsView.swift
@@ -52,6 +52,22 @@ struct MeetingsView: View {
         MeetingTemplatePreset(rawValue: selectedMeetingTemplate) ?? .general
     }
 
+    private var meetingsWithNotesCount: Int {
+        meetingSessions.filter { session in
+            let transcript = coordinator.transcript(for: session)
+            return session.manualNotes?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
+                || transcript?.summaryText?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
+        }.count
+    }
+
+    private var browserResultSummary: String {
+        guard !meetingSessions.isEmpty else { return "No saved meetings" }
+        if filteredMeetingSessions.count == meetingSessions.count {
+            return "\(meetingSessions.count) saved"
+        }
+        return "\(filteredMeetingSessions.count) of \(meetingSessions.count)"
+    }
+
     var body: some View {
         NavigationStack(path: $navigationPath) {
             ScrollView {
@@ -123,14 +139,46 @@ struct MeetingsView: View {
     }
 
     private var header: some View {
-        VStack(alignment: .leading, spacing: MuesliTheme.spacing4) {
-            Text("Meetings")
-                .font(MuesliTheme.title1())
-                .foregroundStyle(MuesliTheme.textPrimary)
-            Text("Record offline conversations and turn them into local notes.")
-                .font(MuesliTheme.callout())
-                .foregroundStyle(MuesliTheme.textSecondary)
-                .fixedSize(horizontal: false, vertical: true)
+        VStack(alignment: .leading, spacing: MuesliTheme.spacing16) {
+            VStack(alignment: .leading, spacing: MuesliTheme.spacing8) {
+                Text("MEETINGS")
+                    .font(MuesliTheme.captionMedium())
+                    .tracking(1.4)
+                    .foregroundStyle(MuesliTheme.textTertiary)
+
+                Text("Record, write, review")
+                    .font(.system(.largeTitle, design: .default, weight: .bold))
+                    .tracking(-0.7)
+                    .foregroundStyle(MuesliTheme.textPrimary)
+                    .lineLimit(2)
+                    .minimumScaleFactor(0.82)
+
+                Text("Local-first meeting capture with notes that sync across Muesli.")
+                    .font(MuesliTheme.callout())
+                    .foregroundStyle(MuesliTheme.textSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            HStack(spacing: MuesliTheme.spacing8) {
+                MeetingHeaderMetric(
+                    value: "\(meetingSessions.count)",
+                    label: "Saved",
+                    systemImage: "tray.full",
+                    tint: MuesliTheme.accent
+                )
+                MeetingHeaderMetric(
+                    value: "\(meetingsWithNotesCount)",
+                    label: "With Notes",
+                    systemImage: "square.and.pencil",
+                    tint: MuesliTheme.syncGreen
+                )
+                MeetingHeaderMetric(
+                    value: coordinator.hasMeetingRecordingInProgress ? "Live" : "Ready",
+                    label: "Recorder",
+                    systemImage: coordinator.hasMeetingRecordingInProgress ? "waveform" : "checkmark",
+                    tint: statusColor
+                )
+            }
         }
     }
 
@@ -140,22 +188,37 @@ struct MeetingsView: View {
             tint: statusColor,
             isInteractive: true
         ) {
-            VStack(alignment: .leading, spacing: MuesliTheme.spacing16) {
-                HStack(alignment: .top, spacing: MuesliTheme.spacing12) {
+            VStack(alignment: .leading, spacing: MuesliTheme.spacing20) {
+                HStack(alignment: .center, spacing: MuesliTheme.spacing12) {
+                    ZStack {
+                        RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium, style: .continuous)
+                            .fill(statusColor.opacity(0.14))
+                        Image(systemName: coordinator.hasMeetingRecordingInProgress ? "stop.fill" : "mic.fill")
+                            .font(.system(size: 18, weight: .bold))
+                            .foregroundStyle(statusColor)
+                    }
+                    .frame(width: 48, height: 48)
+
                     VStack(alignment: .leading, spacing: MuesliTheme.spacing4) {
-                        Text("Meeting Recorder")
+                        Text("Recorder")
                             .font(MuesliTheme.title3())
+                            .tracking(-0.25)
                             .foregroundStyle(MuesliTheme.textPrimary)
                         Text(coordinator.effectiveMeetingStatusText)
-                            .font(MuesliTheme.callout())
+                            .font(MuesliTheme.captionMedium())
                             .foregroundStyle(statusColor)
                     }
 
                     Spacer()
 
-                    Image(systemName: coordinator.hasMeetingRecordingInProgress ? "stop.circle.fill" : "mic.circle.fill")
-                        .font(.system(size: 30, weight: .semibold))
+                    Text(coordinator.hasMeetingRecordingInProgress ? "LIVE" : "LOCAL")
+                        .font(MuesliTheme.captionMedium())
+                        .tracking(1.1)
                         .foregroundStyle(statusColor)
+                        .padding(.horizontal, MuesliTheme.spacing12)
+                        .frame(height: 28)
+                        .background(statusColor.opacity(0.12))
+                        .clipShape(Capsule())
                 }
 
                 TextField("Meeting title", text: $meetingTitle)
@@ -241,7 +304,7 @@ struct MeetingsView: View {
                     }
                 }
             }
-            .padding(MuesliTheme.spacing16)
+            .padding(MuesliTheme.spacing20)
         }
         .accessibilityIdentifier("meetings.recorderPanel")
     }
@@ -298,7 +361,7 @@ struct MeetingsView: View {
                     Text("Meeting Sessions")
                         .font(MuesliTheme.title3())
                         .foregroundStyle(MuesliTheme.textPrimary)
-                    Text("\(meetingSessions.count) saved")
+                    Text(browserResultSummary)
                         .font(MuesliTheme.caption())
                         .foregroundStyle(MuesliTheme.textTertiary)
                 }
@@ -356,70 +419,86 @@ struct MeetingsView: View {
     }
 
     private var browserControls: some View {
-        VStack(spacing: MuesliTheme.spacing12) {
-            HStack(spacing: MuesliTheme.spacing8) {
-                Image(systemName: "magnifyingglass")
-                    .font(.system(size: 15, weight: .semibold))
-                    .foregroundStyle(MuesliTheme.textTertiary)
-                TextField("Search meetings", text: $searchText)
-                    .font(MuesliTheme.body())
-                    .textInputAutocapitalization(.never)
-                    .autocorrectionDisabled()
-                    .foregroundStyle(MuesliTheme.textPrimary)
-                if !searchText.isEmpty {
-                    Button {
-                        searchText = ""
-                    } label: {
-                        Image(systemName: "xmark.circle.fill")
-                            .font(.system(size: 16, weight: .semibold))
-                            .foregroundStyle(MuesliTheme.textTertiary)
-                    }
-                    .buttonStyle(.plain)
-                    .accessibilityLabel("Clear meeting search")
-                }
-            }
-            .padding(.horizontal, MuesliTheme.spacing12)
-            .frame(height: 42)
-            .muesliGlassSurface(cornerRadius: MuesliTheme.cornerMedium)
-
-            ScrollView(.horizontal, showsIndicators: false) {
+        MuesliSurface(cornerRadius: MuesliTheme.cornerLarge, tint: MuesliTheme.accent) {
+            VStack(spacing: MuesliTheme.spacing12) {
                 HStack(spacing: MuesliTheme.spacing8) {
-                    ForEach(MeetingBrowserFilter.allCases) { filter in
+                    Image(systemName: "magnifyingglass")
+                        .font(.system(size: 15, weight: .semibold))
+                        .foregroundStyle(MuesliTheme.textTertiary)
+                    TextField("Search meetings", text: $searchText)
+                        .font(MuesliTheme.body())
+                        .textInputAutocapitalization(.never)
+                        .autocorrectionDisabled()
+                        .foregroundStyle(MuesliTheme.textPrimary)
+                    if !searchText.isEmpty {
                         Button {
-                            selectedFilter = filter
+                            searchText = ""
                         } label: {
-                            Label(filter.label, systemImage: filter.systemImage)
+                            Image(systemName: "xmark.circle.fill")
+                                .font(.system(size: 16, weight: .semibold))
+                                .foregroundStyle(MuesliTheme.textTertiary)
+                        }
+                        .buttonStyle(.plain)
+                        .accessibilityLabel("Clear meeting search")
+                    }
+                }
+                .padding(.horizontal, MuesliTheme.spacing12)
+                .frame(height: 42)
+                .background(MuesliTheme.backgroundRaised.opacity(0.55))
+                .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium, style: .continuous))
+                .overlay(
+                    RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium, style: .continuous)
+                        .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
+                )
+
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: MuesliTheme.spacing8) {
+                        ForEach(MeetingBrowserFilter.allCases) { filter in
+                            Button {
+                                selectedFilter = filter
+                            } label: {
+                                Label(filter.label, systemImage: filter.systemImage)
+                                    .font(MuesliTheme.captionMedium())
+                                    .foregroundStyle(selectedFilter == filter ? MuesliTheme.accent : MuesliTheme.textSecondary)
+                                    .padding(.horizontal, MuesliTheme.spacing12)
+                                    .frame(height: 34)
+                                    .background(selectedFilter == filter ? MuesliTheme.accentSubtle : MuesliTheme.surfacePrimary.opacity(0.72))
+                                    .overlay(
+                                        Capsule()
+                                            .strokeBorder(selectedFilter == filter ? MuesliTheme.accent.opacity(0.32) : MuesliTheme.surfaceBorder, lineWidth: 1)
+                                    )
+                                    .clipShape(Capsule())
+                            }
+                            .buttonStyle(.plain)
+                        }
+
+                        Menu {
+                            ForEach(MeetingSortOrder.allCases) { sort in
+                                Button {
+                                    selectedSort = sort
+                                } label: {
+                                    Label(sort.label, systemImage: selectedSort == sort ? "checkmark" : sort.systemImage)
+                                }
+                            }
+                        } label: {
+                            Label(selectedSort.label, systemImage: "arrow.up.arrow.down")
                                 .font(MuesliTheme.captionMedium())
-                                .foregroundStyle(selectedFilter == filter ? MuesliTheme.backgroundBase : MuesliTheme.textSecondary)
+                                .foregroundStyle(MuesliTheme.textSecondary)
                                 .padding(.horizontal, MuesliTheme.spacing12)
                                 .frame(height: 34)
-                                .background(selectedFilter == filter ? MuesliTheme.accent : MuesliTheme.surfacePrimary)
+                                .background(MuesliTheme.surfacePrimary.opacity(0.72))
+                                .overlay(
+                                    Capsule()
+                                        .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
+                                )
                                 .clipShape(Capsule())
                         }
                         .buttonStyle(.plain)
                     }
-
-                    Menu {
-                        ForEach(MeetingSortOrder.allCases) { sort in
-                            Button {
-                                selectedSort = sort
-                            } label: {
-                                Label(sort.label, systemImage: selectedSort == sort ? "checkmark" : sort.systemImage)
-                            }
-                        }
-                    } label: {
-                        Label(selectedSort.label, systemImage: "arrow.up.arrow.down")
-                            .font(MuesliTheme.captionMedium())
-                            .foregroundStyle(MuesliTheme.textSecondary)
-                            .padding(.horizontal, MuesliTheme.spacing12)
-                            .frame(height: 34)
-                            .background(MuesliTheme.surfacePrimary)
-                            .clipShape(Capsule())
-                    }
-                    .buttonStyle(.plain)
+                    .padding(.vertical, 2)
                 }
-                .padding(.vertical, 2)
             }
+            .padding(MuesliTheme.spacing12)
         }
     }
 
@@ -592,52 +671,137 @@ private enum MeetingSortOrder: String, CaseIterable, Identifiable {
     }
 }
 
+private struct MeetingHeaderMetric: View {
+    let value: String
+    let label: String
+    let systemImage: String
+    let tint: Color
+
+    var body: some View {
+        HStack(spacing: MuesliTheme.spacing8) {
+            Image(systemName: systemImage)
+                .font(.system(size: 13, weight: .bold))
+                .foregroundStyle(tint)
+                .frame(width: 24, height: 24)
+                .background(tint.opacity(0.12))
+                .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall, style: .continuous))
+
+            VStack(alignment: .leading, spacing: 1) {
+                Text(value)
+                    .font(MuesliTheme.captionMedium())
+                    .tracking(-0.15)
+                    .foregroundStyle(MuesliTheme.textPrimary)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.7)
+                Text(label)
+                    .font(MuesliTheme.caption())
+                    .foregroundStyle(MuesliTheme.textTertiary)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.7)
+            }
+        }
+        .padding(.horizontal, MuesliTheme.spacing8)
+        .frame(maxWidth: .infinity, minHeight: 46, alignment: .leading)
+        .background(MuesliTheme.surfacePrimary.opacity(0.70))
+        .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium, style: .continuous)
+                .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
+        )
+    }
+}
+
+private struct MeetingRowBadge: View {
+    let title: String
+    let systemImage: String
+    let tint: Color
+
+    var body: some View {
+        Label(title, systemImage: systemImage)
+            .font(MuesliTheme.captionMedium())
+            .foregroundStyle(tint)
+            .lineLimit(1)
+            .padding(.horizontal, MuesliTheme.spacing8)
+            .frame(height: 26)
+            .background(tint.opacity(0.10))
+            .clipShape(Capsule())
+            .overlay(
+                Capsule()
+                    .strokeBorder(tint.opacity(0.20), lineWidth: 1)
+            )
+    }
+}
+
 private struct MeetingSessionRow: View {
     let session: RecordingSession
     let transcript: Transcript?
 
     var body: some View {
-        MuesliSurface {
-            VStack(alignment: .leading, spacing: MuesliTheme.spacing12) {
-                HStack(alignment: .top, spacing: MuesliTheme.spacing12) {
-                    VStack(alignment: .leading, spacing: MuesliTheme.spacing4) {
-                        Text(session.title ?? session.kind.title)
-                            .font(MuesliTheme.headline())
-                            .foregroundStyle(MuesliTheme.textPrimary)
-                        Text(session.createdAt, formatter: Self.dateFormatter)
-                            .font(MuesliTheme.captionMedium())
-                            .foregroundStyle(MuesliTheme.textSecondary)
-                        Text(session.phase.title)
-                            .font(MuesliTheme.caption())
-                            .foregroundStyle(session.phase.tint)
-                        Label(session.sourceDisplayName, systemImage: session.sourceSystemImage)
-                            .font(MuesliTheme.caption())
-                            .foregroundStyle(MuesliTheme.textTertiary)
-                        if session.hasRetainedAudio {
-                            Label("Audio saved", systemImage: "waveform.path.ecg.rectangle")
-                                .font(MuesliTheme.caption())
-                                .foregroundStyle(MuesliTheme.textTertiary)
+        MuesliSurface(cornerRadius: MuesliTheme.cornerLarge, tint: session.phase.tint, isInteractive: true) {
+            HStack(alignment: .top, spacing: MuesliTheme.spacing12) {
+                RoundedRectangle(cornerRadius: 2, style: .continuous)
+                    .fill(session.phase.tint)
+                    .frame(width: 3, height: 76)
+                    .opacity(0.85)
+
+                VStack(alignment: .leading, spacing: MuesliTheme.spacing12) {
+                    HStack(alignment: .top, spacing: MuesliTheme.spacing12) {
+                        VStack(alignment: .leading, spacing: MuesliTheme.spacing4) {
+                            Text(session.title ?? session.kind.title)
+                                .font(MuesliTheme.headline())
+                                .foregroundStyle(MuesliTheme.textPrimary)
+                                .lineLimit(2)
+                            Text(session.createdAt, formatter: Self.dateFormatter)
+                                .font(MuesliTheme.captionMedium())
+                                .foregroundStyle(MuesliTheme.textSecondary)
                         }
-                        if let transcript, transcript.diarizationState == .completed {
-                            Label("Speakers separated", systemImage: "person.2.wave.2")
-                                .font(MuesliTheme.caption())
-                                .foregroundStyle(MuesliTheme.textTertiary)
+
+                        Spacer()
+
+                        Image(systemName: "chevron.right")
+                            .font(.system(size: 14, weight: .semibold))
+                            .foregroundStyle(MuesliTheme.textTertiary)
+                            .frame(width: 30, height: 30)
+                            .background(MuesliTheme.surfacePrimary.opacity(0.70))
+                            .clipShape(Circle())
+                    }
+
+                    ScrollView(.horizontal, showsIndicators: false) {
+                        HStack(spacing: MuesliTheme.spacing8) {
+                            MeetingRowBadge(
+                                title: session.phase.title,
+                                systemImage: session.phase.systemImage,
+                                tint: session.phase.tint
+                            )
+                            MeetingRowBadge(
+                                title: session.sourceDisplayName,
+                                systemImage: session.sourceSystemImage,
+                                tint: MuesliTheme.accent
+                            )
+                            if session.hasRetainedAudio {
+                                MeetingRowBadge(
+                                    title: "Audio",
+                                    systemImage: "waveform.path.ecg.rectangle",
+                                    tint: MuesliTheme.syncGreen
+                                )
+                            }
+                            if let transcript, transcript.diarizationState == .completed {
+                                MeetingRowBadge(
+                                    title: "Speakers",
+                                    systemImage: "person.2.wave.2",
+                                    tint: MuesliTheme.textSecondary
+                                )
+                            }
                         }
                     }
 
-                    Spacer()
-
-                    Image(systemName: "chevron.right")
-                        .font(.system(size: 15, weight: .semibold))
-                        .foregroundStyle(MuesliTheme.textTertiary)
-                        .frame(width: 32, height: 32)
+                    Text(previewText)
+                        .font(MuesliTheme.body())
+                        .foregroundStyle(previewColor)
+                        .lineLimit(3)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .padding(.top, MuesliTheme.spacing4)
                 }
-
-                Text(previewText)
-                    .font(MuesliTheme.body())
-                    .foregroundStyle(previewColor)
-                    .lineLimit(3)
-                    .fixedSize(horizontal: false, vertical: true)
             }
             .padding(MuesliTheme.spacing16)
         }
@@ -798,6 +962,7 @@ private struct MeetingSessionDetailView: View {
                 }
 
                 HStack(spacing: MuesliTheme.spacing8) {
+                    detailBadge(session.sourceDisplayName, systemImage: session.sourceSystemImage)
                     if session.hasRetainedAudio {
                         detailBadge("Audio saved", systemImage: "waveform.path.ecg.rectangle")
                     }
@@ -817,32 +982,57 @@ private struct MeetingSessionDetailView: View {
     private var manualNotesSection: some View {
         MuesliSurface(cornerRadius: MuesliTheme.cornerLarge, tint: MuesliTheme.accent) {
             VStack(alignment: .leading, spacing: MuesliTheme.spacing12) {
-                HStack(alignment: .firstTextBaseline) {
-                    Label("Live Notes", systemImage: "square.and.pencil")
+                HStack(alignment: .center, spacing: MuesliTheme.spacing12) {
+                    Image(systemName: "square.and.pencil")
+                        .font(.system(size: 16, weight: .bold))
+                        .foregroundStyle(MuesliTheme.accent)
+                        .frame(width: 34, height: 34)
+                        .background(MuesliTheme.accentSubtle)
+                        .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall, style: .continuous))
+
+                    Text("Live Notes")
                         .font(MuesliTheme.title3())
+                        .tracking(-0.15)
                         .foregroundStyle(MuesliTheme.textPrimary)
+
                     Spacer()
+
                     Text(manualNotesSaveState.label)
                         .font(MuesliTheme.captionMedium())
                         .foregroundStyle(manualNotesSaveState.tint)
+                        .padding(.horizontal, MuesliTheme.spacing8)
+                        .frame(height: 26)
+                        .background(manualNotesSaveState.tint.opacity(0.10))
+                        .clipShape(Capsule())
                 }
 
-                TextEditor(text: $manualNotesDraft)
-                    .font(MuesliTheme.body())
-                    .foregroundStyle(MuesliTheme.textPrimary)
-                    .scrollContentBackground(.hidden)
-                    .frame(minHeight: session.phase == .recording ? 220 : 140)
-                    .padding(MuesliTheme.spacing8)
-                    .background(MuesliTheme.surfacePrimary)
-                    .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall, style: .continuous))
-                    .overlay(
-                        RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall, style: .continuous)
-                            .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
-                    )
-                    .accessibilityLabel("Meeting live notes")
-                    .onChange(of: manualNotesDraft) { _, _ in
-                        scheduleManualNotesSave()
+                ZStack(alignment: .topLeading) {
+                    TextEditor(text: $manualNotesDraft)
+                        .font(MuesliTheme.body())
+                        .foregroundStyle(MuesliTheme.textPrimary)
+                        .scrollContentBackground(.hidden)
+                        .frame(minHeight: session.phase == .recording ? 220 : 140)
+                        .padding(MuesliTheme.spacing8)
+                        .accessibilityLabel("Meeting live notes")
+                        .onChange(of: manualNotesDraft) { _, _ in
+                            scheduleManualNotesSave()
+                        }
+
+                    if manualNotesDraft.isEmpty {
+                        Text("Start typing notes...")
+                            .font(MuesliTheme.body())
+                            .foregroundStyle(MuesliTheme.textTertiary)
+                            .padding(.horizontal, MuesliTheme.spacing12)
+                            .padding(.vertical, MuesliTheme.spacing16)
+                            .allowsHitTesting(false)
                     }
+                }
+                .background(MuesliTheme.backgroundRaised.opacity(0.62))
+                .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium, style: .continuous))
+                .overlay(
+                    RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium, style: .continuous)
+                        .strokeBorder(MuesliTheme.accent.opacity(0.18), lineWidth: 1)
+                )
             }
             .padding(MuesliTheme.spacing16)
         }
@@ -1815,6 +2005,23 @@ private extension RecordingSessionPhase {
             "Transcription failed."
         case .cancelled:
             "Recording was cancelled."
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .recording:
+            "mic.fill"
+        case .transcriptionQueued:
+            "clock"
+        case .transcribing:
+            "waveform.badge.magnifyingglass"
+        case .completed:
+            "checkmark"
+        case .failed:
+            "exclamationmark.triangle"
+        case .cancelled:
+            "xmark"
         }
     }
 

--- a/Muesli/MeetingsView.swift
+++ b/Muesli/MeetingsView.swift
@@ -142,7 +142,9 @@ struct MeetingsView: View {
     private var header: some View {
         VStack(alignment: .leading, spacing: MuesliTheme.spacing12) {
             HStack(spacing: MuesliTheme.spacing8) {
-                MuesliMiniLogoMark()
+                Image("MuesliAppIcon")
+                    .resizable()
+                    .scaledToFit()
                     .frame(width: 26, height: 26)
                     .clipShape(RoundedRectangle(cornerRadius: 7, style: .continuous))
                 Text("muesli")
@@ -679,22 +681,6 @@ private struct MeetingInputSurfaceModifier: ViewModifier {
 private extension View {
     func meetingInputSurface(tint: Color? = nil) -> some View {
         modifier(MeetingInputSurfaceModifier(tint: tint))
-    }
-}
-
-private struct MuesliMiniLogoMark: View {
-    private let bars: [CGFloat] = [0.40, 0.62, 0.86, 0.70, 0.48, 0.78, 0.92, 0.58]
-
-    var body: some View {
-        HStack(alignment: .center, spacing: 1.5) {
-            ForEach(Array(bars.enumerated()), id: \.offset) { _, height in
-                Capsule()
-                    .fill(MuesliTheme.brandBlue)
-                    .frame(width: 2, height: 18 * height)
-            }
-        }
-        .frame(width: 26, height: 26)
-        .background(MuesliTheme.backgroundRaised)
     }
 }
 

--- a/Muesli/MeetingsView.swift
+++ b/Muesli/MeetingsView.swift
@@ -822,6 +822,7 @@ private struct MeetingSessionDetailView: View {
     @State private var selectedContent: MeetingContentTab = .notes
     @State private var sharePayload: MeetingSharePayload?
     @State private var isConfirmingDelete = false
+    @State private var isConfirmingAudioDelete = false
     @State private var editedTitle: String?
     @State private var titleDraft = ""
     @State private var isEditingTitle = false
@@ -882,6 +883,18 @@ private struct MeetingSessionDetailView: View {
             Button("Cancel", role: .cancel) {}
         } message: {
             Text("This removes the meeting, transcript, notes, and any retained audio from local history.")
+        }
+        .confirmationDialog(
+            "Delete retained audio?",
+            isPresented: $isConfirmingAudioDelete,
+            titleVisibility: .visible
+        ) {
+            Button("Delete Audio", role: .destructive) {
+                onDeleteAudio()
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("This removes the saved meeting audio file. The transcript, summary, and manual notes stay in place.")
         }
         .onAppear {
             manualNotesDraft = session.manualNotes ?? ""
@@ -1188,7 +1201,9 @@ private struct MeetingSessionDetailView: View {
                         }
                         .buttonStyle(.plain)
 
-                        Button(role: .destructive, action: onDeleteAudio) {
+                        Button(role: .destructive) {
+                            isConfirmingAudioDelete = true
+                        } label: {
                             Image(systemName: "trash")
                                 .font(.system(size: 16, weight: .semibold))
                                 .foregroundStyle(MuesliTheme.destructive)

--- a/Muesli/MeetingsView.swift
+++ b/Muesli/MeetingsView.swift
@@ -52,14 +52,6 @@ struct MeetingsView: View {
         MeetingTemplatePreset(rawValue: selectedMeetingTemplate) ?? .general
     }
 
-    private var meetingsWithNotesCount: Int {
-        meetingSessions.filter { session in
-            let transcript = coordinator.transcript(for: session)
-            return session.manualNotes?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
-                || transcript?.summaryText?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
-        }.count
-    }
-
     private var browserResultSummary: String {
         guard !meetingSessions.isEmpty else { return "No saved meetings" }
         if filteredMeetingSessions.count == meetingSessions.count {
@@ -78,7 +70,7 @@ struct MeetingsView: View {
                 }
                 .padding(.horizontal, MuesliTheme.spacing20)
                 .padding(.top, MuesliTheme.spacing24)
-                .padding(.bottom, MuesliTheme.spacing24)
+                .padding(.bottom, 112)
             }
             .background(MuesliTheme.backgroundBase)
             .toolbar(.hidden, for: .navigationBar)
@@ -139,46 +131,23 @@ struct MeetingsView: View {
     }
 
     private var header: some View {
-        VStack(alignment: .leading, spacing: MuesliTheme.spacing16) {
-            VStack(alignment: .leading, spacing: MuesliTheme.spacing8) {
-                Text("MEETINGS")
-                    .font(MuesliTheme.captionMedium())
-                    .tracking(1.4)
-                    .foregroundStyle(MuesliTheme.textTertiary)
+        VStack(alignment: .leading, spacing: MuesliTheme.spacing8) {
+            Text("MEETINGS")
+                .font(MuesliTheme.captionMedium())
+                .tracking(1.4)
+                .foregroundStyle(MuesliTheme.textTertiary)
 
-                Text("Record, write, review")
-                    .font(.system(.largeTitle, design: .default, weight: .bold))
-                    .tracking(-0.7)
-                    .foregroundStyle(MuesliTheme.textPrimary)
-                    .lineLimit(2)
-                    .minimumScaleFactor(0.82)
+            Text("Record, write, review")
+                .font(.system(.largeTitle, design: .default, weight: .bold))
+                .tracking(-0.7)
+                .foregroundStyle(MuesliTheme.textPrimary)
+                .lineLimit(2)
+                .minimumScaleFactor(0.82)
 
-                Text("Local-first meeting capture with notes that sync across Muesli.")
-                    .font(MuesliTheme.callout())
-                    .foregroundStyle(MuesliTheme.textSecondary)
-                    .fixedSize(horizontal: false, vertical: true)
-            }
-
-            HStack(spacing: MuesliTheme.spacing8) {
-                MeetingHeaderMetric(
-                    value: "\(meetingSessions.count)",
-                    label: "Saved",
-                    systemImage: "tray.full",
-                    tint: MuesliTheme.accent
-                )
-                MeetingHeaderMetric(
-                    value: "\(meetingsWithNotesCount)",
-                    label: "With Notes",
-                    systemImage: "square.and.pencil",
-                    tint: MuesliTheme.syncGreen
-                )
-                MeetingHeaderMetric(
-                    value: coordinator.hasMeetingRecordingInProgress ? "Live" : "Ready",
-                    label: "Recorder",
-                    systemImage: coordinator.hasMeetingRecordingInProgress ? "waveform" : "checkmark",
-                    tint: statusColor
-                )
-            }
+            Text("Local-first meeting capture with notes that sync across Muesli.")
+                .font(MuesliTheme.callout())
+                .foregroundStyle(MuesliTheme.textSecondary)
+                .fixedSize(horizontal: false, vertical: true)
         }
     }
 
@@ -671,46 +640,6 @@ private enum MeetingSortOrder: String, CaseIterable, Identifiable {
     }
 }
 
-private struct MeetingHeaderMetric: View {
-    let value: String
-    let label: String
-    let systemImage: String
-    let tint: Color
-
-    var body: some View {
-        HStack(spacing: MuesliTheme.spacing8) {
-            Image(systemName: systemImage)
-                .font(.system(size: 13, weight: .bold))
-                .foregroundStyle(tint)
-                .frame(width: 24, height: 24)
-                .background(tint.opacity(0.12))
-                .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall, style: .continuous))
-
-            VStack(alignment: .leading, spacing: 1) {
-                Text(value)
-                    .font(MuesliTheme.captionMedium())
-                    .tracking(-0.15)
-                    .foregroundStyle(MuesliTheme.textPrimary)
-                    .lineLimit(1)
-                    .minimumScaleFactor(0.7)
-                Text(label)
-                    .font(MuesliTheme.caption())
-                    .foregroundStyle(MuesliTheme.textTertiary)
-                    .lineLimit(1)
-                    .minimumScaleFactor(0.7)
-            }
-        }
-        .padding(.horizontal, MuesliTheme.spacing8)
-        .frame(maxWidth: .infinity, minHeight: 46, alignment: .leading)
-        .background(MuesliTheme.surfacePrimary.opacity(0.70))
-        .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium, style: .continuous))
-        .overlay(
-            RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium, style: .continuous)
-                .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
-        )
-    }
-}
-
 private struct MeetingRowBadge: View {
     let title: String
     let systemImage: String
@@ -869,7 +798,7 @@ private struct MeetingSessionDetailView: View {
             }
             .padding(.horizontal, MuesliTheme.spacing20)
             .padding(.top, MuesliTheme.spacing16)
-            .padding(.bottom, MuesliTheme.spacing24)
+            .padding(.bottom, 112)
         }
         .background(MuesliTheme.backgroundBase)
         .navigationTitle("Meeting")

--- a/Muesli/MeetingsView.swift
+++ b/Muesli/MeetingsView.swift
@@ -9,51 +9,60 @@ struct MeetingsView: View {
     @State private var sessionPendingDelete: RecordingSession?
     @State private var navigationPath: [UUID] = []
     @State private var searchText = ""
-    @State private var selectedFilter: MeetingBrowserFilter = .all
+    @State private var selectedSourceFilter: MeetingSourceFilter = .all
+    @State private var selectedStatusFilter: MeetingStatusFilter = .all
     @State private var selectedSort: MeetingSortOrder = .newest
+    @State private var isSyncSetupPromptPresented = false
+    @AppStorage(MuesliPreferences.iCloudSyncEnabledKey) private var iCloudSyncEnabled = false
     @AppStorage(MuesliPreferences.meetingTemplateKey) private var selectedMeetingTemplate = MeetingTemplatePreset.general.rawValue
-
-    private var meetingSessions: [RecordingSession] {
-        coordinator.recordingSessions
-            .filter { $0.kind == .meeting }
-            .sorted { lhs, rhs in
-                switch selectedSort {
-                case .newest:
-                    lhs.createdAt > rhs.createdAt
-                case .oldest:
-                    lhs.createdAt < rhs.createdAt
-                }
-            }
-    }
-
-    private var meetingBrowserItems: [MeetingBrowserItem] {
-        meetingSessions.map { session in
-            MeetingBrowserItem(
-                session: session,
-                transcript: coordinator.transcript(for: session)
-            )
-        }
-    }
 
     private var meetingTemplate: MeetingTemplatePreset {
         MeetingTemplatePreset(rawValue: selectedMeetingTemplate) ?? .general
     }
 
-    private func filteredMeetingItems(from items: [MeetingBrowserItem]) -> [MeetingBrowserItem] {
+    private var meetingBrowserState: MeetingBrowserState {
         let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-        return items.filter { item in
-            guard selectedFilter.includes(item.session) else { return false }
-            guard !query.isEmpty else { return true }
-            return item.searchableText.contains(query)
+        var totalCount = 0
+        var filteredItems: [MeetingBrowserItem] = []
+        filteredItems.reserveCapacity(coordinator.recordingSessions.count)
+
+        for session in coordinator.recordingSessions where session.kind == .meeting {
+            totalCount += 1
+            guard selectedSourceFilter.includes(session),
+                  selectedStatusFilter.includes(session) else {
+                continue
+            }
+
+            let item = MeetingBrowserItem(
+                session: session,
+                transcript: coordinator.transcript(for: session)
+            )
+
+            guard query.isEmpty || item.searchableText.contains(query) else {
+                continue
+            }
+
+            filteredItems.append(item)
         }
+
+        filteredItems.sort { lhs, rhs in
+            switch selectedSort {
+            case .newest:
+                lhs.session.createdAt > rhs.session.createdAt
+            case .oldest:
+                lhs.session.createdAt < rhs.session.createdAt
+            }
+        }
+
+        return MeetingBrowserState(totalCount: totalCount, filteredItems: filteredItems)
     }
 
-    private func browserResultSummary(filteredCount: Int) -> String {
-        guard !meetingSessions.isEmpty else { return "No saved meetings" }
-        if filteredCount == meetingSessions.count {
-            return "\(meetingSessions.count) saved"
+    private func browserResultSummary(_ state: MeetingBrowserState) -> String {
+        guard state.totalCount > 0 else { return "No saved meetings" }
+        if state.filteredItems.count == state.totalCount {
+            return "\(state.totalCount) saved"
         }
-        return "\(filteredCount) of \(meetingSessions.count)"
+        return "\(state.filteredItems.count) of \(state.totalCount)"
     }
 
     var body: some View {
@@ -70,6 +79,20 @@ struct MeetingsView: View {
             }
             .background(MuesliTheme.backgroundBase)
             .toolbar(.hidden, for: .navigationBar)
+            .confirmationDialog(
+                "Turn on private iCloud sync?",
+                isPresented: $isSyncSetupPromptPresented,
+                titleVisibility: .visible
+            ) {
+                Button("Open Sync Setup") {
+                    coordinator.requestSyncSetup(source: "meetings_sync")
+                }
+                Button("Not Now", role: .cancel) {
+                    coordinator.iCloudSyncStatusText = nil
+                }
+            } message: {
+                Text("Muesli will sync meeting transcripts, notes, and summaries with your Mac through your private iCloud account. Audio stays local.")
+            }
             .onAppear {
                 refreshVisibleStateIfNeeded()
             }
@@ -282,20 +305,28 @@ struct MeetingsView: View {
 
     @ViewBuilder
     private var sessionsSection: some View {
-        let browserItems = filteredMeetingItems(from: meetingBrowserItems)
+        let browserState = meetingBrowserState
+        let browserItems = browserState.filteredItems
 
         VStack(alignment: .leading, spacing: MuesliTheme.spacing12) {
-            HStack(alignment: .firstTextBaseline) {
+            HStack(alignment: .center) {
                 VStack(alignment: .leading, spacing: MuesliTheme.spacing4) {
                     Text("Recent Meetings")
                         .font(MuesliTheme.title3())
                         .foregroundStyle(MuesliTheme.textPrimary)
-                    Text(browserResultSummary(filteredCount: browserItems.count))
+                    Text(browserResultSummary(browserState))
                         .font(MuesliTheme.caption())
                         .foregroundStyle(MuesliTheme.textTertiary)
                 }
 
                 Spacer()
+
+                ICloudSyncStatusButton(
+                    isEnabled: iCloudSyncEnabled,
+                    isSyncing: coordinator.isICloudSyncInProgress,
+                    hasError: syncStatusIsError,
+                    action: triggerMeetingSync
+                )
 
                 if let status = coordinator.clipboardStatusText {
                     Label(status, systemImage: "checkmark")
@@ -304,9 +335,13 @@ struct MeetingsView: View {
                 }
             }
 
+            if browserState.totalCount > 0 {
+                MeetingSourceFilterPicker(selection: $selectedSourceFilter)
+            }
+
             browserControls
 
-            if meetingSessions.isEmpty {
+            if browserState.totalCount == 0 {
                 emptyState
             } else if browserItems.isEmpty {
                 emptySearchState
@@ -380,11 +415,11 @@ struct MeetingsView: View {
             )
 
             Menu {
-                ForEach(MeetingBrowserFilter.allCases) { filter in
+                ForEach(MeetingStatusFilter.allCases) { filter in
                     Button {
-                        selectedFilter = filter
+                        selectedStatusFilter = filter
                     } label: {
-                        Label(filter.label, systemImage: selectedFilter == filter ? "checkmark" : filter.systemImage)
+                        Label(filter.label, systemImage: selectedStatusFilter == filter ? "checkmark" : filter.systemImage)
                     }
                 }
 
@@ -413,6 +448,19 @@ struct MeetingsView: View {
     private func refreshVisibleStateIfNeeded() {
         guard isActive else { return }
         coordinator.refreshHistory()
+    }
+
+    private var syncStatusIsError: Bool {
+        coordinator.iCloudSyncStatusText?.localizedCaseInsensitiveContains("sync failed") == true
+    }
+
+    private func triggerMeetingSync() {
+        if !iCloudSyncEnabled {
+            coordinator.iCloudSyncStatusText = nil
+            isSyncSetupPromptPresented = true
+            return
+        }
+        coordinator.syncICloudTextIfEnabled(reason: "meetings_manual")
     }
 
     private var emptyState: some View {
@@ -445,7 +493,7 @@ struct MeetingsView: View {
                 Text("No matches")
                     .font(MuesliTheme.headline())
                     .foregroundStyle(MuesliTheme.textPrimary)
-                Text("Adjust the search or filter to find another meeting.")
+                Text("Adjust the search, source, or filter to find another meeting.")
                     .font(MuesliTheme.body())
                     .foregroundStyle(MuesliTheme.textSecondary)
             }
@@ -533,16 +581,19 @@ private struct MeetingBrowserItem: Identifiable {
     }
 }
 
-private enum MeetingBrowserFilter: String, CaseIterable, Identifiable {
+private struct MeetingBrowserState {
+    let totalCount: Int
+    let filteredItems: [MeetingBrowserItem]
+}
+
+private enum MeetingSourceFilter: String, CaseIterable, Identifiable {
     case all
     case thisIPhone
     case fromMac
-    case processing
-    case needsAttention
 
     var id: String { rawValue }
 
-    var label: String {
+    var title: String {
         switch self {
         case .all:
             "All"
@@ -550,25 +601,6 @@ private enum MeetingBrowserFilter: String, CaseIterable, Identifiable {
             "This iPhone"
         case .fromMac:
             "From Mac"
-        case .processing:
-            "Processing"
-        case .needsAttention:
-            "Needs Review"
-        }
-    }
-
-    var systemImage: String {
-        switch self {
-        case .all:
-            "tray.full"
-        case .thisIPhone:
-            "iphone"
-        case .fromMac:
-            "desktopcomputer"
-        case .processing:
-            "waveform.badge.magnifyingglass"
-        case .needsAttention:
-            "exclamationmark.triangle"
         }
     }
 
@@ -580,11 +612,81 @@ private enum MeetingBrowserFilter: String, CaseIterable, Identifiable {
             session.isFromThisIPhone
         case .fromMac:
             session.isFromMac
+        }
+    }
+}
+
+private enum MeetingStatusFilter: String, CaseIterable, Identifiable {
+    case all
+    case processing
+    case needsAttention
+
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .all:
+            "All Statuses"
+        case .processing:
+            "Processing"
+        case .needsAttention:
+            "Needs Review"
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .all:
+            "tray.full"
+        case .processing:
+            "waveform.badge.magnifyingglass"
+        case .needsAttention:
+            "exclamationmark.triangle"
+        }
+    }
+
+    func includes(_ session: RecordingSession) -> Bool {
+        switch self {
+        case .all:
+            true
         case .processing:
             session.phase == .recording || session.phase == .transcriptionQueued || session.phase == .transcribing
         case .needsAttention:
             session.phase == .failed || session.phase == .cancelled
         }
+    }
+}
+
+private struct MeetingSourceFilterPicker: View {
+    @Binding var selection: MeetingSourceFilter
+
+    var body: some View {
+        HStack(spacing: MuesliTheme.spacing4) {
+            ForEach(MeetingSourceFilter.allCases) { filter in
+                Button {
+                    withAnimation(.snappy(duration: 0.18)) {
+                        selection = filter
+                    }
+                } label: {
+                    Text(filter.title)
+                        .font(MuesliTheme.captionMedium())
+                        .foregroundStyle(selection == filter ? MuesliTheme.textPrimary : MuesliTheme.textSecondary)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.82)
+                        .frame(maxWidth: .infinity)
+                        .frame(height: 32)
+                        .background(selection == filter ? MuesliTheme.accent.opacity(0.13) : Color.clear)
+                        .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall, style: .continuous))
+                        .frame(maxWidth: .infinity)
+                        .frame(height: 44)
+                        .contentShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall, style: .continuous))
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Show \(filter.title.lowercased()) meetings")
+            }
+        }
+        .padding(3)
+        .muesliGlassSurface(cornerRadius: MuesliTheme.cornerMedium, tint: MuesliTheme.accent)
     }
 }
 

--- a/Muesli/MeetingsView.swift
+++ b/Muesli/MeetingsView.swift
@@ -12,8 +12,6 @@ struct MeetingsView: View {
     @State private var selectedFilter: MeetingBrowserFilter = .all
     @State private var selectedSort: MeetingSortOrder = .newest
     @AppStorage(MuesliPreferences.meetingTemplateKey) private var selectedMeetingTemplate = MeetingTemplatePreset.general.rawValue
-    @AppStorage(MuesliPreferences.meetingSummariesEnabledKey) private var meetingSummariesEnabled = false
-    @AppStorage(MuesliPreferences.meetingSummaryBackendKey) private var meetingSummaryBackend = MeetingSummaryBackend.openRouter.rawValue
 
     private var meetingSessions: [RecordingSession] {
         coordinator.recordingSessions
@@ -228,7 +226,6 @@ struct MeetingsView: View {
                         .disabled(coordinator.isMeetingTranscribing)
 
                     meetingTemplatePicker
-                    summaryBackendPicker
 
                     Button {
                         if let sessionID = coordinator.startMeetingRecording(title: meetingTitle) {
@@ -302,27 +299,6 @@ struct MeetingsView: View {
         }
         .buttonStyle(.plain)
         .disabled(coordinator.hasMeetingRecordingInProgress || coordinator.isMeetingTranscribing)
-    }
-
-    private var summaryBackendPicker: some View {
-        VStack(alignment: .leading, spacing: MuesliTheme.spacing8) {
-            Toggle(isOn: $meetingSummariesEnabled) {
-                Label("Generate Meeting Notes", systemImage: "sparkles")
-                    .font(MuesliTheme.headline())
-                    .foregroundStyle(MuesliTheme.textPrimary)
-            }
-            .tint(MuesliTheme.accent)
-
-            Picker("Summary Backend", selection: $meetingSummaryBackend) {
-                ForEach(MeetingSummaryBackend.allCases) { backend in
-                    Text(backend.label).tag(backend.rawValue)
-                }
-            }
-            .pickerStyle(.segmented)
-            .disabled(!meetingSummariesEnabled)
-        }
-        .padding(MuesliTheme.spacing12)
-        .muesliGlassSurface(cornerRadius: MuesliTheme.cornerMedium, tint: MuesliTheme.accent)
     }
 
     @ViewBuilder
@@ -805,16 +781,25 @@ private struct MeetingSessionDetailView: View {
     @State private var manualNotesSaveState: ManualNotesSaveState = .saved
     @State private var manualNotesSaveTask: Task<Void, Never>?
     @State private var recordingPulse = false
+    @State private var isEditingCompletedManualNotes = false
 
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: MuesliTheme.spacing20) {
                 detailHeader
-                captureStatusSection
-                manualNotesSection
-                contentSection
-                retainedAudioSection
-                detailActions
+                if isCompletedMeeting {
+                    contentSection
+                    transcriptActionsSection
+                    manualNotesSection
+                    retainedAudioSection
+                    deleteActionSection
+                } else {
+                    captureStatusSection
+                    manualNotesSection
+                    contentSection
+                    retainedAudioSection
+                    detailActions
+                }
             }
             .padding(.horizontal, MuesliTheme.spacing20)
             .padding(.top, MuesliTheme.spacing16)
@@ -1042,44 +1027,88 @@ private struct MeetingSessionDetailView: View {
 
                     Spacer()
 
-                    Text(manualNotesSaveState.label)
-                        .font(MuesliTheme.captionMedium())
-                        .foregroundStyle(manualNotesSaveState.tint)
-                        .padding(.horizontal, MuesliTheme.spacing8)
-                        .frame(height: 26)
-                        .background(manualNotesSaveState.tint.opacity(0.10))
-                        .clipShape(Capsule())
+                    manualNotesHeaderAccessory
                 }
 
-                ZStack(alignment: .topLeading) {
-                    TextEditor(text: $manualNotesDraft)
-                        .font(MuesliTheme.body())
-                        .foregroundStyle(MuesliTheme.textPrimary)
-                        .scrollContentBackground(.hidden)
-                        .frame(minHeight: session.phase == .recording ? 220 : 140)
-                        .padding(MuesliTheme.spacing8)
-                        .accessibilityLabel("Meeting manual notes")
-                        .onChange(of: manualNotesDraft) { _, _ in
-                            scheduleManualNotesSave()
-                        }
+                manualNotesBody
+            }
+            .padding(MuesliTheme.spacing16)
+        }
+    }
 
-                    if manualNotesDraft.isEmpty {
-                        Text("Start typing meeting notes...")
-                            .font(MuesliTheme.body())
-                            .foregroundStyle(MuesliTheme.textTertiary)
-                            .padding(.horizontal, MuesliTheme.spacing12)
-                            .padding(.vertical, MuesliTheme.spacing16)
-                            .allowsHitTesting(false)
+    @ViewBuilder
+    private var manualNotesHeaderAccessory: some View {
+        if isCompletedMeeting {
+            Button {
+                if isEditingCompletedManualNotes {
+                    persistManualNotesIfChanged()
+                }
+                isEditingCompletedManualNotes.toggle()
+            } label: {
+                Text(isEditingCompletedManualNotes ? "Done" : "Edit")
+                    .font(MuesliTheme.captionMedium())
+                    .foregroundStyle(MuesliTheme.accent)
+                    .padding(.horizontal, 10)
+                    .frame(height: 30)
+                    .background(MuesliTheme.accentSubtle)
+                    .clipShape(Capsule())
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel(isEditingCompletedManualNotes ? "Finish editing manual notes" : "Edit manual notes")
+        } else if canEditManualNotes {
+            Text(manualNotesSaveState.label)
+                .font(MuesliTheme.captionMedium())
+                .foregroundStyle(manualNotesSaveState.tint)
+                .padding(.horizontal, MuesliTheme.spacing8)
+                .frame(height: 26)
+                .background(manualNotesSaveState.tint.opacity(0.10))
+                .clipShape(Capsule())
+        }
+    }
+
+    @ViewBuilder
+    private var manualNotesBody: some View {
+        if canEditManualNotes {
+            ZStack(alignment: .topLeading) {
+                TextEditor(text: $manualNotesDraft)
+                    .font(MuesliTheme.body())
+                    .foregroundStyle(MuesliTheme.textPrimary)
+                    .scrollContentBackground(.hidden)
+                    .frame(minHeight: session.phase == .recording ? 220 : 140)
+                    .padding(MuesliTheme.spacing8)
+                    .accessibilityLabel("Meeting manual notes")
+                    .onChange(of: manualNotesDraft) { _, _ in
+                        scheduleManualNotesSave()
                     }
+
+                if manualNotesDraft.isEmpty {
+                    Text("Start typing meeting notes...")
+                        .font(MuesliTheme.body())
+                        .foregroundStyle(MuesliTheme.textTertiary)
+                        .padding(.horizontal, MuesliTheme.spacing12)
+                        .padding(.vertical, MuesliTheme.spacing16)
+                        .allowsHitTesting(false)
                 }
-                .background(MuesliTheme.backgroundRaised.opacity(0.62))
+            }
+            .background(MuesliTheme.backgroundRaised.opacity(0.62))
+            .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium, style: .continuous))
+            .overlay(
+                RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium, style: .continuous)
+                    .strokeBorder(MuesliTheme.accent.opacity(0.18), lineWidth: 1)
+            )
+        } else {
+            Text(manualNotesDraft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? "No manual notes." : manualNotesDraft)
+                .font(MuesliTheme.body())
+                .foregroundStyle(manualNotesDraft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? MuesliTheme.textTertiary : MuesliTheme.textPrimary)
+                .fixedSize(horizontal: false, vertical: true)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(MuesliTheme.spacing16)
+                .background(MuesliTheme.backgroundRaised.opacity(0.48))
                 .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium, style: .continuous))
                 .overlay(
                     RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium, style: .continuous)
-                        .strokeBorder(MuesliTheme.accent.opacity(0.18), lineWidth: 1)
+                        .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
                 )
-            }
-            .padding(MuesliTheme.spacing16)
         }
     }
 
@@ -1149,7 +1178,16 @@ private struct MeetingSessionDetailView: View {
                     .contentShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
             }
             .buttonStyle(.plain)
-        } else if shouldShowPostMeetingArtifacts, let transcript {
+        } else {
+            transcriptActionsSection
+        }
+
+        deleteActionSection
+    }
+
+    @ViewBuilder
+    private var transcriptActionsSection: some View {
+        if shouldShowPostMeetingArtifacts, let transcript {
             VStack(spacing: MuesliTheme.spacing8) {
                 Button {
                     onCopy(copyText(for: transcript), resolvedContent(for: transcript))
@@ -1186,7 +1224,10 @@ private struct MeetingSessionDetailView: View {
                 .buttonStyle(.plain)
             }
         }
+    }
 
+    @ViewBuilder
+    private var deleteActionSection: some View {
         if !isActiveRecording && !isProcessingCurrentMeeting {
             Button {
                 isConfirmingDelete = true
@@ -1249,6 +1290,17 @@ private struct MeetingSessionDetailView: View {
 
     private var shouldShowPostMeetingArtifacts: Bool {
         !isActiveRecording && !isProcessingCurrentMeeting && session.phase != .recording && session.phase != .transcribing
+    }
+
+    private var isCompletedMeeting: Bool {
+        session.phase == .completed
+    }
+
+    private var canEditManualNotes: Bool {
+        isActiveRecording
+            || isProcessingCurrentMeeting
+            || session.phase == .transcriptionQueued
+            || isEditingCompletedManualNotes
     }
 
     private var contentSectionTitle: String {

--- a/Muesli/MeetingsView.swift
+++ b/Muesli/MeetingsView.swift
@@ -38,7 +38,7 @@ struct MeetingsView: View {
                 transcript: coordinator.transcript(for: session)
             )
 
-            guard query.isEmpty || item.searchableText.contains(query) else {
+            guard query.isEmpty || item.containsSearchQuery(query) else {
                 continue
             }
 
@@ -110,6 +110,7 @@ struct MeetingsView: View {
                         isProcessingCurrentMeeting: session.phase == .transcribing,
                         inputLevel: coordinator.inputLevel,
                         statusText: coordinator.activeMeetingSessionID == session.id ? coordinator.effectiveMeetingStatusText : session.phase.title,
+                        actionStatusText: coordinator.clipboardStatusText,
                         onTranscribe: { coordinator.transcribeSession(session) },
                         onStopRecording: { coordinator.stopCurrentMeetingRecording() },
                         onDiscardRecording: {
@@ -329,9 +330,7 @@ struct MeetingsView: View {
                 )
 
                 if let status = coordinator.clipboardStatusText {
-                    Label(status, systemImage: "checkmark")
-                        .font(MuesliTheme.captionMedium())
-                        .foregroundStyle(MuesliTheme.success)
+                    MeetingActionStatusLabel(statusText: status)
                 }
             }
 
@@ -528,7 +527,7 @@ struct MeetingsView: View {
     }
 
     private var isPrimaryMeetingActionDisabled: Bool {
-        coordinator.isMeetingTranscribing && !coordinator.hasMeetingRecordingInProgress
+        coordinator.isMeetingTranscribing
     }
 
     private func openMeeting(_ sessionID: UUID) {
@@ -541,7 +540,6 @@ struct MeetingsView: View {
 private struct MeetingBrowserItem: Identifiable {
     let session: RecordingSession
     let transcript: Transcript?
-    let searchableText: String
     let copyText: String
 
     var id: UUID { session.id }
@@ -549,7 +547,11 @@ private struct MeetingBrowserItem: Identifiable {
     init(session: RecordingSession, transcript: Transcript?) {
         self.session = session
         self.transcript = transcript
-        searchableText = [
+        copyText = Self.preferredCopyText(for: session, transcript: transcript)
+    }
+
+    func containsSearchQuery(_ query: String) -> Bool {
+        [
             session.title ?? "",
             session.phase.title,
             session.sourceDisplayName,
@@ -561,8 +563,7 @@ private struct MeetingBrowserItem: Identifiable {
         ]
         .joined(separator: " ")
         .lowercased()
-
-        copyText = Self.preferredCopyText(for: session, transcript: transcript)
+        .contains(query)
     }
 
     private static func preferredCopyText(for session: RecordingSession, transcript: Transcript?) -> String {
@@ -585,6 +586,20 @@ private struct MeetingBrowserItem: Identifiable {
 private struct MeetingBrowserState {
     let totalCount: Int
     let filteredItems: [MeetingBrowserItem]
+}
+
+private struct MeetingActionStatusLabel: View {
+    let statusText: String
+
+    private var isFailure: Bool {
+        statusText.localizedCaseInsensitiveContains("failed")
+    }
+
+    var body: some View {
+        Label(statusText, systemImage: isFailure ? "exclamationmark.triangle.fill" : "checkmark")
+            .font(MuesliTheme.captionMedium())
+            .foregroundStyle(isFailure ? MuesliTheme.destructive : MuesliTheme.success)
+    }
 }
 
 private enum MeetingSourceFilter: String, CaseIterable, Identifiable {
@@ -909,12 +924,13 @@ private struct MeetingSessionDetailView: View {
     let isProcessingCurrentMeeting: Bool
     let inputLevel: Double
     let statusText: String
+    let actionStatusText: String?
     let onTranscribe: () -> Void
     let onStopRecording: () -> Void
     let onDiscardRecording: () -> Void
     let onCopy: (String, MeetingContentTab) -> Void
-    let onDelete: () -> Void
-    let onDeleteAudio: () -> Void
+    let onDelete: () -> Bool
+    let onDeleteAudio: () -> Bool
     let onRename: (String) -> Void
     let onManualNotesChange: (String) -> Void
     @Environment(\.dismiss) private var dismiss
@@ -937,6 +953,9 @@ private struct MeetingSessionDetailView: View {
         ScrollView {
             VStack(alignment: .leading, spacing: MuesliTheme.spacing20) {
                 detailHeader
+                if let actionStatusText {
+                    MeetingActionStatusLabel(statusText: actionStatusText)
+                }
                 if isCompletedMeeting {
                     contentSection
                     transcriptActionsSection
@@ -980,8 +999,11 @@ private struct MeetingSessionDetailView: View {
             Button("Delete Meeting", role: .destructive) {
                 isLeavingAfterDestructiveAction = true
                 manualNotesSaveTask?.cancel()
-                onDelete()
-                dismiss()
+                if onDelete() {
+                    dismiss()
+                } else {
+                    isLeavingAfterDestructiveAction = false
+                }
             }
             Button("Cancel", role: .cancel) {}
         } message: {
@@ -993,7 +1015,7 @@ private struct MeetingSessionDetailView: View {
             titleVisibility: .visible
         ) {
             Button("Delete Audio", role: .destructive) {
-                onDeleteAudio()
+                _ = onDeleteAudio()
             }
             Button("Cancel", role: .cancel) {}
         } message: {

--- a/Muesli/MeetingsView.swift
+++ b/Muesli/MeetingsView.swift
@@ -12,6 +12,8 @@ struct MeetingsView: View {
     @State private var selectedFilter: MeetingBrowserFilter = .all
     @State private var selectedSort: MeetingSortOrder = .newest
     @AppStorage(MuesliPreferences.meetingTemplateKey) private var selectedMeetingTemplate = MeetingTemplatePreset.general.rawValue
+    @AppStorage(MuesliPreferences.meetingSummariesEnabledKey) private var meetingSummariesEnabled = false
+    @AppStorage(MuesliPreferences.meetingSummaryBackendKey) private var meetingSummaryBackend = MeetingSummaryBackend.openRouter.rawValue
 
     private var meetingSessions: [RecordingSession] {
         coordinator.recordingSessions
@@ -65,7 +67,7 @@ struct MeetingsView: View {
             ScrollView {
                 VStack(alignment: .leading, spacing: MuesliTheme.spacing20) {
                     header
-                    recorderPanel
+                    startMeetingPanel
                     sessionsSection
                 }
                 .padding(.horizontal, MuesliTheme.spacing20)
@@ -87,7 +89,16 @@ struct MeetingsView: View {
                         session: session,
                         transcript: coordinator.transcript(for: session),
                         audioURL: coordinator.audioFileURL(for: session),
+                        isActiveRecording: coordinator.activeMeetingSessionID == session.id && coordinator.hasMeetingRecordingInProgress,
+                        isProcessingCurrentMeeting: session.phase == .transcribing,
+                        inputLevel: coordinator.inputLevel,
+                        statusText: coordinator.activeMeetingSessionID == session.id ? coordinator.effectiveMeetingStatusText : session.phase.title,
                         onTranscribe: { coordinator.transcribeSession(session) },
+                        onStopRecording: { coordinator.stopCurrentMeetingRecording() },
+                        onDiscardRecording: {
+                            coordinator.cancelCurrentMeetingRecording()
+                            navigationPath.removeAll { $0 == session.id }
+                        },
                         onCopy: { text, tab in
                             coordinator.copyText(
                                 text,
@@ -151,7 +162,7 @@ struct MeetingsView: View {
         }
     }
 
-    private var recorderPanel: some View {
+    private var startMeetingPanel: some View {
         MuesliSurface(
             cornerRadius: MuesliTheme.cornerLarge,
             tint: statusColor,
@@ -162,7 +173,7 @@ struct MeetingsView: View {
                     ZStack {
                         RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium, style: .continuous)
                             .fill(statusColor.opacity(0.14))
-                        Image(systemName: coordinator.hasMeetingRecordingInProgress ? "stop.fill" : "mic.fill")
+                        Image(systemName: coordinator.hasMeetingRecordingInProgress ? "arrow.up.forward.square" : "mic.fill")
                             .font(.system(size: 18, weight: .bold))
                             .foregroundStyle(statusColor)
                     }
@@ -173,7 +184,7 @@ struct MeetingsView: View {
                             .font(MuesliTheme.title3())
                             .tracking(-0.25)
                             .foregroundStyle(MuesliTheme.textPrimary)
-                        Text(coordinator.effectiveMeetingStatusText)
+                        Text(coordinator.hasMeetingRecordingInProgress ? "Live meeting open in detail" : coordinator.effectiveMeetingStatusText)
                             .font(MuesliTheme.captionMedium())
                             .foregroundStyle(statusColor)
                     }
@@ -190,52 +201,44 @@ struct MeetingsView: View {
                         .clipShape(Capsule())
                 }
 
-                TextField("Meeting title", text: $meetingTitle)
-                    .font(MuesliTheme.body())
-                    .foregroundStyle(MuesliTheme.textPrimary)
-                    .padding(.horizontal, MuesliTheme.spacing12)
-                    .frame(height: 44)
-                    .muesliGlassSurface(cornerRadius: MuesliTheme.cornerMedium)
-                    .disabled(coordinator.hasMeetingRecordingInProgress || coordinator.isMeetingTranscribing)
-
-                meetingTemplatePicker
-
-                if coordinator.hasMeetingRecordingInProgress || coordinator.isMeetingTranscribing {
-                    VStack(spacing: MuesliTheme.spacing8) {
-                        MuesliInlineWaveformView(
-                            mode: coordinator.isMeetingRecording ? .level : .waiting,
-                            color: statusColor,
-                            level: coordinator.isMeetingRecording ? coordinator.inputLevel : nil,
-                            isActive: isActive,
-                            barCount: 32
-                        )
-                        .frame(maxWidth: .infinity)
-                        .frame(height: 54)
-                        .padding(.horizontal, MuesliTheme.spacing16)
-
-                        Text(coordinator.hasMeetingRecordingInProgress ? "Recording" : "Processing")
-                            .font(MuesliTheme.captionMedium())
-                            .foregroundStyle(MuesliTheme.textSecondary)
-                    }
-                    .frame(maxWidth: .infinity)
-                    .padding(.vertical, MuesliTheme.spacing16)
-                    .muesliGlassSurface(cornerRadius: MuesliTheme.cornerMedium, tint: statusColor)
-                }
-
-                VStack(spacing: MuesliTheme.spacing8) {
+                if coordinator.hasMeetingRecordingInProgress {
                     Button {
-                        if coordinator.hasMeetingRecordingInProgress {
-                            coordinator.stopCurrentMeetingRecording()
-                        } else {
-                            if let sessionID = coordinator.startMeetingRecording(title: meetingTitle) {
-                                navigationPath.append(sessionID)
-                                meetingTitle = ""
-                            }
+                        if let sessionID = coordinator.activeMeetingSessionID {
+                            openMeeting(sessionID)
+                        }
+                    } label: {
+                        Label("Open Live Meeting", systemImage: "arrow.up.forward.square")
+                            .font(MuesliTheme.headline())
+                            .frame(maxWidth: .infinity)
+                            .frame(height: 48)
+                            .foregroundStyle(.white)
+                            .background(statusColor)
+                            .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+                            .contentShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+                    }
+                    .buttonStyle(.plain)
+                    .disabled(coordinator.activeMeetingSessionID == nil)
+                } else {
+                    TextField("Meeting title", text: $meetingTitle)
+                        .font(MuesliTheme.body())
+                        .foregroundStyle(MuesliTheme.textPrimary)
+                        .padding(.horizontal, MuesliTheme.spacing12)
+                        .frame(height: 44)
+                        .muesliGlassSurface(cornerRadius: MuesliTheme.cornerMedium)
+                        .disabled(coordinator.isMeetingTranscribing)
+
+                    meetingTemplatePicker
+                    summaryBackendPicker
+
+                    Button {
+                        if let sessionID = coordinator.startMeetingRecording(title: meetingTitle) {
+                            openMeeting(sessionID)
+                            meetingTitle = ""
                         }
                     } label: {
                         Label(
-                            coordinator.hasMeetingRecordingInProgress ? "Stop Meeting" : "Start Meeting",
-                            systemImage: coordinator.hasMeetingRecordingInProgress ? "stop.fill" : "mic.fill"
+                            "Start Meeting",
+                            systemImage: "mic.fill"
                         )
                         .font(MuesliTheme.headline())
                         .frame(maxWidth: .infinity)
@@ -250,32 +253,11 @@ struct MeetingsView: View {
                     .disabled(isPrimaryMeetingActionDisabled)
                     .sensoryFeedback(.impact, trigger: coordinator.hasMeetingRecordingInProgress)
                     .accessibilityIdentifier("meetings.primaryButton")
-
-                    if coordinator.hasMeetingRecordingInProgress {
-                        Button(role: .destructive) {
-                            coordinator.cancelCurrentMeetingRecording()
-                        } label: {
-                            Label("Discard Meeting", systemImage: "xmark")
-                                .font(MuesliTheme.captionMedium())
-                                .foregroundStyle(MuesliTheme.destructive)
-                                .frame(maxWidth: .infinity)
-                                .frame(minHeight: 44)
-                                .background(MuesliTheme.destructive.opacity(0.07))
-                                .overlay(
-                                    RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall)
-                                        .strokeBorder(MuesliTheme.destructive.opacity(0.22), lineWidth: 1)
-                                )
-                                .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
-                                .contentShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
-                        }
-                        .buttonStyle(.plain)
-                        .accessibilityIdentifier("meetings.discardButton")
-                    }
                 }
             }
             .padding(MuesliTheme.spacing20)
         }
-        .accessibilityIdentifier("meetings.recorderPanel")
+        .accessibilityIdentifier("meetings.startMeetingPanel")
     }
 
     private var meetingTemplatePicker: some View {
@@ -320,6 +302,27 @@ struct MeetingsView: View {
         }
         .buttonStyle(.plain)
         .disabled(coordinator.hasMeetingRecordingInProgress || coordinator.isMeetingTranscribing)
+    }
+
+    private var summaryBackendPicker: some View {
+        VStack(alignment: .leading, spacing: MuesliTheme.spacing8) {
+            Toggle(isOn: $meetingSummariesEnabled) {
+                Label("Generate Meeting Notes", systemImage: "sparkles")
+                    .font(MuesliTheme.headline())
+                    .foregroundStyle(MuesliTheme.textPrimary)
+            }
+            .tint(MuesliTheme.accent)
+
+            Picker("Summary Backend", selection: $meetingSummaryBackend) {
+                ForEach(MeetingSummaryBackend.allCases) { backend in
+                    Text(backend.label).tag(backend.rawValue)
+                }
+            }
+            .pickerStyle(.segmented)
+            .disabled(!meetingSummariesEnabled)
+        }
+        .padding(MuesliTheme.spacing12)
+        .muesliGlassSurface(cornerRadius: MuesliTheme.cornerMedium, tint: MuesliTheme.accent)
     }
 
     @ViewBuilder
@@ -541,6 +544,11 @@ struct MeetingsView: View {
 
     private var isPrimaryMeetingActionDisabled: Bool {
         coordinator.isMeetingTranscribing && !coordinator.hasMeetingRecordingInProgress
+    }
+
+    private func openMeeting(_ sessionID: UUID) {
+        guard navigationPath.last != sessionID else { return }
+        navigationPath.append(sessionID)
     }
 
     private func copyText(for session: RecordingSession) -> String {
@@ -775,7 +783,13 @@ private struct MeetingSessionDetailView: View {
     let session: RecordingSession
     let transcript: Transcript?
     let audioURL: URL?
+    let isActiveRecording: Bool
+    let isProcessingCurrentMeeting: Bool
+    let inputLevel: Double
+    let statusText: String
     let onTranscribe: () -> Void
+    let onStopRecording: () -> Void
+    let onDiscardRecording: () -> Void
     let onCopy: (String, MeetingContentTab) -> Void
     let onDelete: () -> Void
     let onRename: (String) -> Void
@@ -790,15 +804,17 @@ private struct MeetingSessionDetailView: View {
     @State private var manualNotesDraft = ""
     @State private var manualNotesSaveState: ManualNotesSaveState = .saved
     @State private var manualNotesSaveTask: Task<Void, Never>?
+    @State private var recordingPulse = false
 
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: MuesliTheme.spacing20) {
                 detailHeader
+                captureStatusSection
                 manualNotesSection
+                contentSection
                 retainedAudioSection
                 detailActions
-                contentSection
             }
             .padding(.horizontal, MuesliTheme.spacing20)
             .padding(.top, MuesliTheme.spacing16)
@@ -896,7 +912,7 @@ private struct MeetingSessionDetailView: View {
 
                 HStack(spacing: MuesliTheme.spacing8) {
                     detailBadge(session.sourceDisplayName, systemImage: session.sourceSystemImage)
-                    if session.hasRetainedAudio {
+                    if shouldShowPostMeetingArtifacts, session.hasRetainedAudio {
                         detailBadge("Audio saved", systemImage: "waveform.path.ecg.rectangle")
                     }
                     if transcript?.diarizationState == .completed {
@@ -912,6 +928,102 @@ private struct MeetingSessionDetailView: View {
     }
 
     @ViewBuilder
+    private var captureStatusSection: some View {
+        if isActiveRecording || isProcessingCurrentMeeting {
+            MuesliSurface(
+                cornerRadius: MuesliTheme.cornerLarge,
+                tint: captureTint,
+                isInteractive: true
+            ) {
+                VStack(alignment: .leading, spacing: MuesliTheme.spacing16) {
+                    HStack(alignment: .center, spacing: MuesliTheme.spacing12) {
+                        ZStack {
+                            Circle()
+                                .fill(captureTint.opacity(0.16))
+                            Circle()
+                                .fill(captureTint)
+                                .frame(width: 12, height: 12)
+                                .opacity(isActiveRecording ? (recordingPulse ? 0.95 : 0.32) : 0.45)
+                                .animation(
+                                    isActiveRecording
+                                        ? .easeInOut(duration: 0.9).repeatForever(autoreverses: true)
+                                        : .default,
+                                    value: recordingPulse
+                                )
+                        }
+                        .frame(width: 42, height: 42)
+                        .onAppear {
+                            recordingPulse = isActiveRecording
+                        }
+                        .onChange(of: isActiveRecording) { _, isRecording in
+                            recordingPulse = isRecording
+                        }
+
+                        VStack(alignment: .leading, spacing: MuesliTheme.spacing4) {
+                            Text(isActiveRecording ? "Recording" : "Processing")
+                                .font(MuesliTheme.headline())
+                                .foregroundStyle(MuesliTheme.textPrimary)
+                            Text(statusText)
+                                .font(MuesliTheme.captionMedium())
+                                .foregroundStyle(captureTint)
+                        }
+
+                        Spacer()
+                    }
+
+                    MuesliInlineWaveformView(
+                        mode: isActiveRecording ? .level : .waiting,
+                        color: captureTint,
+                        level: isActiveRecording ? inputLevel : nil,
+                        isActive: isActiveRecording || isProcessingCurrentMeeting,
+                        barCount: 34
+                    )
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 58)
+                    .padding(.horizontal, MuesliTheme.spacing12)
+                    .padding(.vertical, MuesliTheme.spacing12)
+                    .muesliGlassSurface(cornerRadius: MuesliTheme.cornerMedium, tint: captureTint)
+
+                    if isActiveRecording {
+                        VStack(spacing: MuesliTheme.spacing8) {
+                            Button(action: onStopRecording) {
+                                Label("Stop Meeting", systemImage: "stop.fill")
+                                    .font(MuesliTheme.headline())
+                                    .frame(maxWidth: .infinity)
+                                    .frame(height: 48)
+                                    .foregroundStyle(.white)
+                                    .background(MuesliTheme.destructive)
+                                    .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+                                    .contentShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+                            }
+                            .buttonStyle(.plain)
+                            .accessibilityIdentifier("meetingDetail.stopButton")
+
+                            Button(role: .destructive, action: onDiscardRecording) {
+                                Label("Discard Meeting", systemImage: "xmark")
+                                    .font(MuesliTheme.captionMedium())
+                                    .foregroundStyle(MuesliTheme.destructive)
+                                    .frame(maxWidth: .infinity)
+                                    .frame(minHeight: 44)
+                                    .background(MuesliTheme.destructive.opacity(0.07))
+                                    .overlay(
+                                        RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall)
+                                            .strokeBorder(MuesliTheme.destructive.opacity(0.24), lineWidth: 1)
+                                    )
+                                    .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+                                    .contentShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+                            }
+                            .buttonStyle(.plain)
+                            .accessibilityIdentifier("meetingDetail.discardButton")
+                        }
+                    }
+                }
+                .padding(MuesliTheme.spacing16)
+            }
+        }
+    }
+
+    @ViewBuilder
     private var manualNotesSection: some View {
         MuesliSurface(cornerRadius: MuesliTheme.cornerLarge, tint: MuesliTheme.accent) {
             VStack(alignment: .leading, spacing: MuesliTheme.spacing12) {
@@ -923,7 +1035,7 @@ private struct MeetingSessionDetailView: View {
                         .background(MuesliTheme.accentSubtle)
                         .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall, style: .continuous))
 
-                    Text("Live Notes")
+                    Text("Manual Notes")
                         .font(MuesliTheme.title3())
                         .tracking(-0.15)
                         .foregroundStyle(MuesliTheme.textPrimary)
@@ -946,13 +1058,13 @@ private struct MeetingSessionDetailView: View {
                         .scrollContentBackground(.hidden)
                         .frame(minHeight: session.phase == .recording ? 220 : 140)
                         .padding(MuesliTheme.spacing8)
-                        .accessibilityLabel("Meeting live notes")
+                        .accessibilityLabel("Meeting manual notes")
                         .onChange(of: manualNotesDraft) { _, _ in
                             scheduleManualNotesSave()
                         }
 
                     if manualNotesDraft.isEmpty {
-                        Text("Start typing notes...")
+                        Text("Start typing meeting notes...")
                             .font(MuesliTheme.body())
                             .foregroundStyle(MuesliTheme.textTertiary)
                             .padding(.horizontal, MuesliTheme.spacing12)
@@ -973,7 +1085,7 @@ private struct MeetingSessionDetailView: View {
 
     @ViewBuilder
     private var retainedAudioSection: some View {
-        if session.hasRetainedAudio, let audioURL {
+        if shouldShowPostMeetingArtifacts, session.hasRetainedAudio, let audioURL {
             MuesliSurface(cornerRadius: MuesliTheme.cornerLarge) {
                 VStack(alignment: .leading, spacing: MuesliTheme.spacing12) {
                     HStack(alignment: .top, spacing: MuesliTheme.spacing12) {
@@ -1023,7 +1135,9 @@ private struct MeetingSessionDetailView: View {
 
     @ViewBuilder
     private var detailActions: some View {
-        if session.phase == .transcriptionQueued {
+        if isActiveRecording || isProcessingCurrentMeeting {
+            EmptyView()
+        } else if session.phase == .transcriptionQueued {
             Button(action: onTranscribe) {
                 Label("Transcribe Meeting", systemImage: "waveform.badge.magnifyingglass")
                     .font(MuesliTheme.headline())
@@ -1035,7 +1149,7 @@ private struct MeetingSessionDetailView: View {
                     .contentShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
             }
             .buttonStyle(.plain)
-        } else if let transcript {
+        } else if shouldShowPostMeetingArtifacts, let transcript {
             VStack(spacing: MuesliTheme.spacing8) {
                 Button {
                     onCopy(copyText(for: transcript), resolvedContent(for: transcript))
@@ -1073,26 +1187,28 @@ private struct MeetingSessionDetailView: View {
             }
         }
 
-        Button {
-            isConfirmingDelete = true
-        } label: {
-            Label("Delete Meeting", systemImage: "trash")
-            .font(MuesliTheme.headline())
-            .frame(maxWidth: .infinity)
-            .frame(height: 44)
-            .foregroundStyle(MuesliTheme.destructive)
-            .background(MuesliTheme.destructive.opacity(0.12))
-            .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
-            .contentShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+        if !isActiveRecording && !isProcessingCurrentMeeting {
+            Button {
+                isConfirmingDelete = true
+            } label: {
+                Label("Delete Meeting", systemImage: "trash")
+                .font(MuesliTheme.headline())
+                .frame(maxWidth: .infinity)
+                .frame(height: 44)
+                .foregroundStyle(MuesliTheme.destructive)
+                .background(MuesliTheme.destructive.opacity(0.12))
+                .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+                .contentShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+            }
+            .buttonStyle(.plain)
         }
-        .buttonStyle(.plain)
     }
 
     @ViewBuilder
     private var contentSection: some View {
         MuesliSurface(cornerRadius: MuesliTheme.cornerLarge) {
             VStack(alignment: .leading, spacing: MuesliTheme.spacing12) {
-                Text("Meeting Note")
+                Text(contentSectionTitle)
                     .font(MuesliTheme.title3())
                     .foregroundStyle(MuesliTheme.textPrimary)
 
@@ -1107,7 +1223,7 @@ private struct MeetingSessionDetailView: View {
                         .foregroundStyle(MuesliTheme.destructive)
                         .fixedSize(horizontal: false, vertical: true)
                 } else {
-                    Text(session.phase.description)
+                    Text(contentPlaceholder)
                         .font(MuesliTheme.body())
                         .foregroundStyle(MuesliTheme.textSecondary)
                         .fixedSize(horizontal: false, vertical: true)
@@ -1125,6 +1241,34 @@ private struct MeetingSessionDetailView: View {
             .padding(.vertical, MuesliTheme.spacing4)
             .background(MuesliTheme.surfacePrimary)
             .clipShape(Capsule())
+    }
+
+    private var captureTint: Color {
+        isActiveRecording ? MuesliTheme.recording : MuesliTheme.transcribing
+    }
+
+    private var shouldShowPostMeetingArtifacts: Bool {
+        !isActiveRecording && !isProcessingCurrentMeeting && session.phase != .recording && session.phase != .transcribing
+    }
+
+    private var contentSectionTitle: String {
+        if transcript?.summaryText?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false {
+            return "Generated Notes"
+        }
+        if isActiveRecording || isProcessingCurrentMeeting || transcript != nil {
+            return "Live Meeting Notes"
+        }
+        return "Meeting Notes"
+    }
+
+    private var contentPlaceholder: String {
+        if isActiveRecording {
+            return "Recording is in progress. Transcript and generated notes will appear here as the meeting is processed."
+        }
+        if isProcessingCurrentMeeting {
+            return "Processing meeting audio into transcript and notes."
+        }
+        return session.phase.description
     }
 
     private func resolvedContent(for transcript: Transcript) -> MeetingContentTab {

--- a/Muesli/MeetingsView.swift
+++ b/Muesli/MeetingsView.swift
@@ -166,11 +166,11 @@ struct MeetingsView: View {
 
     private var startMeetingPanel: some View {
         MeetingPanel(tint: statusColor, isProminent: coordinator.hasMeetingRecordingInProgress) {
-            VStack(alignment: .leading, spacing: 14) {
+            VStack(alignment: .leading, spacing: MuesliTheme.spacing12) {
                 HStack(alignment: .center, spacing: MuesliTheme.spacing12) {
-                    MeetingIconTile(systemImage: coordinator.hasMeetingRecordingInProgress ? "arrow.up.forward.square" : "mic.fill", tint: statusColor)
+                    MeetingIconTile(systemImage: coordinator.hasMeetingRecordingInProgress ? "waveform" : "mic.fill", tint: statusColor, size: 34)
 
-                    Text(coordinator.hasMeetingRecordingInProgress ? "Recording in progress" : "Start a new meeting")
+                    Text(coordinator.hasMeetingRecordingInProgress ? "Live meeting" : "Start a new meeting")
                         .font(MuesliTheme.headline())
                         .foregroundStyle(coordinator.hasMeetingRecordingInProgress ? statusColor : MuesliTheme.accent)
 
@@ -183,10 +183,10 @@ struct MeetingsView: View {
                             openMeeting(sessionID)
                         }
                     } label: {
-                        Label("Open Live Meeting", systemImage: "arrow.up.forward.square")
+                        Label("Return to Meeting", systemImage: "arrow.up.forward.square")
                             .font(MuesliTheme.headline())
                             .frame(maxWidth: .infinity)
-                            .frame(height: 48)
+                            .frame(height: 44)
                             .foregroundStyle(.white)
                             .background(statusColor)
                             .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
@@ -200,7 +200,7 @@ struct MeetingsView: View {
                         .foregroundStyle(MuesliTheme.textPrimary)
                         .padding(.horizontal, MuesliTheme.spacing12)
                         .frame(height: 44)
-                        .muesliGlassSurface(cornerRadius: MuesliTheme.cornerMedium)
+                        .meetingInputSurface()
                         .disabled(coordinator.isMeetingTranscribing)
 
                     meetingTemplatePicker
@@ -217,7 +217,7 @@ struct MeetingsView: View {
                         )
                         .font(MuesliTheme.headline())
                         .frame(maxWidth: .infinity)
-                        .frame(height: 48)
+                        .frame(height: 44)
                         .foregroundStyle(meetingPrimaryButtonTextColor)
                         .background(meetingPrimaryButtonBackground)
                         .overlay(meetingPrimaryButtonBorder)
@@ -250,9 +250,9 @@ struct MeetingsView: View {
         } label: {
             HStack(spacing: MuesliTheme.spacing12) {
                 Image(systemName: "doc.text.magnifyingglass")
-                    .font(.system(size: 16, weight: .semibold))
+                    .font(.system(size: 14, weight: .semibold))
                     .foregroundStyle(MuesliTheme.accent)
-                    .frame(width: 24)
+                    .frame(width: 20)
 
                 VStack(alignment: .leading, spacing: MuesliTheme.spacing4) {
                     Text(meetingTemplate.label)
@@ -272,7 +272,7 @@ struct MeetingsView: View {
                     .foregroundStyle(MuesliTheme.textTertiary)
             }
             .padding(MuesliTheme.spacing12)
-            .muesliGlassSurface(cornerRadius: MuesliTheme.cornerMedium, tint: MuesliTheme.accent)
+            .meetingInputSurface(tint: MuesliTheme.accent)
             .contentShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium, style: .continuous))
         }
         .buttonStyle(.plain)
@@ -284,7 +284,7 @@ struct MeetingsView: View {
         VStack(alignment: .leading, spacing: MuesliTheme.spacing12) {
             HStack(alignment: .firstTextBaseline) {
                 VStack(alignment: .leading, spacing: MuesliTheme.spacing4) {
-                    Text("Meeting Sessions")
+                    Text("Recent Meetings")
                         .font(MuesliTheme.title3())
                         .foregroundStyle(MuesliTheme.textPrimary)
                     Text(browserResultSummary)
@@ -636,13 +636,13 @@ private struct MeetingPanel<Content: View>: View {
 
     private var panelFill: Color {
         isProminent
-            ? (tint ?? MuesliTheme.accent).opacity(0.16)
-            : MuesliTheme.backgroundRaised.opacity(0.72)
+            ? MuesliTheme.backgroundRaised.opacity(0.84)
+            : MuesliTheme.backgroundRaised.opacity(0.64)
     }
 
     private var panelBorder: Color {
         isProminent
-            ? (tint ?? MuesliTheme.accent).opacity(0.42)
+            ? (tint ?? MuesliTheme.accent).opacity(0.38)
             : MuesliTheme.surfaceBorder
     }
 }
@@ -657,8 +657,28 @@ private struct MeetingIconTile: View {
             .font(.system(size: max(14, size * 0.42), weight: .semibold))
             .foregroundStyle(tint)
             .frame(width: size, height: size)
-            .background(tint.opacity(0.13))
+            .background(tint.opacity(0.09))
             .clipShape(RoundedRectangle(cornerRadius: min(10, size * 0.26), style: .continuous))
+    }
+}
+
+private struct MeetingInputSurfaceModifier: ViewModifier {
+    var tint: Color? = nil
+
+    func body(content: Content) -> some View {
+        content
+            .background(MuesliTheme.backgroundDeep.opacity(0.58))
+            .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium, style: .continuous))
+            .overlay(
+                RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium, style: .continuous)
+                    .strokeBorder((tint ?? MuesliTheme.surfaceBorder).opacity(tint == nil ? 1 : 0.24), lineWidth: 1)
+            )
+    }
+}
+
+private extension View {
+    func meetingInputSurface(tint: Color? = nil) -> some View {
+        modifier(MeetingInputSurfaceModifier(tint: tint))
     }
 }
 
@@ -685,7 +705,10 @@ private struct MeetingSessionRow: View {
     var body: some View {
         MeetingPanel(tint: session.phase.tint) {
             HStack(alignment: .center, spacing: MuesliTheme.spacing12) {
-                MeetingIconTile(systemImage: "person.2.wave.2", tint: session.phase.tint, size: 34)
+                Image(systemName: "person.2.wave.2")
+                    .font(.system(size: 17, weight: .semibold))
+                    .foregroundStyle(MuesliTheme.accent)
+                    .frame(width: 28)
 
                 VStack(alignment: .leading, spacing: MuesliTheme.spacing4) {
                     Text(session.title ?? session.kind.title)
@@ -704,7 +727,7 @@ private struct MeetingSessionRow: View {
 
                 Spacer(minLength: MuesliTheme.spacing8)
 
-                Text(session.phase.title)
+                Text(session.phase.compactTitle)
                     .font(MuesliTheme.captionMedium())
                     .foregroundStyle(session.phase.tint)
                     .lineLimit(1)
@@ -727,6 +750,12 @@ private struct MeetingSessionRow: View {
     }
 
     private var previewText: String {
+        if session.phase == .recording {
+            return "In progress"
+        }
+        if session.phase == .transcribing {
+            return "Creating transcript and notes"
+        }
         if let summary = transcript?.summaryText?.trimmingCharacters(in: .whitespacesAndNewlines), !summary.isEmpty {
             return summary.replacingOccurrences(of: "\n", with: " ")
         }
@@ -866,7 +895,7 @@ private struct MeetingSessionDetailView: View {
                         Circle()
                             .fill(session.phase.tint)
                             .frame(width: 6, height: 6)
-                        Text("\(session.phase.title) · \(session.createdAt.formatted(date: .abbreviated, time: .shortened))")
+                        Text(detailStatusLine)
                             .font(MuesliTheme.captionMedium())
                             .foregroundStyle(session.phase == .completed ? MuesliTheme.success : session.phase.tint)
                             .lineLimit(1)
@@ -914,38 +943,47 @@ private struct MeetingSessionDetailView: View {
             MeetingPanel(tint: captureTint, isProminent: isActiveRecording) {
                 VStack(alignment: .leading, spacing: MuesliTheme.spacing16) {
                     HStack(alignment: .center, spacing: MuesliTheme.spacing12) {
-                        ZStack {
-                            Circle()
-                                .fill(captureTint.opacity(0.16))
-                            Circle()
-                                .fill(captureTint)
-                                .frame(width: 12, height: 12)
-                                .opacity(isActiveRecording ? (recordingPulse ? 0.95 : 0.32) : 0.45)
-                                .animation(
-                                    isActiveRecording
-                                        ? .easeInOut(duration: 0.9).repeatForever(autoreverses: true)
-                                        : .default,
-                                    value: recordingPulse
-                                )
-                        }
-                        .frame(width: 42, height: 42)
-                        .onAppear {
-                            recordingPulse = isActiveRecording
-                        }
-                        .onChange(of: isActiveRecording) { _, isRecording in
-                            recordingPulse = isRecording
-                        }
+                        Circle()
+                            .fill(captureTint)
+                            .frame(width: 8, height: 8)
+                            .opacity(isActiveRecording ? (recordingPulse ? 0.95 : 0.32) : 0.55)
+                            .animation(
+                                isActiveRecording
+                                    ? .easeInOut(duration: 0.9).repeatForever(autoreverses: true)
+                                    : .default,
+                                value: recordingPulse
+                            )
+                            .onAppear {
+                                recordingPulse = isActiveRecording
+                            }
+                            .onChange(of: isActiveRecording) { _, isRecording in
+                                recordingPulse = isRecording
+                            }
 
                         VStack(alignment: .leading, spacing: MuesliTheme.spacing4) {
-                            Text(isActiveRecording ? "Recording" : "Processing")
+                            Text(isActiveRecording ? "Listening" : "Processing audio")
                                 .font(MuesliTheme.headline())
                                 .foregroundStyle(MuesliTheme.textPrimary)
-                            Text(statusText)
+                            Text(captureStatusCopy)
                                 .font(MuesliTheme.captionMedium())
-                                .foregroundStyle(captureTint)
+                                .foregroundStyle(MuesliTheme.textSecondary)
                         }
 
                         Spacer()
+
+                        if isActiveRecording {
+                            Button(action: onStopRecording) {
+                                Image(systemName: "stop.fill")
+                                    .font(.system(size: 14, weight: .bold))
+                                    .foregroundStyle(.white)
+                                    .frame(width: 42, height: 42)
+                                    .background(MuesliTheme.destructive.opacity(0.86))
+                                    .clipShape(Circle())
+                            }
+                            .buttonStyle(.plain)
+                            .accessibilityLabel("Stop meeting")
+                            .accessibilityIdentifier("meetingDetail.stopButton")
+                        }
                     }
 
                     MuesliInlineWaveformView(
@@ -967,37 +1005,22 @@ private struct MeetingSessionDetailView: View {
                     )
 
                     if isActiveRecording {
-                        VStack(spacing: MuesliTheme.spacing8) {
-                            Button(action: onStopRecording) {
-                                Label("Stop Meeting", systemImage: "stop.fill")
-                                    .font(MuesliTheme.headline())
-                                    .frame(maxWidth: .infinity)
-                                    .frame(height: 48)
-                                    .foregroundStyle(.white)
-                                    .background(MuesliTheme.destructive)
-                                    .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
-                                    .contentShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
-                            }
-                            .buttonStyle(.plain)
-                            .accessibilityIdentifier("meetingDetail.stopButton")
-
-                            Button(role: .destructive, action: onDiscardRecording) {
-                                Label("Discard Meeting", systemImage: "xmark")
-                                    .font(MuesliTheme.captionMedium())
-                                    .foregroundStyle(MuesliTheme.destructive)
-                                    .frame(maxWidth: .infinity)
-                                    .frame(minHeight: 44)
-                                    .background(MuesliTheme.destructive.opacity(0.07))
-                                    .overlay(
-                                        RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall)
-                                            .strokeBorder(MuesliTheme.destructive.opacity(0.24), lineWidth: 1)
-                                    )
-                                    .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
-                                    .contentShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
-                            }
-                            .buttonStyle(.plain)
-                            .accessibilityIdentifier("meetingDetail.discardButton")
+                        Button(role: .destructive, action: onDiscardRecording) {
+                            Label("Discard Meeting", systemImage: "trash")
+                                .font(MuesliTheme.headline())
+                                .foregroundStyle(MuesliTheme.destructive)
+                                .frame(maxWidth: .infinity)
+                                .frame(height: 44)
+                                .background(MuesliTheme.destructive.opacity(0.06))
+                                .overlay(
+                                    RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall)
+                                        .strokeBorder(MuesliTheme.destructive.opacity(0.32), lineWidth: 1)
+                                )
+                                .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+                                .contentShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
                         }
+                        .buttonStyle(.plain)
+                        .accessibilityIdentifier("meetingDetail.discardButton")
                     }
                 }
                 .padding(MuesliTheme.spacing16)
@@ -1292,6 +1315,20 @@ private struct MeetingSessionDetailView: View {
         isActiveRecording ? MuesliTheme.recording : MuesliTheme.transcribing
     }
 
+    private var detailStatusLine: String {
+        "\(session.phase.headerTitle) · \(session.createdAt.formatted(date: .abbreviated, time: .shortened))"
+    }
+
+    private var captureStatusCopy: String {
+        if isActiveRecording {
+            return "Audio is being captured locally"
+        }
+        if isProcessingCurrentMeeting {
+            return "Creating transcript and notes"
+        }
+        return statusText
+    }
+
     private var shouldShowPostMeetingArtifacts: Bool {
         !isActiveRecording && !isProcessingCurrentMeeting && session.phase != .recording && session.phase != .transcribing
     }
@@ -1312,17 +1349,17 @@ private struct MeetingSessionDetailView: View {
             return "Generated Notes"
         }
         if isActiveRecording || isProcessingCurrentMeeting || transcript != nil {
-            return "Live Meeting Notes"
+            return "Live Transcript"
         }
         return "Meeting Notes"
     }
 
     private var contentPlaceholder: String {
         if isActiveRecording {
-            return "Recording is in progress. Transcript and generated notes will appear here as the meeting is processed."
+            return "Transcript and generated notes will appear after the meeting is processed."
         }
         if isProcessingCurrentMeeting {
-            return "Processing meeting audio into transcript and notes."
+            return "Creating transcript and notes."
         }
         return session.phase.description
     }
@@ -2124,14 +2161,48 @@ private extension RecordingSessionPhase {
         }
     }
 
+    var compactTitle: String {
+        switch self {
+        case .recording:
+            "Live"
+        case .transcriptionQueued:
+            "Saved"
+        case .transcribing:
+            "Processing"
+        case .completed:
+            "Complete"
+        case .failed:
+            "Failed"
+        case .cancelled:
+            "Cancelled"
+        }
+    }
+
+    var headerTitle: String {
+        switch self {
+        case .recording:
+            "Live"
+        case .transcriptionQueued:
+            "Saved"
+        case .transcribing:
+            "Processing"
+        case .completed:
+            "Completed"
+        case .failed:
+            "Needs review"
+        case .cancelled:
+            "Cancelled"
+        }
+    }
+
     var description: String {
         switch self {
         case .recording:
-            "Recording is still active."
+            "In progress."
         case .transcriptionQueued:
             "Audio is saved locally and ready for delayed transcription."
         case .transcribing:
-            "Muesli is transcribing this recording locally."
+            "Creating transcript and notes."
         case .completed:
             "Transcript saved."
         case .failed:

--- a/Muesli/MeetingsView.swift
+++ b/Muesli/MeetingsView.swift
@@ -442,6 +442,7 @@ struct MeetingsView: View {
                     .overlay(Circle().strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1))
             }
             .buttonStyle(.plain)
+            .accessibilityLabel("Filter and sort meetings")
         }
     }
 
@@ -928,6 +929,7 @@ private struct MeetingSessionDetailView: View {
     @State private var manualNotesDraft = ""
     @State private var manualNotesSaveState: ManualNotesSaveState = .saved
     @State private var manualNotesSaveTask: Task<Void, Never>?
+    @State private var isLeavingAfterDestructiveAction = false
     @State private var recordingPulse = false
     @State private var isEditingCompletedManualNotes = false
 
@@ -976,6 +978,8 @@ private struct MeetingSessionDetailView: View {
             titleVisibility: .visible
         ) {
             Button("Delete Meeting", role: .destructive) {
+                isLeavingAfterDestructiveAction = true
+                manualNotesSaveTask?.cancel()
                 onDelete()
                 dismiss()
             }
@@ -1001,6 +1005,8 @@ private struct MeetingSessionDetailView: View {
             titleVisibility: .visible
         ) {
             Button("Discard Recording", role: .destructive) {
+                isLeavingAfterDestructiveAction = true
+                manualNotesSaveTask?.cancel()
                 onDiscardRecording()
             }
             Button("Cancel", role: .cancel) {}
@@ -1015,6 +1021,7 @@ private struct MeetingSessionDetailView: View {
             manualNotesDraft = newValue
         }
         .onDisappear {
+            guard !isLeavingAfterDestructiveAction else { return }
             flushPendingManualNotes()
         }
     }
@@ -1814,14 +1821,6 @@ private enum MeetingExportFormatter {
 }
 
 private extension RecordingSession {
-    var syncOrigin: SyncOrigin {
-        SyncOrigin.classify(
-            source: source,
-            engineIdentifier: engineIdentifier,
-            cloudRecordName: cloudRecordName
-        )
-    }
-
     var isFromMac: Bool {
         syncOrigin == .fromMac
     }

--- a/Muesli/MeetingsView.swift
+++ b/Muesli/MeetingsView.swift
@@ -513,25 +513,21 @@ private struct MeetingBrowserItem: Identifiable {
         .joined(separator: " ")
         .lowercased()
 
-        if let transcript {
-            copyText = Self.preferredCopyText(for: session, transcript: transcript)
-        } else {
-            copyText = session.errorMessage ?? session.phase.description
-        }
+        copyText = Self.preferredCopyText(for: session, transcript: transcript)
     }
 
-    private static func preferredCopyText(for session: RecordingSession, transcript: Transcript) -> String {
-        if let summary = transcript.summaryText?.trimmingCharacters(in: .whitespacesAndNewlines), !summary.isEmpty {
+    private static func preferredCopyText(for session: RecordingSession, transcript: Transcript?) -> String {
+        if let summary = transcript?.summaryText?.trimmingCharacters(in: .whitespacesAndNewlines), !summary.isEmpty {
             return summary
         }
         if let manualNotes = session.manualNotes?.trimmingCharacters(in: .whitespacesAndNewlines), !manualNotes.isEmpty {
             return manualNotes
         }
-        if let speakerTranscript = transcript.speakerTranscript?.trimmingCharacters(in: .whitespacesAndNewlines), !speakerTranscript.isEmpty {
+        if let speakerTranscript = transcript?.speakerTranscript?.trimmingCharacters(in: .whitespacesAndNewlines), !speakerTranscript.isEmpty {
             return speakerTranscript
         }
-        if !transcript.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            return transcript.text
+        if let text = transcript?.text, !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return text
         }
         return session.errorMessage ?? session.phase.description
     }
@@ -1435,18 +1431,20 @@ private struct MeetingSessionDetailView: View {
     }
 
     private func scheduleManualNotesSave() {
+        manualNotesSaveTask?.cancel()
         guard manualNotesDraft != (session.manualNotes ?? "") else {
             manualNotesSaveState = .saved
+            manualNotesSaveTask = nil
             return
         }
         manualNotesSaveState = .saving
-        manualNotesSaveTask?.cancel()
         let draft = manualNotesDraft
         manualNotesSaveTask = Task { @MainActor in
             try? await Task.sleep(nanoseconds: 650_000_000)
             guard !Task.isCancelled else { return }
             onManualNotesChange(draft)
             manualNotesSaveState = .saved
+            manualNotesSaveTask = nil
         }
     }
 

--- a/Muesli/MeetingsView.swift
+++ b/Muesli/MeetingsView.swift
@@ -247,7 +247,7 @@ struct MeetingsView: View {
                         .contentShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
                     }
                     .buttonStyle(.plain)
-                    .disabled(coordinator.isMeetingTranscribing)
+                    .disabled(isPrimaryMeetingActionDisabled)
                     .sensoryFeedback(.impact, trigger: coordinator.hasMeetingRecordingInProgress)
                     .accessibilityIdentifier("meetings.primaryButton")
 
@@ -537,6 +537,10 @@ struct MeetingsView: View {
     private var meetingPrimaryButtonBorder: some View {
         RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall, style: .continuous)
             .strokeBorder(.clear, lineWidth: 1)
+    }
+
+    private var isPrimaryMeetingActionDisabled: Bool {
+        coordinator.isMeetingTranscribing && !coordinator.hasMeetingRecordingInProgress
     }
 
     private func copyText(for session: RecordingSession) -> String {

--- a/Muesli/MeetingsView.swift
+++ b/Muesli/MeetingsView.swift
@@ -819,6 +819,7 @@ private struct MeetingSessionDetailView: View {
     @State private var sharePayload: MeetingSharePayload?
     @State private var isConfirmingDelete = false
     @State private var isConfirmingAudioDelete = false
+    @State private var isConfirmingDiscardRecording = false
     @State private var editedTitle: String?
     @State private var titleDraft = ""
     @State private var isEditingTitle = false
@@ -891,6 +892,18 @@ private struct MeetingSessionDetailView: View {
             Button("Cancel", role: .cancel) {}
         } message: {
             Text("This removes the saved meeting audio file. The transcript, summary, and manual notes stay in place.")
+        }
+        .confirmationDialog(
+            "Discard this meeting recording?",
+            isPresented: $isConfirmingDiscardRecording,
+            titleVisibility: .visible
+        ) {
+            Button("Discard Recording", role: .destructive) {
+                onDiscardRecording()
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("This deletes the in-progress audio recording and meeting notes from local history.")
         }
         .onAppear {
             manualNotesDraft = session.manualNotes ?? ""
@@ -997,7 +1010,9 @@ private struct MeetingSessionDetailView: View {
                         Spacer()
 
                         if isActiveRecording {
-                            Button(role: .destructive, action: onDiscardRecording) {
+                            Button(role: .destructive) {
+                                isConfirmingDiscardRecording = true
+                            } label: {
                                 Image(systemName: "trash")
                                     .font(.system(size: 15, weight: .semibold))
                                     .foregroundStyle(MuesliTheme.destructive)

--- a/Muesli/MeetingsView.swift
+++ b/Muesli/MeetingsView.swift
@@ -1815,7 +1815,11 @@ private enum MeetingExportFormatter {
 
 private extension RecordingSession {
     var syncOrigin: SyncOrigin {
-        SyncOrigin.classify(source: source, engineIdentifier: engineIdentifier)
+        SyncOrigin.classify(
+            source: source,
+            engineIdentifier: engineIdentifier,
+            cloudRecordName: cloudRecordName
+        )
     }
 
     var isFromMac: Bool {

--- a/Muesli/MeetingsView.swift
+++ b/Muesli/MeetingsView.swift
@@ -1814,22 +1814,12 @@ private enum MeetingExportFormatter {
 }
 
 private extension RecordingSession {
-    var normalizedSource: String? {
-        let normalized = source?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-        return normalized?.isEmpty == false ? normalized : nil
+    var syncOrigin: SyncOrigin {
+        SyncOrigin.classify(source: source, engineIdentifier: engineIdentifier)
     }
 
     var isFromMac: Bool {
-        if let normalizedSource {
-            switch normalizedSource {
-            case "ios", "iphone", "app", "keyboard":
-                return false
-            default:
-                return true
-            }
-        }
-
-        return engineIdentifier?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "icloud"
+        syncOrigin == .fromMac
     }
 
     var isFromThisIPhone: Bool {

--- a/Muesli/MeetingsView.swift
+++ b/Muesli/MeetingsView.swift
@@ -1814,12 +1814,22 @@ private enum MeetingExportFormatter {
 }
 
 private extension RecordingSession {
-    var normalizedSource: String {
-        source?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() ?? ""
+    var normalizedSource: String? {
+        let normalized = source?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return normalized?.isEmpty == false ? normalized : nil
     }
 
     var isFromMac: Bool {
-        normalizedSource.contains("mac")
+        if let normalizedSource {
+            switch normalizedSource {
+            case "ios", "iphone", "app", "keyboard":
+                return false
+            default:
+                return true
+            }
+        }
+
+        return engineIdentifier?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "icloud"
     }
 
     var isFromThisIPhone: Bool {

--- a/Muesli/MeetingsView.swift
+++ b/Muesli/MeetingsView.swift
@@ -26,25 +26,12 @@ struct MeetingsView: View {
             }
     }
 
-    private var filteredMeetingSessions: [RecordingSession] {
-        let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-        return meetingSessions.filter { session in
-            guard selectedFilter.includes(session) else { return false }
-            guard !query.isEmpty else { return true }
-            let transcript = coordinator.transcript(for: session)
-            let haystack = [
-                session.title ?? "",
-                session.phase.title,
-                session.sourceDisplayName,
-                session.manualNotes ?? "",
-                transcript?.summaryText ?? "",
-                transcript?.speakerTranscript ?? "",
-                transcript?.text ?? "",
-                session.errorMessage ?? ""
-            ]
-            .joined(separator: " ")
-            .lowercased()
-            return haystack.contains(query)
+    private var meetingBrowserItems: [MeetingBrowserItem] {
+        meetingSessions.map { session in
+            MeetingBrowserItem(
+                session: session,
+                transcript: coordinator.transcript(for: session)
+            )
         }
     }
 
@@ -52,12 +39,21 @@ struct MeetingsView: View {
         MeetingTemplatePreset(rawValue: selectedMeetingTemplate) ?? .general
     }
 
-    private var browserResultSummary: String {
+    private func filteredMeetingItems(from items: [MeetingBrowserItem]) -> [MeetingBrowserItem] {
+        let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return items.filter { item in
+            guard selectedFilter.includes(item.session) else { return false }
+            guard !query.isEmpty else { return true }
+            return item.searchableText.contains(query)
+        }
+    }
+
+    private func browserResultSummary(filteredCount: Int) -> String {
         guard !meetingSessions.isEmpty else { return "No saved meetings" }
-        if filteredMeetingSessions.count == meetingSessions.count {
+        if filteredCount == meetingSessions.count {
             return "\(meetingSessions.count) saved"
         }
-        return "\(filteredMeetingSessions.count) of \(meetingSessions.count)"
+        return "\(filteredCount) of \(meetingSessions.count)"
     }
 
     var body: some View {
@@ -286,13 +282,15 @@ struct MeetingsView: View {
 
     @ViewBuilder
     private var sessionsSection: some View {
+        let browserItems = filteredMeetingItems(from: meetingBrowserItems)
+
         VStack(alignment: .leading, spacing: MuesliTheme.spacing12) {
             HStack(alignment: .firstTextBaseline) {
                 VStack(alignment: .leading, spacing: MuesliTheme.spacing4) {
                     Text("Recent Meetings")
                         .font(MuesliTheme.title3())
                         .foregroundStyle(MuesliTheme.textPrimary)
-                    Text(browserResultSummary)
+                    Text(browserResultSummary(filteredCount: browserItems.count))
                         .font(MuesliTheme.caption())
                         .foregroundStyle(MuesliTheme.textTertiary)
                 }
@@ -310,17 +308,17 @@ struct MeetingsView: View {
 
             if meetingSessions.isEmpty {
                 emptyState
-            } else if filteredMeetingSessions.isEmpty {
+            } else if browserItems.isEmpty {
                 emptySearchState
             } else {
                 LazyVStack(spacing: MuesliTheme.spacing12) {
-                    ForEach(filteredMeetingSessions) { session in
+                    ForEach(browserItems) { item in
                         MuesliSwipeActionRow(
                             leadingAction: .init(
                                 title: "Delete",
                                 systemImage: "trash",
                                 tint: MuesliTheme.destructive,
-                                perform: { sessionPendingDelete = session }
+                                perform: { sessionPendingDelete = item.session }
                             ),
                             trailingAction: .init(
                                 title: "Copy",
@@ -328,16 +326,16 @@ struct MeetingsView: View {
                                 tint: MuesliTheme.success,
                                 perform: {
                                     coordinator.copyText(
-                                        copyText(for: session),
+                                        item.copyText,
                                         telemetryName: "meeting_row_copied"
                                     )
                                 }
                             )
                         ) {
-                            NavigationLink(value: session.id) {
+                            NavigationLink(value: item.session.id) {
                                 MeetingSessionRow(
-                                    session: session,
-                                    transcript: coordinator.transcript(for: session)
+                                    session: item.session,
+                                    transcript: item.transcript
                                 )
                             }
                             .buttonStyle(.plain)
@@ -489,11 +487,40 @@ struct MeetingsView: View {
         navigationPath.append(sessionID)
     }
 
-    private func copyText(for session: RecordingSession) -> String {
-        guard let transcript = coordinator.transcript(for: session) else {
-            return session.errorMessage ?? session.phase.description
-        }
+}
 
+private struct MeetingBrowserItem: Identifiable {
+    let session: RecordingSession
+    let transcript: Transcript?
+    let searchableText: String
+    let copyText: String
+
+    var id: UUID { session.id }
+
+    init(session: RecordingSession, transcript: Transcript?) {
+        self.session = session
+        self.transcript = transcript
+        searchableText = [
+            session.title ?? "",
+            session.phase.title,
+            session.sourceDisplayName,
+            session.manualNotes ?? "",
+            transcript?.summaryText ?? "",
+            transcript?.speakerTranscript ?? "",
+            transcript?.text ?? "",
+            session.errorMessage ?? ""
+        ]
+        .joined(separator: " ")
+        .lowercased()
+
+        if let transcript {
+            copyText = Self.preferredCopyText(for: session, transcript: transcript)
+        } else {
+            copyText = session.errorMessage ?? session.phase.description
+        }
+    }
+
+    private static func preferredCopyText(for session: RecordingSession, transcript: Transcript) -> String {
         if let summary = transcript.summaryText?.trimmingCharacters(in: .whitespacesAndNewlines), !summary.isEmpty {
             return summary
         }
@@ -864,8 +891,7 @@ private struct MeetingSessionDetailView: View {
             manualNotesDraft = newValue
         }
         .onDisappear {
-            manualNotesSaveTask?.cancel()
-            persistManualNotesIfChanged()
+            flushPendingManualNotes()
         }
     }
 
@@ -999,7 +1025,10 @@ private struct MeetingSessionDetailView: View {
                     )
 
                     if isActiveRecording {
-                        Button(action: onStopRecording) {
+                        Button {
+                            flushPendingManualNotes()
+                            onStopRecording()
+                        } label: {
                             Label("Stop Meeting", systemImage: "stop.fill")
                                 .font(MuesliTheme.headline())
                                 .foregroundStyle(.white)
@@ -1045,7 +1074,7 @@ private struct MeetingSessionDetailView: View {
         if isCompletedMeeting {
             Button {
                 if isEditingCompletedManualNotes {
-                    persistManualNotesIfChanged()
+                    flushPendingManualNotes()
                 }
                 isEditingCompletedManualNotes.toggle()
             } label: {
@@ -1404,6 +1433,11 @@ private struct MeetingSessionDetailView: View {
             onManualNotesChange(draft)
             manualNotesSaveState = .saved
         }
+    }
+
+    private func flushPendingManualNotes() {
+        manualNotesSaveTask?.cancel()
+        persistManualNotesIfChanged()
     }
 
     private func persistManualNotesIfChanged() {

--- a/Muesli/MeetingsView.swift
+++ b/Muesli/MeetingsView.swift
@@ -140,63 +140,41 @@ struct MeetingsView: View {
     }
 
     private var header: some View {
-        VStack(alignment: .leading, spacing: MuesliTheme.spacing8) {
-            Text("MEETINGS")
-                .font(MuesliTheme.captionMedium())
-                .tracking(1.4)
-                .foregroundStyle(MuesliTheme.textTertiary)
+        VStack(alignment: .leading, spacing: MuesliTheme.spacing12) {
+            HStack(spacing: MuesliTheme.spacing8) {
+                MuesliMiniLogoMark()
+                    .frame(width: 26, height: 26)
+                    .clipShape(RoundedRectangle(cornerRadius: 7, style: .continuous))
+                Text("muesli")
+                    .font(MuesliTheme.headline())
+                    .foregroundStyle(MuesliTheme.textPrimary)
+            }
 
-            Text("Record, write, review")
-                .font(.system(.largeTitle, design: .default, weight: .bold))
-                .tracking(-0.7)
-                .foregroundStyle(MuesliTheme.textPrimary)
-                .lineLimit(2)
-                .minimumScaleFactor(0.82)
+            VStack(alignment: .leading, spacing: MuesliTheme.spacing4) {
+                Text("Meetings")
+                    .font(.system(.largeTitle, design: .default, weight: .bold))
+                    .foregroundStyle(MuesliTheme.textPrimary)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.86)
 
-            Text("Local-first meeting capture with notes that sync across Muesli.")
-                .font(MuesliTheme.callout())
-                .foregroundStyle(MuesliTheme.textSecondary)
-                .fixedSize(horizontal: false, vertical: true)
+                Text("Record, write, review.")
+                    .font(MuesliTheme.callout())
+                    .foregroundStyle(MuesliTheme.textSecondary)
+            }
         }
     }
 
     private var startMeetingPanel: some View {
-        MuesliSurface(
-            cornerRadius: MuesliTheme.cornerLarge,
-            tint: statusColor,
-            isInteractive: true
-        ) {
-            VStack(alignment: .leading, spacing: MuesliTheme.spacing20) {
+        MeetingPanel(tint: statusColor, isProminent: coordinator.hasMeetingRecordingInProgress) {
+            VStack(alignment: .leading, spacing: 14) {
                 HStack(alignment: .center, spacing: MuesliTheme.spacing12) {
-                    ZStack {
-                        RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium, style: .continuous)
-                            .fill(statusColor.opacity(0.14))
-                        Image(systemName: coordinator.hasMeetingRecordingInProgress ? "arrow.up.forward.square" : "mic.fill")
-                            .font(.system(size: 18, weight: .bold))
-                            .foregroundStyle(statusColor)
-                    }
-                    .frame(width: 48, height: 48)
+                    MeetingIconTile(systemImage: coordinator.hasMeetingRecordingInProgress ? "arrow.up.forward.square" : "mic.fill", tint: statusColor)
 
-                    VStack(alignment: .leading, spacing: MuesliTheme.spacing4) {
-                        Text("Recorder")
-                            .font(MuesliTheme.title3())
-                            .tracking(-0.25)
-                            .foregroundStyle(MuesliTheme.textPrimary)
-                        Text(coordinator.hasMeetingRecordingInProgress ? "Live meeting open in detail" : coordinator.effectiveMeetingStatusText)
-                            .font(MuesliTheme.captionMedium())
-                            .foregroundStyle(statusColor)
-                    }
+                    Text(coordinator.hasMeetingRecordingInProgress ? "Recording in progress" : "Start a new meeting")
+                        .font(MuesliTheme.headline())
+                        .foregroundStyle(coordinator.hasMeetingRecordingInProgress ? statusColor : MuesliTheme.accent)
 
-                    Spacer()
-
-                    Text(coordinator.hasMeetingRecordingInProgress ? "LIVE" : "LOCAL")
-                        .font(MuesliTheme.captionMedium())
-                        .tracking(1.1)
-                        .foregroundStyle(statusColor)
-                        .padding(.horizontal, MuesliTheme.spacing12)
-                        .frame(height: 28)
-                        .background(statusColor.opacity(0.12))
-                        .clipShape(Capsule())
+                    Spacer(minLength: MuesliTheme.spacing8)
                 }
 
                 if coordinator.hasMeetingRecordingInProgress {
@@ -252,7 +230,7 @@ struct MeetingsView: View {
                     .accessibilityIdentifier("meetings.primaryButton")
                 }
             }
-            .padding(MuesliTheme.spacing20)
+            .padding(MuesliTheme.spacing16)
         }
         .accessibilityIdentifier("meetings.startMeetingPanel")
     }
@@ -367,86 +345,65 @@ struct MeetingsView: View {
     }
 
     private var browserControls: some View {
-        MuesliSurface(cornerRadius: MuesliTheme.cornerLarge, tint: MuesliTheme.accent) {
-            VStack(spacing: MuesliTheme.spacing12) {
-                HStack(spacing: MuesliTheme.spacing8) {
-                    Image(systemName: "magnifyingglass")
-                        .font(.system(size: 15, weight: .semibold))
-                        .foregroundStyle(MuesliTheme.textTertiary)
-                    TextField("Search meetings", text: $searchText)
-                        .font(MuesliTheme.body())
-                        .textInputAutocapitalization(.never)
-                        .autocorrectionDisabled()
-                        .foregroundStyle(MuesliTheme.textPrimary)
-                    if !searchText.isEmpty {
-                        Button {
-                            searchText = ""
-                        } label: {
-                            Image(systemName: "xmark.circle.fill")
-                                .font(.system(size: 16, weight: .semibold))
-                                .foregroundStyle(MuesliTheme.textTertiary)
-                        }
-                        .buttonStyle(.plain)
-                        .accessibilityLabel("Clear meeting search")
+        HStack(spacing: MuesliTheme.spacing8) {
+            HStack(spacing: MuesliTheme.spacing8) {
+                Image(systemName: "magnifyingglass")
+                    .font(.system(size: 15, weight: .semibold))
+                    .foregroundStyle(MuesliTheme.textTertiary)
+                TextField("Search meetings", text: $searchText)
+                    .font(MuesliTheme.body())
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled()
+                    .foregroundStyle(MuesliTheme.textPrimary)
+                if !searchText.isEmpty {
+                    Button {
+                        searchText = ""
+                    } label: {
+                        Image(systemName: "xmark.circle.fill")
+                            .font(.system(size: 16, weight: .semibold))
+                            .foregroundStyle(MuesliTheme.textTertiary)
                     }
-                }
-                .padding(.horizontal, MuesliTheme.spacing12)
-                .frame(height: 42)
-                .background(MuesliTheme.backgroundRaised.opacity(0.55))
-                .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium, style: .continuous))
-                .overlay(
-                    RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium, style: .continuous)
-                        .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
-                )
-
-                ScrollView(.horizontal, showsIndicators: false) {
-                    HStack(spacing: MuesliTheme.spacing8) {
-                        ForEach(MeetingBrowserFilter.allCases) { filter in
-                            Button {
-                                selectedFilter = filter
-                            } label: {
-                                Label(filter.label, systemImage: filter.systemImage)
-                                    .font(MuesliTheme.captionMedium())
-                                    .foregroundStyle(selectedFilter == filter ? MuesliTheme.accent : MuesliTheme.textSecondary)
-                                    .padding(.horizontal, MuesliTheme.spacing12)
-                                    .frame(height: 34)
-                                    .background(selectedFilter == filter ? MuesliTheme.accentSubtle : MuesliTheme.surfacePrimary.opacity(0.72))
-                                    .overlay(
-                                        Capsule()
-                                            .strokeBorder(selectedFilter == filter ? MuesliTheme.accent.opacity(0.32) : MuesliTheme.surfaceBorder, lineWidth: 1)
-                                    )
-                                    .clipShape(Capsule())
-                            }
-                            .buttonStyle(.plain)
-                        }
-
-                        Menu {
-                            ForEach(MeetingSortOrder.allCases) { sort in
-                                Button {
-                                    selectedSort = sort
-                                } label: {
-                                    Label(sort.label, systemImage: selectedSort == sort ? "checkmark" : sort.systemImage)
-                                }
-                            }
-                        } label: {
-                            Label(selectedSort.label, systemImage: "arrow.up.arrow.down")
-                                .font(MuesliTheme.captionMedium())
-                                .foregroundStyle(MuesliTheme.textSecondary)
-                                .padding(.horizontal, MuesliTheme.spacing12)
-                                .frame(height: 34)
-                                .background(MuesliTheme.surfacePrimary.opacity(0.72))
-                                .overlay(
-                                    Capsule()
-                                        .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
-                                )
-                                .clipShape(Capsule())
-                        }
-                        .buttonStyle(.plain)
-                    }
-                    .padding(.vertical, 2)
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("Clear meeting search")
                 }
             }
-            .padding(MuesliTheme.spacing12)
+            .padding(.horizontal, MuesliTheme.spacing12)
+            .frame(height: 44)
+            .background(MuesliTheme.backgroundRaised.opacity(0.72))
+            .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium, style: .continuous))
+            .overlay(
+                RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium, style: .continuous)
+                    .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
+            )
+
+            Menu {
+                ForEach(MeetingBrowserFilter.allCases) { filter in
+                    Button {
+                        selectedFilter = filter
+                    } label: {
+                        Label(filter.label, systemImage: selectedFilter == filter ? "checkmark" : filter.systemImage)
+                    }
+                }
+
+                Divider()
+
+                ForEach(MeetingSortOrder.allCases) { sort in
+                    Button {
+                        selectedSort = sort
+                    } label: {
+                        Label(sort.label, systemImage: selectedSort == sort ? "checkmark" : sort.systemImage)
+                    }
+                }
+            } label: {
+                Image(systemName: "line.3.horizontal.decrease")
+                    .font(.system(size: 16, weight: .semibold))
+                    .foregroundStyle(MuesliTheme.textPrimary)
+                    .frame(width: 44, height: 44)
+                    .background(MuesliTheme.backgroundRaised.opacity(0.72))
+                    .clipShape(Circle())
+                    .overlay(Circle().strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1))
+            }
+            .buttonStyle(.plain)
         }
     }
 
@@ -649,79 +606,124 @@ private struct MeetingRowBadge: View {
     }
 }
 
+private struct MeetingPanel<Content: View>: View {
+    var tint: Color? = nil
+    var isProminent = false
+    @ViewBuilder var content: Content
+
+    init(
+        tint: Color? = nil,
+        isProminent: Bool = false,
+        @ViewBuilder content: () -> Content
+    ) {
+        self.tint = tint
+        self.isProminent = isProminent
+        self.content = content()
+    }
+
+    var body: some View {
+        content
+            .background {
+                RoundedRectangle(cornerRadius: MuesliTheme.cornerLarge, style: .continuous)
+                    .fill(panelFill)
+            }
+            .overlay(
+                RoundedRectangle(cornerRadius: MuesliTheme.cornerLarge, style: .continuous)
+                    .strokeBorder(panelBorder, lineWidth: 1)
+            )
+            .shadow(color: MuesliTheme.glassShadow.opacity(isProminent ? 0.9 : 0.45), radius: isProminent ? 14 : 8, x: 0, y: isProminent ? 8 : 4)
+    }
+
+    private var panelFill: Color {
+        isProminent
+            ? (tint ?? MuesliTheme.accent).opacity(0.16)
+            : MuesliTheme.backgroundRaised.opacity(0.72)
+    }
+
+    private var panelBorder: Color {
+        isProminent
+            ? (tint ?? MuesliTheme.accent).opacity(0.42)
+            : MuesliTheme.surfaceBorder
+    }
+}
+
+private struct MeetingIconTile: View {
+    let systemImage: String
+    var tint: Color = MuesliTheme.accent
+    var size: CGFloat = 36
+
+    var body: some View {
+        Image(systemName: systemImage)
+            .font(.system(size: max(14, size * 0.42), weight: .semibold))
+            .foregroundStyle(tint)
+            .frame(width: size, height: size)
+            .background(tint.opacity(0.13))
+            .clipShape(RoundedRectangle(cornerRadius: min(10, size * 0.26), style: .continuous))
+    }
+}
+
+private struct MuesliMiniLogoMark: View {
+    private let bars: [CGFloat] = [0.40, 0.62, 0.86, 0.70, 0.48, 0.78, 0.92, 0.58]
+
+    var body: some View {
+        HStack(alignment: .center, spacing: 1.5) {
+            ForEach(Array(bars.enumerated()), id: \.offset) { _, height in
+                Capsule()
+                    .fill(MuesliTheme.brandBlue)
+                    .frame(width: 2, height: 18 * height)
+            }
+        }
+        .frame(width: 26, height: 26)
+        .background(MuesliTheme.backgroundRaised)
+    }
+}
+
 private struct MeetingSessionRow: View {
     let session: RecordingSession
     let transcript: Transcript?
 
     var body: some View {
-        MuesliSurface(cornerRadius: MuesliTheme.cornerLarge, tint: session.phase.tint, isInteractive: true) {
-            HStack(alignment: .top, spacing: MuesliTheme.spacing12) {
-                RoundedRectangle(cornerRadius: 2, style: .continuous)
-                    .fill(session.phase.tint)
-                    .frame(width: 3, height: 76)
-                    .opacity(0.85)
+        MeetingPanel(tint: session.phase.tint) {
+            HStack(alignment: .center, spacing: MuesliTheme.spacing12) {
+                MeetingIconTile(systemImage: "person.2.wave.2", tint: session.phase.tint, size: 34)
 
-                VStack(alignment: .leading, spacing: MuesliTheme.spacing12) {
-                    HStack(alignment: .top, spacing: MuesliTheme.spacing12) {
-                        VStack(alignment: .leading, spacing: MuesliTheme.spacing4) {
-                            Text(session.title ?? session.kind.title)
-                                .font(MuesliTheme.headline())
-                                .foregroundStyle(MuesliTheme.textPrimary)
-                                .lineLimit(2)
-                            Text(session.createdAt, formatter: Self.dateFormatter)
-                                .font(MuesliTheme.captionMedium())
-                                .foregroundStyle(MuesliTheme.textSecondary)
-                        }
-
-                        Spacer()
-
-                        Image(systemName: "chevron.right")
-                            .font(.system(size: 14, weight: .semibold))
-                            .foregroundStyle(MuesliTheme.textTertiary)
-                            .frame(width: 30, height: 30)
-                            .background(MuesliTheme.surfacePrimary.opacity(0.70))
-                            .clipShape(Circle())
-                    }
-
-                    ScrollView(.horizontal, showsIndicators: false) {
-                        HStack(spacing: MuesliTheme.spacing8) {
-                            MeetingRowBadge(
-                                title: session.phase.title,
-                                systemImage: session.phase.systemImage,
-                                tint: session.phase.tint
-                            )
-                            MeetingRowBadge(
-                                title: session.sourceDisplayName,
-                                systemImage: session.sourceSystemImage,
-                                tint: MuesliTheme.accent
-                            )
-                            if session.hasRetainedAudio {
-                                MeetingRowBadge(
-                                    title: "Audio",
-                                    systemImage: "waveform.path.ecg.rectangle",
-                                    tint: MuesliTheme.syncGreen
-                                )
-                            }
-                            if let transcript, transcript.diarizationState == .completed {
-                                MeetingRowBadge(
-                                    title: "Speakers",
-                                    systemImage: "person.2.wave.2",
-                                    tint: MuesliTheme.textSecondary
-                                )
-                            }
-                        }
-                    }
-
+                VStack(alignment: .leading, spacing: MuesliTheme.spacing4) {
+                    Text(session.title ?? session.kind.title)
+                        .font(MuesliTheme.headline())
+                        .foregroundStyle(MuesliTheme.textPrimary)
+                        .lineLimit(1)
+                    Text(rowSubtitle)
+                        .font(MuesliTheme.caption())
+                        .foregroundStyle(MuesliTheme.textSecondary)
+                        .lineLimit(1)
                     Text(previewText)
-                        .font(MuesliTheme.body())
+                        .font(MuesliTheme.caption())
                         .foregroundStyle(previewColor)
-                        .lineLimit(3)
-                        .fixedSize(horizontal: false, vertical: true)
-                        .padding(.top, MuesliTheme.spacing4)
+                        .lineLimit(1)
                 }
+
+                Spacer(minLength: MuesliTheme.spacing8)
+
+                Text(session.phase.title)
+                    .font(MuesliTheme.captionMedium())
+                    .foregroundStyle(session.phase.tint)
+                    .lineLimit(1)
+                    .padding(.horizontal, MuesliTheme.spacing8)
+                    .frame(height: 26)
+                    .background(session.phase.tint.opacity(0.12))
+                    .clipShape(Capsule())
+
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(MuesliTheme.textTertiary)
             }
-            .padding(MuesliTheme.spacing16)
+            .padding(.horizontal, MuesliTheme.spacing16)
+            .padding(.vertical, MuesliTheme.spacing12)
         }
+    }
+
+    private var rowSubtitle: String {
+        "\(session.createdAt.formatted(date: .abbreviated, time: .shortened)) · \(session.sourceDisplayName)"
     }
 
     private var previewText: String {
@@ -849,77 +851,67 @@ private struct MeetingSessionDetailView: View {
     }
 
     private var detailHeader: some View {
-        MuesliSurface(cornerRadius: MuesliTheme.cornerLarge) {
-            VStack(alignment: .leading, spacing: MuesliTheme.spacing12) {
-                HStack(alignment: .top, spacing: MuesliTheme.spacing12) {
-                    Image(systemName: "person.2.wave.2")
-                        .font(.system(size: 20, weight: .semibold))
-                        .foregroundStyle(session.phase.tint)
-                        .frame(width: 28)
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(alignment: .center, spacing: 10) {
+                MeetingIconTile(systemImage: "person.2.wave.2", tint: session.phase.tint, size: 30)
 
-                    VStack(alignment: .leading, spacing: MuesliTheme.spacing4) {
-                        HStack(alignment: .firstTextBaseline, spacing: MuesliTheme.spacing8) {
-                            Text(displayTitle)
-                                .font(MuesliTheme.title3())
-                                .foregroundStyle(MuesliTheme.textPrimary)
-                                .fixedSize(horizontal: false, vertical: true)
+                VStack(alignment: .leading, spacing: MuesliTheme.spacing4) {
+                    Text(displayTitle)
+                        .font(MuesliTheme.title3())
+                        .foregroundStyle(MuesliTheme.textPrimary)
+                        .lineLimit(2)
+                        .minimumScaleFactor(0.86)
 
-                            Button {
-                                titleDraft = displayTitle
-                                isEditingTitle = true
-                            } label: {
-                                Image(systemName: "pencil")
-                                    .font(.system(size: 14, weight: .semibold))
-                                    .foregroundStyle(MuesliTheme.accent)
-                                    .frame(width: 44, height: 44)
-                                    .background(MuesliTheme.accentSubtle)
-                                    .clipShape(Circle())
-                                    .contentShape(Circle())
-                            }
-                            .buttonStyle(.plain)
-                            .accessibilityLabel("Edit meeting title")
-                        }
-                        Text(session.createdAt, formatter: MeetingSessionRow.dateFormatter)
+                    HStack(spacing: 6) {
+                        Circle()
+                            .fill(session.phase.tint)
+                            .frame(width: 6, height: 6)
+                        Text("\(session.phase.title) · \(session.createdAt.formatted(date: .abbreviated, time: .shortened))")
                             .font(MuesliTheme.captionMedium())
-                            .foregroundStyle(MuesliTheme.textSecondary)
+                            .foregroundStyle(session.phase == .completed ? MuesliTheme.success : session.phase.tint)
+                            .lineLimit(1)
                     }
-
-                    Spacer()
-
-                    Text(session.phase.title)
-                        .font(MuesliTheme.captionMedium())
-                        .foregroundStyle(session.phase.tint)
-                        .padding(.horizontal, MuesliTheme.spacing8)
-                        .padding(.vertical, MuesliTheme.spacing4)
-                        .background(session.phase.tint.opacity(0.12))
-                        .clipShape(Capsule())
                 }
 
+                Spacer(minLength: MuesliTheme.spacing8)
+
+                Button {
+                    titleDraft = displayTitle
+                    isEditingTitle = true
+                } label: {
+                    Image(systemName: "pencil")
+                        .font(.system(size: 14, weight: .semibold))
+                        .foregroundStyle(MuesliTheme.accent)
+                        .frame(width: 38, height: 38)
+                        .background(MuesliTheme.surfacePrimary.opacity(0.74))
+                        .clipShape(Circle())
+                        .contentShape(Circle())
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Edit meeting title")
+            }
+
+            ScrollView(.horizontal, showsIndicators: false) {
                 HStack(spacing: MuesliTheme.spacing8) {
                     detailBadge(session.sourceDisplayName, systemImage: session.sourceSystemImage)
                     if shouldShowPostMeetingArtifacts, session.hasRetainedAudio {
-                        detailBadge("Audio saved", systemImage: "waveform.path.ecg.rectangle")
+                        detailBadge("Audio", systemImage: "waveform.path.ecg.rectangle")
                     }
                     if transcript?.diarizationState == .completed {
-                        detailBadge("Diarized", systemImage: "person.2.wave.2")
+                        detailBadge("Speakers", systemImage: "person.2.wave.2")
                     }
                     if transcript?.summaryState == .completed {
                         detailBadge("Notes", systemImage: "sparkles")
                     }
                 }
             }
-            .padding(MuesliTheme.spacing16)
         }
     }
 
     @ViewBuilder
     private var captureStatusSection: some View {
         if isActiveRecording || isProcessingCurrentMeeting {
-            MuesliSurface(
-                cornerRadius: MuesliTheme.cornerLarge,
-                tint: captureTint,
-                isInteractive: true
-            ) {
+            MeetingPanel(tint: captureTint, isProminent: isActiveRecording) {
                 VStack(alignment: .leading, spacing: MuesliTheme.spacing16) {
                     HStack(alignment: .center, spacing: MuesliTheme.spacing12) {
                         ZStack {
@@ -967,7 +959,12 @@ private struct MeetingSessionDetailView: View {
                     .frame(height: 58)
                     .padding(.horizontal, MuesliTheme.spacing12)
                     .padding(.vertical, MuesliTheme.spacing12)
-                    .muesliGlassSurface(cornerRadius: MuesliTheme.cornerMedium, tint: captureTint)
+                    .background(MuesliTheme.backgroundRaised.opacity(0.52))
+                    .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium, style: .continuous))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium, style: .continuous)
+                            .strokeBorder(captureTint.opacity(0.18), lineWidth: 1)
+                    )
 
                     if isActiveRecording {
                         VStack(spacing: MuesliTheme.spacing8) {
@@ -1010,19 +1007,13 @@ private struct MeetingSessionDetailView: View {
 
     @ViewBuilder
     private var manualNotesSection: some View {
-        MuesliSurface(cornerRadius: MuesliTheme.cornerLarge, tint: MuesliTheme.accent) {
+        MeetingPanel(tint: canEditManualNotes ? MuesliTheme.accent : nil, isProminent: canEditManualNotes && !isCompletedMeeting) {
             VStack(alignment: .leading, spacing: MuesliTheme.spacing12) {
                 HStack(alignment: .center, spacing: MuesliTheme.spacing12) {
-                    Image(systemName: "square.and.pencil")
-                        .font(.system(size: 16, weight: .bold))
-                        .foregroundStyle(MuesliTheme.accent)
-                        .frame(width: 34, height: 34)
-                        .background(MuesliTheme.accentSubtle)
-                        .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall, style: .continuous))
+                    MeetingIconTile(systemImage: "square.and.pencil", tint: MuesliTheme.accent, size: 34)
 
                     Text("Manual Notes")
                         .font(MuesliTheme.title3())
-                        .tracking(-0.15)
                         .foregroundStyle(MuesliTheme.textPrimary)
 
                     Spacer()
@@ -1115,19 +1106,16 @@ private struct MeetingSessionDetailView: View {
     @ViewBuilder
     private var retainedAudioSection: some View {
         if shouldShowPostMeetingArtifacts, session.hasRetainedAudio, let audioURL {
-            MuesliSurface(cornerRadius: MuesliTheme.cornerLarge) {
+            MeetingPanel {
                 VStack(alignment: .leading, spacing: MuesliTheme.spacing12) {
                     HStack(alignment: .top, spacing: MuesliTheme.spacing12) {
-                        Image(systemName: "waveform.path.ecg.rectangle")
-                            .font(.system(size: 20, weight: .semibold))
-                            .foregroundStyle(MuesliTheme.accent)
-                            .frame(width: 28)
+                        MeetingIconTile(systemImage: "waveform.path.ecg.rectangle", tint: MuesliTheme.accent, size: 34)
 
                         VStack(alignment: .leading, spacing: MuesliTheme.spacing4) {
-                            Text("Audio Recording")
+                            Text("Audio")
                                 .font(MuesliTheme.headline())
                                 .foregroundStyle(MuesliTheme.textPrimary)
-                            Text("Stored in Muesli's app data until you export it.")
+                            Text("Playback and export")
                                 .font(MuesliTheme.captionMedium())
                                 .foregroundStyle(MuesliTheme.textSecondary)
                             Text(audioURL.lastPathComponent)
@@ -1188,40 +1176,43 @@ private struct MeetingSessionDetailView: View {
     @ViewBuilder
     private var transcriptActionsSection: some View {
         if shouldShowPostMeetingArtifacts, let transcript {
-            VStack(spacing: MuesliTheme.spacing8) {
-                Button {
-                    onCopy(copyText(for: transcript), resolvedContent(for: transcript))
-                } label: {
-                    Label("Copy \(resolvedContent(for: transcript).copyLabel)", systemImage: "doc.on.doc")
-                        .font(MuesliTheme.headline())
-                        .frame(maxWidth: .infinity)
-                        .frame(height: 44)
-                        .foregroundStyle(MuesliTheme.accent)
-                        .background(MuesliTheme.accentSubtle)
-                        .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
-                        .contentShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
-                }
-                .buttonStyle(.plain)
-
-                Menu {
-                    ForEach(MeetingShareKind.available(for: transcript)) { kind in
-                        Button {
-                            share(kind, transcript: transcript)
-                        } label: {
-                            Label(kind.label, systemImage: kind.systemImage)
-                        }
+            MeetingPanel {
+                HStack(spacing: MuesliTheme.spacing8) {
+                    Button {
+                        onCopy(copyText(for: transcript), resolvedContent(for: transcript))
+                    } label: {
+                        Label("Copy Text", systemImage: "doc.on.doc")
+                            .font(MuesliTheme.headline())
+                            .frame(maxWidth: .infinity)
+                            .frame(height: 44)
+                            .foregroundStyle(MuesliTheme.accent)
+                            .background(MuesliTheme.accentSubtle)
+                            .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+                            .contentShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
                     }
-                } label: {
-                    Label("Share Meeting", systemImage: "square.and.arrow.up")
-                        .font(MuesliTheme.headline())
-                        .frame(maxWidth: .infinity)
-                        .frame(height: 44)
-                        .foregroundStyle(MuesliTheme.accent)
-                        .background(MuesliTheme.surfacePrimary)
-                        .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
-                        .contentShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+                    .buttonStyle(.plain)
+
+                    Menu {
+                        ForEach(MeetingShareKind.available(for: transcript)) { kind in
+                            Button {
+                                share(kind, transcript: transcript)
+                            } label: {
+                                Label(kind.label, systemImage: kind.systemImage)
+                            }
+                        }
+                    } label: {
+                        Label("Share Meeting", systemImage: "square.and.arrow.up")
+                            .font(MuesliTheme.headline())
+                            .frame(maxWidth: .infinity)
+                            .frame(height: 44)
+                            .foregroundStyle(MuesliTheme.accent)
+                            .background(MuesliTheme.surfacePrimary)
+                            .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+                            .contentShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+                    }
+                    .buttonStyle(.plain)
                 }
-                .buttonStyle(.plain)
+                .padding(MuesliTheme.spacing8)
             }
         }
     }
@@ -1247,11 +1238,23 @@ private struct MeetingSessionDetailView: View {
 
     @ViewBuilder
     private var contentSection: some View {
-        MuesliSurface(cornerRadius: MuesliTheme.cornerLarge) {
+        MeetingPanel(tint: isCompletedMeeting ? MuesliTheme.syncGreen : nil) {
             VStack(alignment: .leading, spacing: MuesliTheme.spacing12) {
-                Text(contentSectionTitle)
-                    .font(MuesliTheme.title3())
-                    .foregroundStyle(MuesliTheme.textPrimary)
+                HStack(spacing: 10) {
+                    if isCompletedMeeting {
+                        Image(systemName: "sparkles")
+                            .font(.system(size: 15, weight: .semibold))
+                            .foregroundStyle(MuesliTheme.syncGreen)
+                    } else {
+                        Circle()
+                            .fill(captureTint)
+                            .frame(width: 7, height: 7)
+                    }
+                    Text(contentSectionTitle)
+                        .font(MuesliTheme.title3())
+                        .foregroundStyle(MuesliTheme.textPrimary)
+                    Spacer()
+                }
 
                 if let transcript {
                     MeetingTranscriptContent(
@@ -1278,6 +1281,7 @@ private struct MeetingSessionDetailView: View {
         Label(title, systemImage: systemImage)
             .font(MuesliTheme.captionMedium())
             .foregroundStyle(MuesliTheme.textSecondary)
+            .lineLimit(1)
             .padding(.horizontal, MuesliTheme.spacing8)
             .padding(.vertical, MuesliTheme.spacing4)
             .background(MuesliTheme.surfacePrimary)

--- a/Shared/DictationModels.swift
+++ b/Shared/DictationModels.swift
@@ -98,6 +98,7 @@ struct SyncTextRecord: Codable, Sendable, Equatable, Identifiable {
     var engineIdentifier: String?
     var createdAt: Date
     var updatedAt: Date
+    var manualNotesUpdatedAt: Date? = nil
     var startedAt: Date?
     var endedAt: Date?
     var durationSeconds: Double

--- a/Shared/DictationModels.swift
+++ b/Shared/DictationModels.swift
@@ -311,6 +311,7 @@ struct RecordingSession: Codable, Sendable, Equatable, Identifiable {
     var transcriptID: UUID?
     var engineIdentifier: String?
     var source: String?
+    var manualNotes: String?
     var errorMessage: String?
 
     init(
@@ -327,6 +328,7 @@ struct RecordingSession: Codable, Sendable, Equatable, Identifiable {
         transcriptID: UUID? = nil,
         engineIdentifier: String? = nil,
         source: String? = nil,
+        manualNotes: String? = nil,
         errorMessage: String? = nil
     ) {
         self.id = id
@@ -342,6 +344,7 @@ struct RecordingSession: Codable, Sendable, Equatable, Identifiable {
         self.transcriptID = transcriptID
         self.engineIdentifier = engineIdentifier
         self.source = source
+        self.manualNotes = manualNotes
         self.errorMessage = errorMessage
     }
 
@@ -364,6 +367,7 @@ struct RecordingSession: Codable, Sendable, Equatable, Identifiable {
         case transcriptID
         case engineIdentifier
         case source
+        case manualNotes
         case errorMessage
     }
 
@@ -382,6 +386,7 @@ struct RecordingSession: Codable, Sendable, Equatable, Identifiable {
         transcriptID = try container.decodeIfPresent(UUID.self, forKey: .transcriptID)
         engineIdentifier = try container.decodeIfPresent(String.self, forKey: .engineIdentifier)
         source = try container.decodeIfPresent(String.self, forKey: .source)
+        manualNotes = try container.decodeIfPresent(String.self, forKey: .manualNotes)
         errorMessage = try container.decodeIfPresent(String.self, forKey: .errorMessage)
     }
 }

--- a/Shared/DictationModels.swift
+++ b/Shared/DictationModels.swift
@@ -105,6 +105,47 @@ struct SyncTextRecord: Codable, Sendable, Equatable, Identifiable {
     var cloudChangeTag: String?
 }
 
+enum SyncOrigin: Sendable, Equatable {
+    case thisIPhone
+    case fromMac
+
+    static func classify(
+        source: String?,
+        engineIdentifier: String? = nil,
+        cloudRecordName: String? = nil,
+        importedFromCloud: Bool = false
+    ) -> SyncOrigin {
+        if let source = normalized(source) {
+            return isLocalSource(source) ? .thisIPhone : .fromMac
+        }
+
+        if normalized(engineIdentifier) == "icloud" || importedFromCloud || isMacGeneratedCloudRecordName(cloudRecordName) {
+            return .fromMac
+        }
+
+        return .thisIPhone
+    }
+
+    private static func normalized(_ value: String?) -> String? {
+        let normalized = value?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return normalized?.isEmpty == false ? normalized : nil
+    }
+
+    private static func isLocalSource(_ source: String) -> Bool {
+        switch source {
+        case "ios", "iphone", "app", "keyboard":
+            true
+        default:
+            false
+        }
+    }
+
+    private static func isMacGeneratedCloudRecordName(_ cloudRecordName: String?) -> Bool {
+        guard let cloudRecordName = normalized(cloudRecordName) else { return false }
+        return cloudRecordName.hasPrefix("dictation-") || cloudRecordName.hasPrefix("meeting-")
+    }
+}
+
 struct DictationRequest: Codable, Sendable, Equatable, Identifiable {
     let id: UUID
     let createdAt: Date

--- a/Shared/DictationModels.swift
+++ b/Shared/DictationModels.swift
@@ -94,6 +94,7 @@ struct SyncTextRecord: Codable, Sendable, Equatable, Identifiable {
     var summaryText: String?
     var manualNotes: String?
     var source: String?
+    var localSource: String? = nil
     var engineIdentifier: String?
     var createdAt: Date
     var updatedAt: Date
@@ -115,11 +116,15 @@ enum SyncOrigin: Sendable, Equatable {
         cloudRecordName: String? = nil,
         importedFromCloud: Bool = false
     ) -> SyncOrigin {
+        if isMacGeneratedCloudRecordName(cloudRecordName) {
+            return .fromMac
+        }
+
         if let source = normalized(source) {
             return isLocalSource(source) ? .thisIPhone : .fromMac
         }
 
-        if normalized(engineIdentifier) == "icloud" || importedFromCloud || isMacGeneratedCloudRecordName(cloudRecordName) {
+        if normalized(engineIdentifier) == "icloud" || importedFromCloud {
             return .fromMac
         }
 
@@ -352,6 +357,7 @@ struct RecordingSession: Codable, Sendable, Equatable, Identifiable {
     var transcriptID: UUID?
     var engineIdentifier: String?
     var source: String?
+    var cloudRecordName: String?
     var manualNotes: String?
     var errorMessage: String?
 
@@ -369,6 +375,7 @@ struct RecordingSession: Codable, Sendable, Equatable, Identifiable {
         transcriptID: UUID? = nil,
         engineIdentifier: String? = nil,
         source: String? = nil,
+        cloudRecordName: String? = nil,
         manualNotes: String? = nil,
         errorMessage: String? = nil
     ) {
@@ -385,6 +392,7 @@ struct RecordingSession: Codable, Sendable, Equatable, Identifiable {
         self.transcriptID = transcriptID
         self.engineIdentifier = engineIdentifier
         self.source = source
+        self.cloudRecordName = cloudRecordName
         self.manualNotes = manualNotes
         self.errorMessage = errorMessage
     }
@@ -408,6 +416,7 @@ struct RecordingSession: Codable, Sendable, Equatable, Identifiable {
         case transcriptID
         case engineIdentifier
         case source
+        case cloudRecordName
         case manualNotes
         case errorMessage
     }
@@ -427,6 +436,7 @@ struct RecordingSession: Codable, Sendable, Equatable, Identifiable {
         transcriptID = try container.decodeIfPresent(UUID.self, forKey: .transcriptID)
         engineIdentifier = try container.decodeIfPresent(String.self, forKey: .engineIdentifier)
         source = try container.decodeIfPresent(String.self, forKey: .source)
+        cloudRecordName = try container.decodeIfPresent(String.self, forKey: .cloudRecordName)
         manualNotes = try container.decodeIfPresent(String.self, forKey: .manualNotes)
         errorMessage = try container.decodeIfPresent(String.self, forKey: .errorMessage)
     }

--- a/Shared/DictationModels.swift
+++ b/Shared/DictationModels.swift
@@ -341,6 +341,10 @@ struct DictationResult: Codable, Sendable, Equatable, Identifiable {
         self.engineIdentifier = engineIdentifier
         self.source = source
     }
+
+    var syncOrigin: SyncOrigin {
+        SyncOrigin.classify(source: source, engineIdentifier: engineIdentifier)
+    }
 }
 
 struct RecordingSession: Codable, Sendable, Equatable, Identifiable {
@@ -400,6 +404,14 @@ struct RecordingSession: Codable, Sendable, Equatable, Identifiable {
     var duration: TimeInterval? {
         guard let startedAt else { return nil }
         return (endedAt ?? .now).timeIntervalSince(startedAt)
+    }
+
+    var syncOrigin: SyncOrigin {
+        SyncOrigin.classify(
+            source: source,
+            engineIdentifier: engineIdentifier,
+            cloudRecordName: cloudRecordName
+        )
     }
 
     enum CodingKeys: String, CodingKey {

--- a/Shared/SharedStore.swift
+++ b/Shared/SharedStore.swift
@@ -1608,7 +1608,7 @@ private struct SharedStoreDatabase {
 
     private func upsertSyncedMeeting(_ record: SyncTextRecord, db: OpaquePointer) throws {
         let existingSession = try queryRows(
-            "SELECT id, manual_notes, manual_notes_updated_at, updated_at FROM recording_sessions WHERE cloud_record_name = ? LIMIT 1",
+            "SELECT id, manual_notes, manual_notes_updated_at, updated_at, payload FROM recording_sessions WHERE cloud_record_name = ? LIMIT 1",
             db: db
         ) { statement in
             try bind(record.id, to: statement, at: 1)
@@ -1617,21 +1617,60 @@ private struct SharedStoreDatabase {
                 id: sqliteColumnString(statement, 0),
                 manualNotes: sqliteColumnString(statement, 1),
                 manualNotesUpdatedAt: sqlite3_column_double(statement, 2),
-                updatedAt: sqlite3_column_double(statement, 3)
+                updatedAt: sqlite3_column_double(statement, 3),
+                payload: sqliteColumnData(statement, 4)
             )
         }.first ?? nil
+        let existingManualNotesUpdatedAt = existingSession?.manualNotesUpdatedAt ?? 0
         let incomingManualNotesUpdatedAt = record.manualNotesUpdatedAt?.timeIntervalSince1970
-            ?? ((existingSession?.manualNotesUpdatedAt ?? 0) > 0 ? 0 : record.updatedAt.timeIntervalSince1970)
+            ?? ((existingSession == nil || record.manualNotes != nil) ? record.updatedAt.timeIntervalSince1970 : 0)
         let shouldUseIncomingManualNotes = existingSession == nil
-            || incomingManualNotesUpdatedAt >= (existingSession?.manualNotesUpdatedAt ?? 0)
+            || incomingManualNotesUpdatedAt > existingManualNotesUpdatedAt
         let resolvedManualNotes = shouldUseIncomingManualNotes ? record.manualNotes : existingSession?.manualNotes
         let resolvedManualNotesUpdatedAt = shouldUseIncomingManualNotes
             ? incomingManualNotesUpdatedAt
-            : (existingSession?.manualNotesUpdatedAt ?? 0)
+            : existingManualNotesUpdatedAt
 
         if let existingSession,
-           existingSession.updatedAt > record.updatedAt.timeIntervalSince1970,
-           !shouldUseIncomingManualNotes {
+           existingSession.updatedAt > record.updatedAt.timeIntervalSince1970 {
+            if shouldUseIncomingManualNotes, let existingID = existingSession.id {
+                let encodedPayload: Data?
+                if let payload = existingSession.payload,
+                   var payloadSession = try? decoder.decode(RecordingSession.self, from: payload) {
+                    payloadSession.manualNotes = resolvedManualNotes
+                    encodedPayload = try encoder.encode(payloadSession)
+                } else {
+                    encodedPayload = nil
+                }
+                if let encodedPayload {
+                    try execute(
+                        """
+                        UPDATE recording_sessions
+                        SET manual_notes = ?, manual_notes_updated_at = ?, payload = ?
+                        WHERE id = ? AND deleted_at IS NULL
+                        """,
+                        db: db
+                    ) { statement in
+                        try bind(resolvedManualNotes, to: statement, at: 1)
+                        try bind(resolvedManualNotesUpdatedAt, to: statement, at: 2)
+                        try bind(encodedPayload, to: statement, at: 3)
+                        try bind(existingID, to: statement, at: 4)
+                    }
+                } else {
+                    try execute(
+                        """
+                        UPDATE recording_sessions
+                        SET manual_notes = ?, manual_notes_updated_at = ?
+                        WHERE id = ? AND deleted_at IS NULL
+                        """,
+                        db: db
+                    ) { statement in
+                        try bind(resolvedManualNotes, to: statement, at: 1)
+                        try bind(resolvedManualNotesUpdatedAt, to: statement, at: 2)
+                        try bind(existingID, to: statement, at: 3)
+                    }
+                }
+            }
             return
         }
 

--- a/Shared/SharedStore.swift
+++ b/Shared/SharedStore.swift
@@ -346,7 +346,7 @@ private enum SharedStoreDatabaseError: Error, LocalizedError {
 
 private struct SharedStoreDatabase {
     private static let databaseFileName = "Muesli.sqlite"
-    private static let schemaVersion = 3
+    private static let schemaVersion = 4
 
     private static let initializationLock = NSLock()
     nonisolated(unsafe) private static var initializedDatabasePaths: Set<String> = []
@@ -693,13 +693,14 @@ private struct SharedStoreDatabase {
                        s.started_at, s.ended_at, s.engine_identifier, s.error_message,
                        s.updated_at, s.deleted_at, s.cloud_change_tag, s.payload,
                        t.text, t.speaker_transcript, t.summary_text, t.summary_backend,
-                       t.summary_model, t.updated_at, t.deleted_at, s.manual_notes
+                       t.summary_model, t.updated_at, t.deleted_at, s.manual_notes,
+                       s.manual_notes_updated_at
                 FROM recording_sessions s
                 LEFT JOIN transcripts t ON t.session_id = s.id
                 WHERE (s.sync_dirty = 1 OR t.sync_dirty = 1)
                   AND s.cloud_record_name IS NOT NULL
                   AND s.kind = ?
-                ORDER BY MAX(s.updated_at, COALESCE(t.updated_at, 0)) DESC
+                ORDER BY MAX(s.updated_at, COALESCE(t.updated_at, 0), s.manual_notes_updated_at) DESC
                 LIMIT ?
                 """,
                 db: db
@@ -711,7 +712,8 @@ private struct SharedStoreDatabase {
                 let ended = Self.optionalDate(statement, 7)
                 let text = sqliteColumnString(statement, 14) ?? ""
                 let summary = sqliteColumnString(statement, 16)
-                let updated = max(sqlite3_column_double(statement, 10), sqlite3_column_double(statement, 19))
+                let manualNotesUpdatedAt = sqlite3_column_double(statement, 22)
+                let updated = max(sqlite3_column_double(statement, 10), sqlite3_column_double(statement, 19), manualNotesUpdatedAt)
                 let payload = sqliteColumnData(statement, 13)
                 let session = payload.flatMap { try? decoder.decode(RecordingSession.self, from: $0) }
                 let manualNotes = session?.manualNotes ?? sqliteColumnString(statement, 21)
@@ -728,6 +730,7 @@ private struct SharedStoreDatabase {
                     engineIdentifier: sqliteColumnString(statement, 8),
                     createdAt: Date(timeIntervalSince1970: sqlite3_column_double(statement, 5)),
                     updatedAt: Date(timeIntervalSince1970: updated),
+                    manualNotesUpdatedAt: manualNotesUpdatedAt > 0 ? Date(timeIntervalSince1970: manualNotesUpdatedAt) : nil,
                     startedAt: started,
                     endedAt: ended,
                     durationSeconds: started.map { (ended ?? Date()).timeIntervalSince($0) } ?? 0,
@@ -791,12 +794,13 @@ private struct SharedStoreDatabase {
                        s.started_at, s.ended_at, s.engine_identifier, s.error_message,
                        s.updated_at, s.deleted_at, s.cloud_change_tag, s.payload,
                        t.text, t.speaker_transcript, t.summary_text, t.summary_backend,
-                       t.summary_model, t.updated_at, t.deleted_at, s.manual_notes
+                       t.summary_model, t.updated_at, t.deleted_at, s.manual_notes,
+                       s.manual_notes_updated_at
                 FROM recording_sessions s
                 LEFT JOIN transcripts t ON t.session_id = s.id
                 WHERE s.cloud_record_name IS NOT NULL
                   AND s.kind = ?
-                ORDER BY MAX(s.updated_at, COALESCE(t.updated_at, 0)) DESC
+                ORDER BY MAX(s.updated_at, COALESCE(t.updated_at, 0), s.manual_notes_updated_at) DESC
                 LIMIT ?
                 """,
                 db: db
@@ -808,7 +812,8 @@ private struct SharedStoreDatabase {
                 let ended = Self.optionalDate(statement, 7)
                 let text = sqliteColumnString(statement, 14) ?? ""
                 let summary = sqliteColumnString(statement, 16)
-                let updated = max(sqlite3_column_double(statement, 10), sqlite3_column_double(statement, 19))
+                let manualNotesUpdatedAt = sqlite3_column_double(statement, 22)
+                let updated = max(sqlite3_column_double(statement, 10), sqlite3_column_double(statement, 19), manualNotesUpdatedAt)
                 let payload = sqliteColumnData(statement, 13)
                 let session = payload.flatMap { try? decoder.decode(RecordingSession.self, from: $0) }
                 let manualNotes = session?.manualNotes ?? sqliteColumnString(statement, 21)
@@ -825,6 +830,7 @@ private struct SharedStoreDatabase {
                     engineIdentifier: sqliteColumnString(statement, 8),
                     createdAt: Date(timeIntervalSince1970: sqlite3_column_double(statement, 5)),
                     updatedAt: Date(timeIntervalSince1970: updated),
+                    manualNotesUpdatedAt: manualNotesUpdatedAt > 0 ? Date(timeIntervalSince1970: manualNotesUpdatedAt) : nil,
                     startedAt: started,
                     endedAt: ended,
                     durationSeconds: started.map { (ended ?? Date()).timeIntervalSince($0) } ?? 0,
@@ -946,6 +952,7 @@ private struct SharedStoreDatabase {
             ("recording_sessions", "transcript_id", "ALTER TABLE recording_sessions ADD COLUMN transcript_id TEXT"),
             ("recording_sessions", "engine_identifier", "ALTER TABLE recording_sessions ADD COLUMN engine_identifier TEXT"),
             ("recording_sessions", "manual_notes", "ALTER TABLE recording_sessions ADD COLUMN manual_notes TEXT"),
+            ("recording_sessions", "manual_notes_updated_at", "ALTER TABLE recording_sessions ADD COLUMN manual_notes_updated_at REAL NOT NULL DEFAULT 0"),
             ("recording_sessions", "error_message", "ALTER TABLE recording_sessions ADD COLUMN error_message TEXT"),
             ("recording_sessions", "updated_at", "ALTER TABLE recording_sessions ADD COLUMN updated_at REAL NOT NULL DEFAULT 0"),
             ("recording_sessions", "deleted_at", "ALTER TABLE recording_sessions ADD COLUMN deleted_at REAL"),
@@ -1084,6 +1091,10 @@ private struct SharedStoreDatabase {
                     transcript_id = COALESCE(transcript_id, ?),
                     engine_identifier = COALESCE(engine_identifier, ?),
                     manual_notes = COALESCE(manual_notes, ?),
+                    manual_notes_updated_at = CASE
+                        WHEN manual_notes_updated_at = 0 AND manual_notes IS NOT NULL THEN updated_at
+                        ELSE manual_notes_updated_at
+                    END,
                     error_message = COALESCE(error_message, ?),
                     updated_at = CASE WHEN updated_at = 0 THEN ? ELSE updated_at END,
                     cloud_record_name = COALESCE(NULLIF(cloud_record_name, ''), ?),
@@ -1350,10 +1361,10 @@ private struct SharedStoreDatabase {
             INSERT INTO recording_sessions (
                 id, request_id, kind, title, phase, created_at, started_at, ended_at,
                 audio_file_name, keeps_audio_recording, transcript_id, engine_identifier,
-                manual_notes, error_message, updated_at, deleted_at, cloud_record_name, cloud_change_tag,
+                manual_notes, manual_notes_updated_at, error_message, updated_at, deleted_at, cloud_record_name, cloud_change_tag,
                 last_synced_at, sync_dirty, payload
             )
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, ?, NULL, NULL, 1, ?)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, ?, NULL, NULL, 1, ?)
             ON CONFLICT(id) DO UPDATE SET
                 request_id = excluded.request_id,
                 kind = excluded.kind,
@@ -1367,6 +1378,10 @@ private struct SharedStoreDatabase {
                 transcript_id = excluded.transcript_id,
                 engine_identifier = excluded.engine_identifier,
                 manual_notes = excluded.manual_notes,
+                manual_notes_updated_at = CASE
+                    WHEN excluded.manual_notes IS NOT recording_sessions.manual_notes THEN excluded.manual_notes_updated_at
+                    ELSE recording_sessions.manual_notes_updated_at
+                END,
                 error_message = excluded.error_message,
                 updated_at = excluded.updated_at,
                 deleted_at = NULL,
@@ -1389,10 +1404,11 @@ private struct SharedStoreDatabase {
             try bind(session.transcriptID?.uuidString, to: statement, at: 11)
             try bind(session.engineIdentifier, to: statement, at: 12)
             try bind(session.manualNotes, to: statement, at: 13)
-            try bind(session.errorMessage, to: statement, at: 14)
-            try bind(now, to: statement, at: 15)
-            try bind(session.id.uuidString, to: statement, at: 16)
-            try bind(try encoder.encode(session), to: statement, at: 17)
+            try bind(session.manualNotes == nil ? 0 : now, to: statement, at: 14)
+            try bind(session.errorMessage, to: statement, at: 15)
+            try bind(now, to: statement, at: 16)
+            try bind(session.id.uuidString, to: statement, at: 17)
+            try bind(try encoder.encode(session), to: statement, at: 18)
         }
     }
 
@@ -1418,15 +1434,16 @@ private struct SharedStoreDatabase {
                 try execute(
                     """
                     UPDATE recording_sessions
-                    SET manual_notes = ?, updated_at = ?, sync_dirty = 1, payload = ?
+                    SET manual_notes = ?, manual_notes_updated_at = ?, updated_at = ?, sync_dirty = 1, payload = ?
                     WHERE id = ? AND deleted_at IS NULL
                     """,
                     db: db
                 ) { statement in
                     try bind(manualNotes, to: statement, at: 1)
                     try bind(now, to: statement, at: 2)
-                    try bind(try encoder.encode(session), to: statement, at: 3)
-                    try bind(sessionID.uuidString, to: statement, at: 4)
+                    try bind(now, to: statement, at: 3)
+                    try bind(try encoder.encode(session), to: statement, at: 4)
+                    try bind(sessionID.uuidString, to: statement, at: 5)
                 }
                 didUpdate = true
             }
@@ -1590,20 +1607,35 @@ private struct SharedStoreDatabase {
     }
 
     private func upsertSyncedMeeting(_ record: SyncTextRecord, db: OpaquePointer) throws {
-        if let localUpdatedAt = try localUpdatedAt(table: "recording_sessions", recordName: record.id, db: db),
-           localUpdatedAt > record.updatedAt.timeIntervalSince1970 {
-            return
-        }
-
-        let existingSessionID = try queryRows(
-            "SELECT id FROM recording_sessions WHERE cloud_record_name = ? LIMIT 1",
+        let existingSession = try queryRows(
+            "SELECT id, manual_notes, manual_notes_updated_at, updated_at FROM recording_sessions WHERE cloud_record_name = ? LIMIT 1",
             db: db
         ) { statement in
             try bind(record.id, to: statement, at: 1)
         } read: { statement in
-            sqliteColumnString(statement, 0)
+            (
+                id: sqliteColumnString(statement, 0),
+                manualNotes: sqliteColumnString(statement, 1),
+                manualNotesUpdatedAt: sqlite3_column_double(statement, 2),
+                updatedAt: sqlite3_column_double(statement, 3)
+            )
         }.first ?? nil
-        let sessionID = existingSessionID.flatMap(UUID.init(uuidString:)) ?? UUID(uuidString: record.id) ?? UUID()
+        let incomingManualNotesUpdatedAt = record.manualNotesUpdatedAt?.timeIntervalSince1970
+            ?? ((existingSession?.manualNotesUpdatedAt ?? 0) > 0 ? 0 : record.updatedAt.timeIntervalSince1970)
+        let shouldUseIncomingManualNotes = existingSession == nil
+            || incomingManualNotesUpdatedAt >= (existingSession?.manualNotesUpdatedAt ?? 0)
+        let resolvedManualNotes = shouldUseIncomingManualNotes ? record.manualNotes : existingSession?.manualNotes
+        let resolvedManualNotesUpdatedAt = shouldUseIncomingManualNotes
+            ? incomingManualNotesUpdatedAt
+            : (existingSession?.manualNotesUpdatedAt ?? 0)
+
+        if let existingSession,
+           existingSession.updatedAt > record.updatedAt.timeIntervalSince1970,
+           !shouldUseIncomingManualNotes {
+            return
+        }
+
+        let sessionID = existingSession?.id.flatMap(UUID.init(uuidString:)) ?? UUID(uuidString: record.id) ?? UUID()
         let transcriptID = UUID()
         let importedSource = Self.syncSource(record.source, fallback: "macos")
         let session = RecordingSession(
@@ -1624,7 +1656,7 @@ private struct SharedStoreDatabase {
             errorMessage: nil
         )
         var sessionWithManualNotes = session
-        sessionWithManualNotes.manualNotes = record.manualNotes
+        sessionWithManualNotes.manualNotes = resolvedManualNotes
         let transcript = Transcript(
             id: transcriptID,
             sessionID: sessionID,
@@ -1642,10 +1674,10 @@ private struct SharedStoreDatabase {
             INSERT INTO recording_sessions (
                 id, request_id, kind, title, phase, created_at, started_at, ended_at,
                 audio_file_name, keeps_audio_recording, transcript_id, engine_identifier,
-                manual_notes, error_message, updated_at, deleted_at, cloud_record_name, cloud_change_tag,
+                manual_notes, manual_notes_updated_at, error_message, updated_at, deleted_at, cloud_record_name, cloud_change_tag,
                 last_synced_at, sync_dirty, payload
             )
-            VALUES (?, NULL, ?, ?, ?, ?, ?, ?, NULL, 0, ?, ?, ?, NULL, ?, ?, ?, ?, ?, 0, ?)
+            VALUES (?, NULL, ?, ?, ?, ?, ?, ?, NULL, 0, ?, ?, ?, ?, NULL, ?, ?, ?, ?, ?, 0, ?)
             ON CONFLICT(id) DO UPDATE SET
                 title = excluded.title,
                 phase = excluded.phase,
@@ -1656,6 +1688,7 @@ private struct SharedStoreDatabase {
                 transcript_id = excluded.transcript_id,
                 engine_identifier = excluded.engine_identifier,
                 manual_notes = excluded.manual_notes,
+                manual_notes_updated_at = excluded.manual_notes_updated_at,
                 updated_at = excluded.updated_at,
                 deleted_at = excluded.deleted_at,
                 cloud_record_name = excluded.cloud_record_name,
@@ -1675,13 +1708,14 @@ private struct SharedStoreDatabase {
             try bind(session.endedAt?.timeIntervalSince1970, to: statement, at: 7)
             try bind(transcriptID.uuidString, to: statement, at: 8)
             try bind(session.engineIdentifier, to: statement, at: 9)
-            try bind(record.manualNotes, to: statement, at: 10)
-            try bind(record.updatedAt.timeIntervalSince1970, to: statement, at: 11)
-            try bind(record.isDeleted ? record.updatedAt.timeIntervalSince1970 : nil, to: statement, at: 12)
-            try bind(record.id, to: statement, at: 13)
-            try bind(record.cloudChangeTag, to: statement, at: 14)
-            try bind(Date().timeIntervalSince1970, to: statement, at: 15)
-            try bind(try encoder.encode(sessionWithManualNotes), to: statement, at: 16)
+            try bind(resolvedManualNotes, to: statement, at: 10)
+            try bind(resolvedManualNotesUpdatedAt, to: statement, at: 11)
+            try bind(record.updatedAt.timeIntervalSince1970, to: statement, at: 12)
+            try bind(record.isDeleted ? record.updatedAt.timeIntervalSince1970 : nil, to: statement, at: 13)
+            try bind(record.id, to: statement, at: 14)
+            try bind(record.cloudChangeTag, to: statement, at: 15)
+            try bind(Date().timeIntervalSince1970, to: statement, at: 16)
+            try bind(try encoder.encode(sessionWithManualNotes), to: statement, at: 17)
         }
 
         try execute("DELETE FROM transcripts WHERE session_id = ?", db: db) { statement in
@@ -2017,6 +2051,7 @@ private struct SharedStoreDatabase {
         transcript_id TEXT,
         engine_identifier TEXT,
         manual_notes TEXT,
+        manual_notes_updated_at REAL NOT NULL DEFAULT 0,
         error_message TEXT,
         updated_at REAL NOT NULL DEFAULT 0,
         deleted_at REAL,

--- a/Shared/SharedStore.swift
+++ b/Shared/SharedStore.swift
@@ -461,43 +461,51 @@ private struct SharedStoreDatabase {
 
     func recordingSessions() throws -> [RecordingSession] {
         try withDatabase { db in
-            try queryBlobs(
-                "SELECT payload FROM recording_sessions WHERE deleted_at IS NULL ORDER BY created_at DESC",
+            try queryRows(
+                "SELECT payload, cloud_record_name FROM recording_sessions WHERE deleted_at IS NULL ORDER BY created_at DESC",
                 db: db
-            ) { _ in }.map { try decoder.decode(RecordingSession.self, from: $0) }
+            ) { _ in } read: { statement in
+                try decodeRecordingSession(statement)
+            }
         }
     }
 
     func recordingSession(id: UUID) throws -> RecordingSession? {
         try withDatabase { db in
-            try querySingleBlob(
-                "SELECT payload FROM recording_sessions WHERE id = ? LIMIT 1",
+            try queryRows(
+                "SELECT payload, cloud_record_name FROM recording_sessions WHERE id = ? LIMIT 1",
                 db: db
             ) { statement in
                 try bind(id.uuidString, to: statement, at: 1)
-            }.map { try decoder.decode(RecordingSession.self, from: $0) }
+            } read: { statement in
+                try decodeRecordingSession(statement)
+            }.first
         }
     }
 
     func activeRecordingSession(id: UUID) throws -> RecordingSession? {
         try withDatabase { db in
-            try querySingleBlob(
-                "SELECT payload FROM recording_sessions WHERE id = ? AND deleted_at IS NULL LIMIT 1",
+            try queryRows(
+                "SELECT payload, cloud_record_name FROM recording_sessions WHERE id = ? AND deleted_at IS NULL LIMIT 1",
                 db: db
             ) { statement in
                 try bind(id.uuidString, to: statement, at: 1)
-            }.map { try decoder.decode(RecordingSession.self, from: $0) }
+            } read: { statement in
+                try decodeRecordingSession(statement)
+            }.first
         }
     }
 
     func recordingSession(requestID: UUID) throws -> RecordingSession? {
         try withDatabase { db in
-            try querySingleBlob(
-                "SELECT payload FROM recording_sessions WHERE request_id = ? LIMIT 1",
+            try queryRows(
+                "SELECT payload, cloud_record_name FROM recording_sessions WHERE request_id = ? LIMIT 1",
                 db: db
             ) { statement in
                 try bind(requestID.uuidString, to: statement, at: 1)
-            }.map { try decoder.decode(RecordingSession.self, from: $0) }
+            } read: { statement in
+                try decodeRecordingSession(statement)
+            }.first
         }
     }
 
@@ -660,7 +668,8 @@ private struct SharedStoreDatabase {
                     speakerTranscript: nil,
                     summaryText: nil,
                     manualNotes: nil,
-                    source: Self.syncSource(result?.source),
+                    source: Self.syncPlatformSource(result?.source),
+                    localSource: Self.syncSource(result?.source),
                     engineIdentifier: sqliteColumnString(statement, 2),
                     createdAt: Date(timeIntervalSince1970: sqlite3_column_double(statement, 3)),
                     updatedAt: Date(timeIntervalSince1970: sqlite3_column_double(statement, 4)),
@@ -713,7 +722,8 @@ private struct SharedStoreDatabase {
                     speakerTranscript: sqliteColumnString(statement, 15),
                     summaryText: summary,
                     manualNotes: manualNotes,
-                    source: Self.syncSource(session?.source),
+                    source: Self.syncPlatformSource(session?.source),
+                    localSource: Self.syncSource(session?.source, fallback: "meeting"),
                     engineIdentifier: sqliteColumnString(statement, 8),
                     createdAt: Date(timeIntervalSince1970: sqlite3_column_double(statement, 5)),
                     updatedAt: Date(timeIntervalSince1970: updated),
@@ -756,7 +766,8 @@ private struct SharedStoreDatabase {
                     speakerTranscript: nil,
                     summaryText: nil,
                     manualNotes: nil,
-                    source: Self.syncSource(result?.source),
+                    source: Self.syncPlatformSource(result?.source),
+                    localSource: Self.syncSource(result?.source),
                     engineIdentifier: sqliteColumnString(statement, 2),
                     createdAt: Date(timeIntervalSince1970: sqlite3_column_double(statement, 3)),
                     updatedAt: Date(timeIntervalSince1970: sqlite3_column_double(statement, 4)),
@@ -808,7 +819,8 @@ private struct SharedStoreDatabase {
                     speakerTranscript: sqliteColumnString(statement, 15),
                     summaryText: summary,
                     manualNotes: manualNotes,
-                    source: Self.syncSource(session?.source),
+                    source: Self.syncPlatformSource(session?.source),
+                    localSource: Self.syncSource(session?.source, fallback: "meeting"),
                     engineIdentifier: sqliteColumnString(statement, 8),
                     createdAt: Date(timeIntervalSince1970: sqlite3_column_double(statement, 5)),
                     updatedAt: Date(timeIntervalSince1970: updated),
@@ -1605,6 +1617,7 @@ private struct SharedStoreDatabase {
             transcriptID: transcriptID,
             engineIdentifier: record.engineIdentifier,
             source: importedSource,
+            cloudRecordName: record.id,
             errorMessage: nil
         )
         var sessionWithManualNotes = session
@@ -1795,6 +1808,15 @@ private struct SharedStoreDatabase {
         }
     }
 
+    private func decodeRecordingSession(_ statement: OpaquePointer) throws -> RecordingSession {
+        guard let payload = sqliteColumnData(statement, 0) else {
+            throw SharedStoreDatabaseError.stepFailed("Missing recording session payload")
+        }
+        var session = try decoder.decode(RecordingSession.self, from: payload)
+        session.cloudRecordName = sqliteColumnString(statement, 1)
+        return session
+    }
+
     private func forEachRow(
         _ sql: String,
         db: OpaquePointer,
@@ -1930,6 +1952,22 @@ private struct SharedStoreDatabase {
             return fallback
         }
         return normalized
+    }
+
+    private static func syncPlatformSource(_ source: String?, fallback: String = "ios") -> String {
+        guard let normalized = source?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased(),
+              !normalized.isEmpty else {
+            return fallback
+        }
+
+        switch normalized {
+        case "ios", "iphone", "app", "keyboard":
+            return "ios"
+        case "macos", "mac", "dictation", "cua", "meeting", "audio_import":
+            return "macos"
+        default:
+            return fallback
+        }
     }
 
     private static let schemaSQL = """

--- a/Shared/SharedStore.swift
+++ b/Shared/SharedStore.swift
@@ -1590,6 +1590,7 @@ private struct SharedStoreDatabase {
         }.first ?? nil
         let sessionID = existingSessionID.flatMap(UUID.init(uuidString:)) ?? UUID(uuidString: record.id) ?? UUID()
         let transcriptID = UUID()
+        let importedSource = Self.syncSource(record.source, fallback: "macos")
         let session = RecordingSession(
             id: sessionID,
             requestID: nil,
@@ -1603,7 +1604,7 @@ private struct SharedStoreDatabase {
             keepsAudioRecording: false,
             transcriptID: transcriptID,
             engineIdentifier: record.engineIdentifier,
-            source: record.source,
+            source: importedSource,
             errorMessage: nil
         )
         var sessionWithManualNotes = session

--- a/Shared/SharedStore.swift
+++ b/Shared/SharedStore.swift
@@ -148,7 +148,8 @@ struct SharedStore: Sendable {
         try database().deleteRecordingSession(id: id)
     }
 
-    func updateMeetingManualNotes(sessionID: UUID, manualNotes: String) throws {
+    @discardableResult
+    func updateMeetingManualNotes(sessionID: UUID, manualNotes: String) throws -> Bool {
         try database().updateMeetingManualNotes(sessionID: sessionID, manualNotes: manualNotes)
     }
 
@@ -910,9 +911,9 @@ private struct SharedStoreDatabase {
 
     private func ensureInitialized(_ db: OpaquePointer) throws {
         Self.initializationLock.lock()
-        let didInitialize = Self.initializedDatabasePaths.contains(databaseURL.path)
-        Self.initializationLock.unlock()
-        guard !didInitialize else { return }
+        defer { Self.initializationLock.unlock() }
+
+        guard !Self.initializedDatabasePaths.contains(databaseURL.path) else { return }
 
         try exec(Self.schemaSQL, db: db)
         try migrateSchemaIfNeeded(db)
@@ -920,9 +921,7 @@ private struct SharedStoreDatabase {
         try backfillNormalizedColumns(db)
         try setUserVersion(Self.schemaVersion, db: db)
 
-        Self.initializationLock.lock()
         Self.initializedDatabasePaths.insert(databaseURL.path)
-        Self.initializationLock.unlock()
     }
 
     private func migrateSchemaIfNeeded(_ db: OpaquePointer) throws {
@@ -1397,8 +1396,10 @@ private struct SharedStoreDatabase {
         }
     }
 
-    func updateMeetingManualNotes(sessionID: UUID, manualNotes: String) throws {
+    @discardableResult
+    func updateMeetingManualNotes(sessionID: UUID, manualNotes: String) throws -> Bool {
         try withDatabase { db in
+            var didUpdate = false
             try transaction(db: db) {
                 guard let data = try querySingleBlob(
                     "SELECT payload FROM recording_sessions WHERE id = ? AND deleted_at IS NULL LIMIT 1",
@@ -1427,7 +1428,9 @@ private struct SharedStoreDatabase {
                     try bind(try encoder.encode(session), to: statement, at: 3)
                     try bind(sessionID.uuidString, to: statement, at: 4)
                 }
+                didUpdate = true
             }
+            return didUpdate
         }
     }
 

--- a/Shared/SharedStore.swift
+++ b/Shared/SharedStore.swift
@@ -148,6 +148,10 @@ struct SharedStore: Sendable {
         try database().deleteRecordingSession(id: id)
     }
 
+    func updateMeetingManualNotes(sessionID: UUID, manualNotes: String) throws {
+        try database().updateMeetingManualNotes(sessionID: sessionID, manualNotes: manualNotes)
+    }
+
     func saveTranscript(_ transcript: Transcript) throws {
         try database().saveTranscript(transcript)
     }
@@ -341,7 +345,7 @@ private enum SharedStoreDatabaseError: Error, LocalizedError {
 
 private struct SharedStoreDatabase {
     private static let databaseFileName = "Muesli.sqlite"
-    private static let schemaVersion = 2
+    private static let schemaVersion = 3
 
     private static let initializationLock = NSLock()
     nonisolated(unsafe) private static var initializedDatabasePaths: Set<String> = []
@@ -679,7 +683,7 @@ private struct SharedStoreDatabase {
                        s.started_at, s.ended_at, s.engine_identifier, s.error_message,
                        s.updated_at, s.deleted_at, s.cloud_change_tag, s.payload,
                        t.text, t.speaker_transcript, t.summary_text, t.summary_backend,
-                       t.summary_model, t.updated_at, t.deleted_at
+                       t.summary_model, t.updated_at, t.deleted_at, s.manual_notes
                 FROM recording_sessions s
                 LEFT JOIN transcripts t ON t.session_id = s.id
                 WHERE (s.sync_dirty = 1 OR t.sync_dirty = 1)
@@ -700,6 +704,7 @@ private struct SharedStoreDatabase {
                 let updated = max(sqlite3_column_double(statement, 10), sqlite3_column_double(statement, 19))
                 let payload = sqliteColumnData(statement, 13)
                 let session = payload.flatMap { try? decoder.decode(RecordingSession.self, from: $0) }
+                let manualNotes = session?.manualNotes ?? sqliteColumnString(statement, 21)
                 return SyncTextRecord(
                     id: sqliteColumnString(statement, 0) ?? UUID().uuidString,
                     kind: .meeting,
@@ -707,7 +712,7 @@ private struct SharedStoreDatabase {
                     text: text,
                     speakerTranscript: sqliteColumnString(statement, 15),
                     summaryText: summary,
-                    manualNotes: nil,
+                    manualNotes: manualNotes,
                     source: Self.syncSource(session?.source),
                     engineIdentifier: sqliteColumnString(statement, 8),
                     createdAt: Date(timeIntervalSince1970: sqlite3_column_double(statement, 5)),
@@ -715,7 +720,7 @@ private struct SharedStoreDatabase {
                     startedAt: started,
                     endedAt: ended,
                     durationSeconds: started.map { (ended ?? Date()).timeIntervalSince($0) } ?? 0,
-                    wordCount: Self.wordCount(text + " " + (summary ?? "")),
+                    wordCount: Self.wordCount(text + " " + (summary ?? "") + " " + (manualNotes ?? "")),
                     isDeleted: sqlite3_column_type(statement, 11) != SQLITE_NULL || sqlite3_column_type(statement, 20) != SQLITE_NULL,
                     cloudChangeTag: sqliteColumnString(statement, 12)
                 )
@@ -774,7 +779,7 @@ private struct SharedStoreDatabase {
                        s.started_at, s.ended_at, s.engine_identifier, s.error_message,
                        s.updated_at, s.deleted_at, s.cloud_change_tag, s.payload,
                        t.text, t.speaker_transcript, t.summary_text, t.summary_backend,
-                       t.summary_model, t.updated_at, t.deleted_at
+                       t.summary_model, t.updated_at, t.deleted_at, s.manual_notes
                 FROM recording_sessions s
                 LEFT JOIN transcripts t ON t.session_id = s.id
                 WHERE s.cloud_record_name IS NOT NULL
@@ -794,6 +799,7 @@ private struct SharedStoreDatabase {
                 let updated = max(sqlite3_column_double(statement, 10), sqlite3_column_double(statement, 19))
                 let payload = sqliteColumnData(statement, 13)
                 let session = payload.flatMap { try? decoder.decode(RecordingSession.self, from: $0) }
+                let manualNotes = session?.manualNotes ?? sqliteColumnString(statement, 21)
                 return SyncTextRecord(
                     id: sqliteColumnString(statement, 0) ?? UUID().uuidString,
                     kind: .meeting,
@@ -801,7 +807,7 @@ private struct SharedStoreDatabase {
                     text: text,
                     speakerTranscript: sqliteColumnString(statement, 15),
                     summaryText: summary,
-                    manualNotes: nil,
+                    manualNotes: manualNotes,
                     source: Self.syncSource(session?.source),
                     engineIdentifier: sqliteColumnString(statement, 8),
                     createdAt: Date(timeIntervalSince1970: sqlite3_column_double(statement, 5)),
@@ -809,7 +815,7 @@ private struct SharedStoreDatabase {
                     startedAt: started,
                     endedAt: ended,
                     durationSeconds: started.map { (ended ?? Date()).timeIntervalSince($0) } ?? 0,
-                    wordCount: Self.wordCount(text + " " + (summary ?? "")),
+                    wordCount: Self.wordCount(text + " " + (summary ?? "") + " " + (manualNotes ?? "")),
                     isDeleted: sqlite3_column_type(statement, 11) != SQLITE_NULL || sqlite3_column_type(statement, 20) != SQLITE_NULL,
                     cloudChangeTag: sqliteColumnString(statement, 12)
                 )
@@ -928,6 +934,7 @@ private struct SharedStoreDatabase {
             ("recording_sessions", "keeps_audio_recording", "ALTER TABLE recording_sessions ADD COLUMN keeps_audio_recording INTEGER NOT NULL DEFAULT 0"),
             ("recording_sessions", "transcript_id", "ALTER TABLE recording_sessions ADD COLUMN transcript_id TEXT"),
             ("recording_sessions", "engine_identifier", "ALTER TABLE recording_sessions ADD COLUMN engine_identifier TEXT"),
+            ("recording_sessions", "manual_notes", "ALTER TABLE recording_sessions ADD COLUMN manual_notes TEXT"),
             ("recording_sessions", "error_message", "ALTER TABLE recording_sessions ADD COLUMN error_message TEXT"),
             ("recording_sessions", "updated_at", "ALTER TABLE recording_sessions ADD COLUMN updated_at REAL NOT NULL DEFAULT 0"),
             ("recording_sessions", "deleted_at", "ALTER TABLE recording_sessions ADD COLUMN deleted_at REAL"),
@@ -1065,6 +1072,7 @@ private struct SharedStoreDatabase {
                     keeps_audio_recording = ?,
                     transcript_id = COALESCE(transcript_id, ?),
                     engine_identifier = COALESCE(engine_identifier, ?),
+                    manual_notes = COALESCE(manual_notes, ?),
                     error_message = COALESCE(error_message, ?),
                     updated_at = CASE WHEN updated_at = 0 THEN ? ELSE updated_at END,
                     cloud_record_name = COALESCE(NULLIF(cloud_record_name, ''), ?),
@@ -1084,10 +1092,11 @@ private struct SharedStoreDatabase {
                 try bind(session?.keepsAudioRecording == true ? 1 : 0, to: update, at: 9)
                 try bind(session?.transcriptID?.uuidString, to: update, at: 10)
                 try bind(session?.engineIdentifier, to: update, at: 11)
-                try bind(session?.errorMessage, to: update, at: 12)
-                try bind(createdAt, to: update, at: 13)
-                try bind(id, to: update, at: 14)
-                try bind(rowID, to: update, at: 15)
+                try bind(session?.manualNotes, to: update, at: 12)
+                try bind(session?.errorMessage, to: update, at: 13)
+                try bind(createdAt, to: update, at: 14)
+                try bind(id, to: update, at: 15)
+                try bind(rowID, to: update, at: 16)
             }
         }
     }
@@ -1330,10 +1339,10 @@ private struct SharedStoreDatabase {
             INSERT INTO recording_sessions (
                 id, request_id, kind, title, phase, created_at, started_at, ended_at,
                 audio_file_name, keeps_audio_recording, transcript_id, engine_identifier,
-                error_message, updated_at, deleted_at, cloud_record_name, cloud_change_tag,
+                manual_notes, error_message, updated_at, deleted_at, cloud_record_name, cloud_change_tag,
                 last_synced_at, sync_dirty, payload
             )
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, ?, NULL, NULL, 1, ?)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, ?, NULL, NULL, 1, ?)
             ON CONFLICT(id) DO UPDATE SET
                 request_id = excluded.request_id,
                 kind = excluded.kind,
@@ -1346,6 +1355,7 @@ private struct SharedStoreDatabase {
                 keeps_audio_recording = excluded.keeps_audio_recording,
                 transcript_id = excluded.transcript_id,
                 engine_identifier = excluded.engine_identifier,
+                manual_notes = excluded.manual_notes,
                 error_message = excluded.error_message,
                 updated_at = excluded.updated_at,
                 deleted_at = NULL,
@@ -1367,10 +1377,45 @@ private struct SharedStoreDatabase {
             try bind(session.keepsAudioRecording ? 1 : 0, to: statement, at: 10)
             try bind(session.transcriptID?.uuidString, to: statement, at: 11)
             try bind(session.engineIdentifier, to: statement, at: 12)
-            try bind(session.errorMessage, to: statement, at: 13)
-            try bind(now, to: statement, at: 14)
-            try bind(session.id.uuidString, to: statement, at: 15)
-            try bind(try encoder.encode(session), to: statement, at: 16)
+            try bind(session.manualNotes, to: statement, at: 13)
+            try bind(session.errorMessage, to: statement, at: 14)
+            try bind(now, to: statement, at: 15)
+            try bind(session.id.uuidString, to: statement, at: 16)
+            try bind(try encoder.encode(session), to: statement, at: 17)
+        }
+    }
+
+    func updateMeetingManualNotes(sessionID: UUID, manualNotes: String) throws {
+        try withDatabase { db in
+            try transaction(db: db) {
+                guard let data = try querySingleBlob(
+                    "SELECT payload FROM recording_sessions WHERE id = ? AND deleted_at IS NULL LIMIT 1",
+                    db: db,
+                    bindValues: { statement in
+                        try bind(sessionID.uuidString, to: statement, at: 1)
+                    }
+                ) else {
+                    return
+                }
+
+                var session = try decoder.decode(RecordingSession.self, from: data)
+                guard session.kind == .meeting else { return }
+                session.manualNotes = manualNotes
+                let now = Date().timeIntervalSince1970
+                try execute(
+                    """
+                    UPDATE recording_sessions
+                    SET manual_notes = ?, updated_at = ?, sync_dirty = 1, payload = ?
+                    WHERE id = ? AND deleted_at IS NULL
+                    """,
+                    db: db
+                ) { statement in
+                    try bind(manualNotes, to: statement, at: 1)
+                    try bind(now, to: statement, at: 2)
+                    try bind(try encoder.encode(session), to: statement, at: 3)
+                    try bind(sessionID.uuidString, to: statement, at: 4)
+                }
+            }
         }
     }
 
@@ -1561,6 +1606,8 @@ private struct SharedStoreDatabase {
             source: record.source,
             errorMessage: nil
         )
+        var sessionWithManualNotes = session
+        sessionWithManualNotes.manualNotes = record.manualNotes
         let transcript = Transcript(
             id: transcriptID,
             sessionID: sessionID,
@@ -1578,10 +1625,10 @@ private struct SharedStoreDatabase {
             INSERT INTO recording_sessions (
                 id, request_id, kind, title, phase, created_at, started_at, ended_at,
                 audio_file_name, keeps_audio_recording, transcript_id, engine_identifier,
-                error_message, updated_at, deleted_at, cloud_record_name, cloud_change_tag,
+                manual_notes, error_message, updated_at, deleted_at, cloud_record_name, cloud_change_tag,
                 last_synced_at, sync_dirty, payload
             )
-            VALUES (?, NULL, ?, ?, ?, ?, ?, ?, NULL, 0, ?, ?, NULL, ?, ?, ?, ?, ?, 0, ?)
+            VALUES (?, NULL, ?, ?, ?, ?, ?, ?, NULL, 0, ?, ?, ?, NULL, ?, ?, ?, ?, ?, 0, ?)
             ON CONFLICT(id) DO UPDATE SET
                 title = excluded.title,
                 phase = excluded.phase,
@@ -1591,6 +1638,7 @@ private struct SharedStoreDatabase {
                 keeps_audio_recording = 0,
                 transcript_id = excluded.transcript_id,
                 engine_identifier = excluded.engine_identifier,
+                manual_notes = excluded.manual_notes,
                 updated_at = excluded.updated_at,
                 deleted_at = excluded.deleted_at,
                 cloud_record_name = excluded.cloud_record_name,
@@ -1610,12 +1658,13 @@ private struct SharedStoreDatabase {
             try bind(session.endedAt?.timeIntervalSince1970, to: statement, at: 7)
             try bind(transcriptID.uuidString, to: statement, at: 8)
             try bind(session.engineIdentifier, to: statement, at: 9)
-            try bind(record.updatedAt.timeIntervalSince1970, to: statement, at: 10)
-            try bind(record.isDeleted ? record.updatedAt.timeIntervalSince1970 : nil, to: statement, at: 11)
-            try bind(record.id, to: statement, at: 12)
-            try bind(record.cloudChangeTag, to: statement, at: 13)
-            try bind(Date().timeIntervalSince1970, to: statement, at: 14)
-            try bind(try encoder.encode(session), to: statement, at: 15)
+            try bind(record.manualNotes, to: statement, at: 10)
+            try bind(record.updatedAt.timeIntervalSince1970, to: statement, at: 11)
+            try bind(record.isDeleted ? record.updatedAt.timeIntervalSince1970 : nil, to: statement, at: 12)
+            try bind(record.id, to: statement, at: 13)
+            try bind(record.cloudChangeTag, to: statement, at: 14)
+            try bind(Date().timeIntervalSince1970, to: statement, at: 15)
+            try bind(try encoder.encode(sessionWithManualNotes), to: statement, at: 16)
         }
 
         try execute("DELETE FROM transcripts WHERE session_id = ?", db: db) { statement in
@@ -1925,6 +1974,7 @@ private struct SharedStoreDatabase {
         keeps_audio_recording INTEGER NOT NULL DEFAULT 0,
         transcript_id TEXT,
         engine_identifier TEXT,
+        manual_notes TEXT,
         error_message TEXT,
         updated_at REAL NOT NULL DEFAULT 0,
         deleted_at REAL,

--- a/Tests/MuesliTests/DictationModelsTests.swift
+++ b/Tests/MuesliTests/DictationModelsTests.swift
@@ -47,10 +47,12 @@ final class DictationModelsTests: XCTestCase {
     }
 
     func testSyncOriginClassifiesRemoteSourcesAsFromMac() {
+        let macMeetingRecordName = "meeting-\(UUID().uuidString)"
         XCTAssertEqual(SyncOrigin.classify(source: "macos"), .fromMac)
         XCTAssertEqual(SyncOrigin.classify(source: "meeting"), .fromMac)
         XCTAssertEqual(SyncOrigin.classify(source: nil, engineIdentifier: "icloud"), .fromMac)
         XCTAssertEqual(SyncOrigin.classify(source: nil, cloudRecordName: "meeting-123"), .fromMac)
+        XCTAssertEqual(SyncOrigin.classify(source: "ios", cloudRecordName: macMeetingRecordName), .fromMac)
         XCTAssertEqual(SyncOrigin.classify(source: nil, importedFromCloud: true), .fromMac)
     }
 

--- a/Tests/MuesliTests/DictationModelsTests.swift
+++ b/Tests/MuesliTests/DictationModelsTests.swift
@@ -56,6 +56,17 @@ final class DictationModelsTests: XCTestCase {
         XCTAssertEqual(SyncOrigin.classify(source: nil, importedFromCloud: true), .fromMac)
     }
 
+    func testRecordingSessionSyncOriginUsesCloudRecordNameBeforeStaleSource() {
+        let session = RecordingSession(
+            kind: .meeting,
+            engineIdentifier: nil,
+            source: "ios",
+            cloudRecordName: "meeting-\(UUID().uuidString)"
+        )
+
+        XCTAssertEqual(session.syncOrigin, .fromMac)
+    }
+
     func testFillerWordFilterRemovesCommonDisfluencies() {
         let filtered = FillerWordFilter.apply("um you know, muesli is kind of working")
 

--- a/Tests/MuesliTests/DictationModelsTests.swift
+++ b/Tests/MuesliTests/DictationModelsTests.swift
@@ -38,6 +38,22 @@ final class DictationModelsTests: XCTestCase {
         XCTAssertNil(decoded.source)
     }
 
+    func testSyncOriginClassifiesLocalSourcesAsThisIPhone() {
+        XCTAssertEqual(SyncOrigin.classify(source: nil), .thisIPhone)
+        XCTAssertEqual(SyncOrigin.classify(source: "ios"), .thisIPhone)
+        XCTAssertEqual(SyncOrigin.classify(source: "iPhone"), .thisIPhone)
+        XCTAssertEqual(SyncOrigin.classify(source: "app"), .thisIPhone)
+        XCTAssertEqual(SyncOrigin.classify(source: "keyboard"), .thisIPhone)
+    }
+
+    func testSyncOriginClassifiesRemoteSourcesAsFromMac() {
+        XCTAssertEqual(SyncOrigin.classify(source: "macos"), .fromMac)
+        XCTAssertEqual(SyncOrigin.classify(source: "meeting"), .fromMac)
+        XCTAssertEqual(SyncOrigin.classify(source: nil, engineIdentifier: "icloud"), .fromMac)
+        XCTAssertEqual(SyncOrigin.classify(source: nil, cloudRecordName: "meeting-123"), .fromMac)
+        XCTAssertEqual(SyncOrigin.classify(source: nil, importedFromCloud: true), .fromMac)
+    }
+
     func testFillerWordFilterRemovesCommonDisfluencies() {
         let filtered = FillerWordFilter.apply("um you know, muesli is kind of working")
 

--- a/Tests/MuesliTests/MeetingLifecycleReducerTests.swift
+++ b/Tests/MuesliTests/MeetingLifecycleReducerTests.swift
@@ -1,0 +1,64 @@
+import XCTest
+@testable import Muesli
+
+final class MeetingLifecycleReducerTests: XCTestCase {
+    func testLifecycleMovesThroughRecordingAndTranscription() {
+        let sessionID = UUID()
+
+        var state = MeetingLifecycleReducer.reduce(
+            MeetingLifecycleState(),
+            event: .startRequested(sessionID)
+        )
+        XCTAssertEqual(state.phase, .starting(sessionID))
+        XCTAssertEqual(state.activeSessionID, sessionID)
+        XCTAssertTrue(state.isRecordingVisible)
+
+        state = MeetingLifecycleReducer.reduce(state, event: .recordingStarted(sessionID))
+        XCTAssertEqual(state.phase, .recording(sessionID))
+        XCTAssertTrue(state.isRecordingVisible)
+
+        state = MeetingLifecycleReducer.reduce(state, event: .stopRequested(sessionID))
+        XCTAssertEqual(state.phase, .stopping(sessionID))
+        XCTAssertTrue(state.isRecordingVisible)
+
+        state = MeetingLifecycleReducer.reduce(state, event: .transcriptionStarted(sessionID))
+        XCTAssertEqual(state.phase, .transcribing(sessionID))
+        XCTAssertFalse(state.isRecordingVisible)
+
+        state = MeetingLifecycleReducer.reduce(state, event: .finished(sessionID))
+        XCTAssertEqual(state.phase, .idle)
+        XCTAssertNil(state.activeSessionID)
+    }
+
+    func testLifecycleIgnoresEventsForStaleSessions() {
+        let activeID = UUID()
+        let staleID = UUID()
+        let activeState = MeetingLifecycleReducer.reduce(
+            MeetingLifecycleState(),
+            event: .startRequested(activeID)
+        )
+
+        XCTAssertEqual(
+            MeetingLifecycleReducer.reduce(activeState, event: .recordingStarted(staleID)),
+            activeState
+        )
+        XCTAssertEqual(
+            MeetingLifecycleReducer.reduce(activeState, event: .finished(staleID)),
+            activeState
+        )
+    }
+
+    func testLifecycleCancellationBecomesNonRecordingTerminalWork() {
+        let sessionID = UUID()
+        var state = MeetingLifecycleReducer.reduce(
+            MeetingLifecycleState(),
+            event: .startRequested(sessionID)
+        )
+
+        state = MeetingLifecycleReducer.reduce(state, event: .cancelRequested(sessionID))
+
+        XCTAssertEqual(state.phase, .cancelling(sessionID))
+        XCTAssertTrue(state.isCancelling)
+        XCTAssertFalse(state.isRecordingVisible)
+    }
+}

--- a/Tests/MuesliTests/MeetingLifecycleReducerTests.swift
+++ b/Tests/MuesliTests/MeetingLifecycleReducerTests.swift
@@ -61,4 +61,17 @@ final class MeetingLifecycleReducerTests: XCTestCase {
         XCTAssertTrue(state.isCancelling)
         XCTAssertFalse(state.isRecordingVisible)
     }
+
+    func testLifecycleReportsOnlyTheActiveStartupSessionAsStarting() {
+        let sessionID = UUID()
+        let otherID = UUID()
+        let state = MeetingLifecycleReducer.reduce(
+            MeetingLifecycleState(),
+            event: .startRequested(sessionID)
+        )
+
+        XCTAssertTrue(state.isStarting(sessionID: sessionID))
+        XCTAssertFalse(state.isStarting(sessionID: otherID))
+        XCTAssertFalse(MeetingLifecycleState().isStarting(sessionID: sessionID))
+    }
 }

--- a/Tests/MuesliTests/SharedStoreTests.swift
+++ b/Tests/MuesliTests/SharedStoreTests.swift
@@ -737,6 +737,64 @@ final class SharedStoreTests: XCTestCase {
         XCTAssertEqual(syncedTranscript.summaryText, "New remote summary")
     }
 
+    func testStaleSyncedMeetingWithoutManualNotesDoesNotOverwriteNewerLocalState() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let store = SharedStore(containerURL: directory)
+        let transcriptID = UUID()
+        let session = RecordingSession(
+            id: UUID(),
+            requestID: nil,
+            kind: .meeting,
+            title: "Local completed meeting",
+            createdAt: Date(timeIntervalSince1970: 1_000),
+            phase: .completed,
+            transcriptID: transcriptID,
+            engineIdentifier: "local-engine",
+            source: "ios",
+            cloudRecordName: nil
+        )
+        try store.saveSession(session)
+        try store.saveTranscript(Transcript(
+            id: transcriptID,
+            sessionID: session.id,
+            text: "Local completed transcript",
+            createdAt: Date(timeIntervalSince1970: 1_000),
+            engineIdentifier: "local-engine",
+            summaryText: "Local summary"
+        ))
+
+        try store.upsertSyncedTextRecord(SyncTextRecord(
+            id: session.id.uuidString,
+            kind: .meeting,
+            title: "Stale remote title",
+            text: "Stale remote transcript",
+            speakerTranscript: nil,
+            summaryText: "Stale remote summary",
+            manualNotes: nil,
+            source: "macos",
+            engineIdentifier: "icloud",
+            createdAt: Date(timeIntervalSince1970: 900),
+            updatedAt: Date(timeIntervalSince1970: 950),
+            manualNotesUpdatedAt: nil,
+            startedAt: Date(timeIntervalSince1970: 900),
+            endedAt: Date(timeIntervalSince1970: 940),
+            durationSeconds: 40,
+            wordCount: 3,
+            isDeleted: false,
+            cloudChangeTag: "stale-tag"
+        ))
+
+        let syncedSession = try XCTUnwrap(try store.recordingSession(id: session.id))
+        let syncedTranscript = try XCTUnwrap(try store.transcript(for: session.id))
+        XCTAssertEqual(syncedSession.title, "Local completed meeting")
+        XCTAssertEqual(syncedSession.phase, .completed)
+        XCTAssertEqual(syncedSession.engineIdentifier, "local-engine")
+        XCTAssertEqual(syncedTranscript.text, "Local completed transcript")
+        XCTAssertEqual(syncedTranscript.summaryText, "Local summary")
+    }
+
     func testSyncedMeetingWithoutSourceDefaultsToMacOrigin() throws {
         let directory = try makeTemporaryDirectory()
         defer { try? FileManager.default.removeItem(at: directory) }

--- a/Tests/MuesliTests/SharedStoreTests.swift
+++ b/Tests/MuesliTests/SharedStoreTests.swift
@@ -3,14 +3,14 @@ import SQLite3
 @testable import Muesli
 
 final class SharedStoreTests: XCTestCase {
-    func testFreshSQLiteStoreCreatesV2Schema() throws {
+    func testFreshSQLiteStoreCreatesV3Schema() throws {
         let directory = try makeTemporaryDirectory()
         defer { try? FileManager.default.removeItem(at: directory) }
 
         let store = SharedStore(containerURL: directory)
         XCTAssertEqual(try store.resultsHistory(), [])
 
-        XCTAssertEqual(try sqliteInt("PRAGMA user_version", in: directory), 2)
+        XCTAssertEqual(try sqliteInt("PRAGMA user_version", in: directory), 3)
         XCTAssertTrue(try sqliteColumnNames(table: "result_history", in: directory).isSuperset(of: [
             "session_id",
             "text",
@@ -23,6 +23,7 @@ final class SharedStoreTests: XCTestCase {
             "sync_dirty"
         ]))
         XCTAssertTrue(try sqliteColumnNames(table: "recording_sessions", in: directory).contains("audio_file_name"))
+        XCTAssertTrue(try sqliteColumnNames(table: "recording_sessions", in: directory).contains("manual_notes"))
         XCTAssertTrue(try sqliteColumnNames(table: "transcripts", in: directory).contains("summary_model"))
         XCTAssertTrue(try sqliteColumnNames(table: "custom_words", in: directory).contains("matching_threshold"))
     }
@@ -75,7 +76,7 @@ final class SharedStoreTests: XCTestCase {
         XCTAssertEqual(try sqliteString("SELECT text FROM result_history LIMIT 1", in: directory), "migrated dictation")
         XCTAssertEqual(try sqliteString("SELECT engine_identifier FROM result_history LIMIT 1", in: directory), "parakeet-v3")
         XCTAssertEqual(try sqliteString("SELECT replacement FROM custom_words LIMIT 1", in: directory), "Muesli")
-        XCTAssertEqual(try sqliteInt("PRAGMA user_version", in: directory), 2)
+        XCTAssertEqual(try sqliteInt("PRAGMA user_version", in: directory), 3)
     }
 
     func testResultsHistoryPersistsSortedResultsAfterOneOffResultIsCleared() throws {
@@ -595,6 +596,66 @@ final class SharedStoreTests: XCTestCase {
         XCTAssertEqual(record.source, "macos")
     }
 
+    func testMeetingManualNotesPersistAndSync() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let store = SharedStore(containerURL: directory)
+        let session = RecordingSession(
+            id: UUID(),
+            requestID: UUID(),
+            kind: .meeting,
+            title: "Design review",
+            createdAt: Date(timeIntervalSince1970: 100),
+            phase: .recording,
+            source: "ios"
+        )
+        try store.saveSession(session)
+        try store.updateMeetingManualNotes(sessionID: session.id, manualNotes: "Follow up with Alex.")
+
+        let saved = try XCTUnwrap(try store.recordingSession(id: session.id))
+        XCTAssertEqual(saved.manualNotes, "Follow up with Alex.")
+        XCTAssertEqual(
+            try sqliteString("SELECT manual_notes FROM recording_sessions WHERE id = '\(session.id.uuidString)'", in: directory),
+            "Follow up with Alex."
+        )
+
+        let record = try XCTUnwrap(try store.textRecordsNeedingSync().first { $0.kind == .meeting })
+        XCTAssertEqual(record.manualNotes, "Follow up with Alex.")
+    }
+
+    func testSyncedMeetingPreservesManualNotes() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let store = SharedStore(containerURL: directory)
+        let recordID = UUID().uuidString
+        try store.upsertSyncedTextRecord(SyncTextRecord(
+            id: recordID,
+            kind: .meeting,
+            title: "Mac sync",
+            text: "Transcript",
+            speakerTranscript: nil,
+            summaryText: "Summary",
+            manualNotes: "Mac-side written notes",
+            source: "macos",
+            engineIdentifier: "icloud",
+            createdAt: Date(timeIntervalSince1970: 100),
+            updatedAt: Date(timeIntervalSince1970: 150),
+            startedAt: Date(timeIntervalSince1970: 90),
+            endedAt: Date(timeIntervalSince1970: 140),
+            durationSeconds: 50,
+            wordCount: 4,
+            isDeleted: false,
+            cloudChangeTag: "tag"
+        ))
+
+        let sessionID = try XCTUnwrap(UUID(uuidString: recordID))
+        let session = try XCTUnwrap(try store.recordingSession(id: sessionID))
+        XCTAssertEqual(session.manualNotes, "Mac-side written notes")
+        XCTAssertEqual(session.source, "macos")
+    }
+
     func testRecordingSessionDecodesLegacyPayloadWithoutAudioRetentionFlag() throws {
         let session = RecordingSession(
             kind: .meeting,
@@ -781,7 +842,7 @@ final class SharedStoreTests: XCTestCase {
         XCTAssertEqual(try store.recordingSessions(), [session])
         XCTAssertEqual(try store.transcript(for: session.id), transcript)
         XCTAssertEqual(try store.customWords(), [customWord])
-        XCTAssertEqual(try sqliteInt("PRAGMA user_version", in: directory), 2)
+        XCTAssertEqual(try sqliteInt("PRAGMA user_version", in: directory), 3)
         XCTAssertEqual(try sqliteString("SELECT text FROM result_history LIMIT 1", in: directory), "legacy sqlite dictation")
         XCTAssertEqual(try sqliteString("SELECT audio_file_name FROM recording_sessions LIMIT 1", in: directory), "legacy.wav")
         XCTAssertEqual(try sqliteString("SELECT summary_text FROM transcripts LIMIT 1", in: directory), "Legacy notes")

--- a/Tests/MuesliTests/SharedStoreTests.swift
+++ b/Tests/MuesliTests/SharedStoreTests.swift
@@ -654,6 +654,7 @@ final class SharedStoreTests: XCTestCase {
         let session = try XCTUnwrap(try store.recordingSession(id: sessionID))
         XCTAssertEqual(session.manualNotes, "Mac-side written notes")
         XCTAssertEqual(session.source, "macos")
+        XCTAssertEqual(session.cloudRecordName, recordID)
     }
 
     func testSyncedMeetingWithoutSourceDefaultsToMacOrigin() throws {
@@ -685,6 +686,38 @@ final class SharedStoreTests: XCTestCase {
         let sessionID = try XCTUnwrap(UUID(uuidString: recordID))
         let session = try XCTUnwrap(try store.recordingSession(id: sessionID))
         XCTAssertEqual(session.source, "macos")
+        XCTAssertEqual(session.cloudRecordName, recordID)
+    }
+
+    func testSyncedMacMeetingWithStaleIOSSourceClassifiesFromCloudRecordName() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let store = SharedStore(containerURL: directory)
+        let recordID = "meeting-\(UUID().uuidString)"
+        try store.upsertSyncedTextRecord(SyncTextRecord(
+            id: recordID,
+            kind: .meeting,
+            title: "Legacy source sync",
+            text: "Transcript",
+            speakerTranscript: nil,
+            summaryText: nil,
+            manualNotes: nil,
+            source: "ios",
+            engineIdentifier: nil,
+            createdAt: Date(timeIntervalSince1970: 100),
+            updatedAt: Date(timeIntervalSince1970: 150),
+            startedAt: Date(timeIntervalSince1970: 90),
+            endedAt: Date(timeIntervalSince1970: 140),
+            durationSeconds: 50,
+            wordCount: 1,
+            isDeleted: false,
+            cloudChangeTag: "tag"
+        ))
+
+        let session = try XCTUnwrap(try store.recordingSessions().first { $0.cloudRecordName == recordID })
+        XCTAssertEqual(session.source, "ios")
+        XCTAssertEqual(SyncOrigin.classify(source: session.source, cloudRecordName: session.cloudRecordName), .fromMac)
     }
 
     func testRecordingSessionDecodesLegacyPayloadWithoutAudioRetentionFlag() throws {

--- a/Tests/MuesliTests/SharedStoreTests.swift
+++ b/Tests/MuesliTests/SharedStoreTests.swift
@@ -656,6 +656,37 @@ final class SharedStoreTests: XCTestCase {
         XCTAssertEqual(session.source, "macos")
     }
 
+    func testSyncedMeetingWithoutSourceDefaultsToMacOrigin() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let store = SharedStore(containerURL: directory)
+        let recordID = UUID().uuidString
+        try store.upsertSyncedTextRecord(SyncTextRecord(
+            id: recordID,
+            kind: .meeting,
+            title: "Legacy Mac sync",
+            text: "Transcript",
+            speakerTranscript: nil,
+            summaryText: nil,
+            manualNotes: nil,
+            source: nil,
+            engineIdentifier: nil,
+            createdAt: Date(timeIntervalSince1970: 100),
+            updatedAt: Date(timeIntervalSince1970: 150),
+            startedAt: Date(timeIntervalSince1970: 90),
+            endedAt: Date(timeIntervalSince1970: 140),
+            durationSeconds: 50,
+            wordCount: 1,
+            isDeleted: false,
+            cloudChangeTag: "tag"
+        ))
+
+        let sessionID = try XCTUnwrap(UUID(uuidString: recordID))
+        let session = try XCTUnwrap(try store.recordingSession(id: sessionID))
+        XCTAssertEqual(session.source, "macos")
+    }
+
     func testRecordingSessionDecodesLegacyPayloadWithoutAudioRetentionFlag() throws {
         let session = RecordingSession(
             kind: .meeting,

--- a/Tests/MuesliTests/SharedStoreTests.swift
+++ b/Tests/MuesliTests/SharedStoreTests.swift
@@ -3,14 +3,14 @@ import SQLite3
 @testable import Muesli
 
 final class SharedStoreTests: XCTestCase {
-    func testFreshSQLiteStoreCreatesV3Schema() throws {
+    func testFreshSQLiteStoreCreatesV4Schema() throws {
         let directory = try makeTemporaryDirectory()
         defer { try? FileManager.default.removeItem(at: directory) }
 
         let store = SharedStore(containerURL: directory)
         XCTAssertEqual(try store.resultsHistory(), [])
 
-        XCTAssertEqual(try sqliteInt("PRAGMA user_version", in: directory), 3)
+        XCTAssertEqual(try sqliteInt("PRAGMA user_version", in: directory), 4)
         XCTAssertTrue(try sqliteColumnNames(table: "result_history", in: directory).isSuperset(of: [
             "session_id",
             "text",
@@ -24,6 +24,7 @@ final class SharedStoreTests: XCTestCase {
         ]))
         XCTAssertTrue(try sqliteColumnNames(table: "recording_sessions", in: directory).contains("audio_file_name"))
         XCTAssertTrue(try sqliteColumnNames(table: "recording_sessions", in: directory).contains("manual_notes"))
+        XCTAssertTrue(try sqliteColumnNames(table: "recording_sessions", in: directory).contains("manual_notes_updated_at"))
         XCTAssertTrue(try sqliteColumnNames(table: "transcripts", in: directory).contains("summary_model"))
         XCTAssertTrue(try sqliteColumnNames(table: "custom_words", in: directory).contains("matching_threshold"))
     }
@@ -76,7 +77,7 @@ final class SharedStoreTests: XCTestCase {
         XCTAssertEqual(try sqliteString("SELECT text FROM result_history LIMIT 1", in: directory), "migrated dictation")
         XCTAssertEqual(try sqliteString("SELECT engine_identifier FROM result_history LIMIT 1", in: directory), "parakeet-v3")
         XCTAssertEqual(try sqliteString("SELECT replacement FROM custom_words LIMIT 1", in: directory), "Muesli")
-        XCTAssertEqual(try sqliteInt("PRAGMA user_version", in: directory), 3)
+        XCTAssertEqual(try sqliteInt("PRAGMA user_version", in: directory), 4)
     }
 
     func testResultsHistoryPersistsSortedResultsAfterOneOffResultIsCleared() throws {
@@ -680,6 +681,62 @@ final class SharedStoreTests: XCTestCase {
         XCTAssertEqual(session.cloudRecordName, recordID)
     }
 
+    func testSyncedMeetingDoesNotClobberNewerLocalManualNotesWithStaleRemoteNotes() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let store = SharedStore(containerURL: directory)
+        let session = RecordingSession(
+            id: UUID(),
+            requestID: nil,
+            kind: .meeting,
+            title: "Conflict sync",
+            createdAt: Date(timeIntervalSince1970: 100),
+            phase: .completed,
+            transcriptID: UUID(),
+            engineIdentifier: "icloud",
+            source: "ios",
+            cloudRecordName: nil
+        )
+        try store.saveSession(session)
+        try store.saveTranscript(Transcript(
+            id: try XCTUnwrap(session.transcriptID),
+            sessionID: session.id,
+            text: "Old transcript",
+            createdAt: Date(timeIntervalSince1970: 100),
+            engineIdentifier: "icloud",
+            summaryText: "Old summary"
+        ))
+        try store.updateMeetingManualNotes(sessionID: session.id, manualNotes: "New local notes")
+
+        try store.upsertSyncedTextRecord(SyncTextRecord(
+            id: session.id.uuidString,
+            kind: .meeting,
+            title: "Conflict sync",
+            text: "New remote transcript",
+            speakerTranscript: nil,
+            summaryText: "New remote summary",
+            manualNotes: "Stale remote notes",
+            source: "macos",
+            engineIdentifier: "icloud",
+            createdAt: Date(timeIntervalSince1970: 100),
+            updatedAt: Date().addingTimeInterval(60),
+            manualNotesUpdatedAt: Date(timeIntervalSince1970: 120),
+            startedAt: Date(timeIntervalSince1970: 90),
+            endedAt: Date(timeIntervalSince1970: 140),
+            durationSeconds: 50,
+            wordCount: 6,
+            isDeleted: false,
+            cloudChangeTag: "newer-transcript-tag"
+        ))
+
+        let syncedSession = try XCTUnwrap(try store.recordingSession(id: session.id))
+        let syncedTranscript = try XCTUnwrap(try store.transcript(for: session.id))
+        XCTAssertEqual(syncedSession.manualNotes, "New local notes")
+        XCTAssertEqual(syncedTranscript.text, "New remote transcript")
+        XCTAssertEqual(syncedTranscript.summaryText, "New remote summary")
+    }
+
     func testSyncedMeetingWithoutSourceDefaultsToMacOrigin() throws {
         let directory = try makeTemporaryDirectory()
         defer { try? FileManager.default.removeItem(at: directory) }
@@ -931,7 +988,7 @@ final class SharedStoreTests: XCTestCase {
         XCTAssertEqual(try store.recordingSessions(), [expectedSession])
         XCTAssertEqual(try store.transcript(for: session.id), transcript)
         XCTAssertEqual(try store.customWords(), [customWord])
-        XCTAssertEqual(try sqliteInt("PRAGMA user_version", in: directory), 3)
+        XCTAssertEqual(try sqliteInt("PRAGMA user_version", in: directory), 4)
         XCTAssertEqual(try sqliteString("SELECT text FROM result_history LIMIT 1", in: directory), "legacy sqlite dictation")
         XCTAssertEqual(try sqliteString("SELECT audio_file_name FROM recording_sessions LIMIT 1", in: directory), "legacy.wav")
         XCTAssertEqual(try sqliteString("SELECT summary_text FROM transcripts LIMIT 1", in: directory), "Legacy notes")

--- a/Tests/MuesliTests/SharedStoreTests.swift
+++ b/Tests/MuesliTests/SharedStoreTests.swift
@@ -624,6 +624,29 @@ final class SharedStoreTests: XCTestCase {
         XCTAssertEqual(record.manualNotes, "Follow up with Alex.")
     }
 
+    func testUpdateMeetingManualNotesReportsMissingOrNonMeetingSession() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let store = SharedStore(containerURL: directory)
+        let dictationSession = RecordingSession(
+            id: UUID(),
+            requestID: UUID(),
+            kind: .quickDictation,
+            title: "Voice note",
+            createdAt: Date(timeIntervalSince1970: 100),
+            phase: .completed,
+            source: "ios"
+        )
+        try store.saveSession(dictationSession)
+
+        XCTAssertFalse(try store.updateMeetingManualNotes(sessionID: UUID(), manualNotes: "Missing"))
+        XCTAssertFalse(try store.updateMeetingManualNotes(sessionID: dictationSession.id, manualNotes: "Wrong kind"))
+
+        let saved = try XCTUnwrap(try store.recordingSession(id: dictationSession.id))
+        XCTAssertNil(saved.manualNotes)
+    }
+
     func testSyncedMeetingPreservesManualNotes() throws {
         let directory = try makeTemporaryDirectory()
         defer { try? FileManager.default.removeItem(at: directory) }
@@ -901,9 +924,11 @@ final class SharedStoreTests: XCTestCase {
         )
 
         let store = SharedStore(containerURL: directory)
+        var expectedSession = session
+        expectedSession.cloudRecordName = session.id.uuidString
 
         XCTAssertEqual(try store.resultsHistory(), [result])
-        XCTAssertEqual(try store.recordingSessions(), [session])
+        XCTAssertEqual(try store.recordingSessions(), [expectedSession])
         XCTAssertEqual(try store.transcript(for: session.id), transcript)
         XCTAssertEqual(try store.customWords(), [customWord])
         XCTAssertEqual(try sqliteInt("PRAGMA user_version", in: directory), 3)

--- a/Tests/MuesliUITests/MuesliSmokeUITests.swift
+++ b/Tests/MuesliUITests/MuesliSmokeUITests.swift
@@ -30,5 +30,6 @@ final class MuesliSmokeUITests: XCTestCase {
         app.buttons["tab.meetings"].tap()
 
         XCTAssertTrue(app.staticTexts["Meetings"].waitForExistence(timeout: 5))
+        XCTAssertTrue(app.staticTexts["Start a new meeting"].waitForExistence(timeout: 5))
     }
 }

--- a/Tests/MuesliUITests/MuesliSmokeUITests.swift
+++ b/Tests/MuesliUITests/MuesliSmokeUITests.swift
@@ -30,7 +30,5 @@ final class MuesliSmokeUITests: XCTestCase {
         app.buttons["tab.meetings"].tap()
 
         XCTAssertTrue(app.staticTexts["Meetings"].waitForExistence(timeout: 5))
-        XCTAssertTrue(app.staticTexts["Meeting Recorder"].exists)
-        XCTAssertTrue(app.buttons["Start Meeting"].exists)
     }
 }

--- a/project.yml
+++ b/project.yml
@@ -22,7 +22,7 @@ settings:
 packages:
   FluidAudio:
     url: https://github.com/FluidInference/FluidAudio.git
-    from: "0.14.5"
+    exactVersion: "0.14.5"
   TelemetryDeck:
     url: https://github.com/TelemetryDeck/SwiftSDK
     from: "2.12.0"


### PR DESCRIPTION
## Summary
- redesign the Meetings browser/detail flow around browser, active meeting, and completed meeting states
- move active meeting stop/discard controls so Stop Meeting is the primary action and discard is a secondary trash icon
- make meeting audio retention honor the Save Meeting Audio setting, with explicit delete retained audio support
- remove the meetings-page summary backend selector and keep summary provider selection in Settings
- restore the official Muesli app icon in the Meetings header

## Validation
- xcodebuild build -project MuesliiOS.xcodeproj -scheme Muesli -configuration Debug -destination "platform=iOS Simulator,name=iPhone 17 Pro" -derivedDataPath build/meetings-audio-retention
- xcodebuild build -project MuesliiOS.xcodeproj -scheme Muesli -configuration Debug -destination "platform=iOS,id=00008140-001C6D2C11FA801C" -derivedDataPath build/picophone-meetings-revamp
- installed and launched on Picophone with devicectl

## Notes
- Temporary meeting audio may still exist while processing because transcription/diarization need it; completed or failed sessions clean it up unless Save Meeting Audio is enabled.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli-ios/pr/17"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786049246&installation_id=136549638&pr_number=17&repository=Muesli-HQ%2Fmuesli-ios&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli-ios%2Fpull%2F17&signature=9d2cf627e6cb81eefda5fa09f97afa1cbdb79fec9b1e56a161abd52aa63f50d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced Meetings browsing with search, filters/sorting, redesigned meeting rows, and swipe actions.
  * Added meeting manual notes with a “Written Notes” section (including for exported notes and failure summaries).
  * Added retained-audio export and improved audio deletion confirmation flows.
* **Bug Fixes**
  * Reworked meeting recording/transcription lifecycle for more reliable busy behavior and smoother keyboard resume/retry.
  * Improved transcript saving/finalization using transcript caching, and ensured discard/cancel behavior is consistent.
* **Tests**
  * Expanded coverage for meeting lifecycle transitions, manual-notes persistence/sync/conflict handling, and sync-origin classification (plus related UI adjustments).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->