### PR TITLE
Add structured failure telemetry

### DIFF
--- a/Muesli/AppTelemetry.swift
+++ b/Muesli/AppTelemetry.swift
@@ -1,11 +1,23 @@
 import Foundation
 import TelemetryDeck
+import UIKit
+
+enum AppTelemetryFailureDomain: String {
+    case audio
+    case cloudSync = "cloud_sync"
+    case keyboardSession = "keyboard_session"
+    case meeting
+    case model
+    case summary
+    case transcription
+}
 
 @MainActor
 enum AppTelemetry {
     private static let appIDInfoKey = "MuesliTelemetryDeckAppID"
     private static let fallbackAppID = "A851C6BD-4F55-41ED-A6BC-DA43C850B069"
     private static var isInitialized = false
+    private static let maxParameterLength = 96
 
     static func configure() {
         signal("app_launched")
@@ -14,6 +26,36 @@ enum AppTelemetry {
     static func signal(_ name: String, parameters: [String: String] = [:]) {
         guard initializeIfNeeded() else { return }
         TelemetryDeck.signal("Muesli.iOS.\(name)", parameters: parameters)
+    }
+
+    static func failure(
+        _ name: String,
+        domain: AppTelemetryFailureDomain,
+        stage: String,
+        error: Error? = nil,
+        reason: String? = nil,
+        isTimeout: Bool = false,
+        parameters: [String: String] = [:]
+    ) {
+        var enriched = runtimeParameters()
+        enriched["failure_domain"] = domain.rawValue
+        enriched["failure_stage"] = normalizedParameterValue(stage)
+        if let reason {
+            enriched["failure_reason"] = normalizedParameterValue(reason)
+        }
+        if isTimeout {
+            enriched["timeout"] = "true"
+        }
+        if let error {
+            enriched.merge(errorParameters(for: error), uniquingKeysWith: { _, new in new })
+        }
+        enriched.merge(normalized(parameters), uniquingKeysWith: { _, new in new })
+
+        signal(name, parameters: enriched)
+
+        var aggregate = enriched
+        aggregate["failure_event"] = normalizedParameterValue(name)
+        signal("failure_observed", parameters: aggregate)
     }
 
     @discardableResult
@@ -29,5 +71,63 @@ enum AppTelemetry {
         TelemetryDeck.initialize(config: .init(appID: appID))
         isInitialized = true
         return true
+    }
+
+    private static func runtimeParameters() -> [String: String] {
+        [
+            "app_version": Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "unknown",
+            "app_build": Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? "unknown",
+            "ios_version": UIDevice.current.systemVersion,
+            "device_model": deviceModelIdentifier(),
+            "device_family": UIDevice.current.userInterfaceIdiom == .pad ? "ipad" : "iphone",
+        ]
+    }
+
+    private static func errorParameters(for error: Error) -> [String: String] {
+        let nsError = error as NSError
+        var parameters = [
+            "error_type": normalizedParameterValue(String(describing: type(of: error))),
+            "error_domain": normalizedParameterValue(nsError.domain),
+            "error_code": "\(nsError.code)",
+        ]
+
+        if nsError.domain == NSURLErrorDomain {
+            parameters["network_error"] = "true"
+        }
+        if nsError.domain == "CKErrorDomain" {
+            parameters["cloudkit_error"] = "true"
+        }
+
+        return parameters
+    }
+
+    private static func normalized(_ parameters: [String: String]) -> [String: String] {
+        parameters.reduce(into: [:]) { result, element in
+            result[normalizedParameterKey(element.key)] = normalizedParameterValue(element.value)
+        }
+    }
+
+    private static func normalizedParameterKey(_ value: String) -> String {
+        let allowed = CharacterSet(charactersIn: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_")
+        let scalars = value.unicodeScalars.map { allowed.contains($0) ? Character($0) : "_" }
+        let normalized = String(scalars).lowercased()
+        return normalized.isEmpty ? "unknown" : String(normalized.prefix(48))
+    }
+
+    private static func normalizedParameterValue(_ value: String) -> String {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return "unknown" }
+        return String(trimmed.prefix(maxParameterLength))
+    }
+
+    private static func deviceModelIdentifier() -> String {
+        var systemInfo = utsname()
+        uname(&systemInfo)
+        let mirror = Mirror(reflecting: systemInfo.machine)
+        let identifier = mirror.children.reduce(into: "") { result, element in
+            guard let value = element.value as? Int8, value != 0 else { return }
+            result.append(String(UnicodeScalar(UInt8(value))))
+        }
+        return identifier.isEmpty ? "unknown" : identifier
     }
 }

--- a/Muesli/AppTelemetry.swift
+++ b/Muesli/AppTelemetry.swift
@@ -6,10 +6,57 @@ enum AppTelemetryFailureDomain: String {
     case audio
     case cloudSync = "cloud_sync"
     case keyboardSession = "keyboard_session"
+    case liveActivity = "live_activity"
     case meeting
     case model
     case summary
     case transcription
+}
+
+enum AppTelemetryParameterSanitizer {
+    static let maxKeyLength = 48
+    static let maxValueLength = 96
+
+    private static let allowedKeyCharacters = CharacterSet(
+        charactersIn: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_"
+    )
+    private static let reservedKeys: Set<String> = [
+        "app_version",
+        "app_build",
+        "cloudkit_error",
+        "device_family",
+        "device_model",
+        "error_code",
+        "error_domain",
+        "error_type",
+        "failure_domain",
+        "failure_event",
+        "failure_reason",
+        "failure_stage",
+        "ios_version",
+        "network_error",
+        "timeout",
+    ]
+
+    static func normalizedKey(_ value: String) -> String {
+        let scalars = value.unicodeScalars.map { allowedKeyCharacters.contains($0) ? Character($0) : "_" }
+        let normalized = String(scalars).lowercased()
+        return normalized.isEmpty ? "unknown" : String(normalized.prefix(maxKeyLength))
+    }
+
+    static func normalizedValue(_ value: String) -> String {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return "unknown" }
+        return String(trimmed.prefix(maxValueLength))
+    }
+
+    static func normalizedCustomParameters(_ parameters: [String: String]) -> [String: String] {
+        parameters.reduce(into: [:]) { result, element in
+            let key = normalizedKey(element.key)
+            let outputKey = reservedKeys.contains(key) ? normalizedKey("custom_\(key)") : key
+            result[outputKey] = normalizedValue(element.value)
+        }
+    }
 }
 
 @MainActor
@@ -17,7 +64,6 @@ enum AppTelemetry {
     private static let appIDInfoKey = "MuesliTelemetryDeckAppID"
     private static let fallbackAppID = "A851C6BD-4F55-41ED-A6BC-DA43C850B069"
     private static var isInitialized = false
-    private static let maxParameterLength = 96
 
     static func configure() {
         signal("app_launched")
@@ -39,9 +85,9 @@ enum AppTelemetry {
     ) {
         var enriched = runtimeParameters()
         enriched["failure_domain"] = domain.rawValue
-        enriched["failure_stage"] = normalizedParameterValue(stage)
+        enriched["failure_stage"] = AppTelemetryParameterSanitizer.normalizedValue(stage)
         if let reason {
-            enriched["failure_reason"] = normalizedParameterValue(reason)
+            enriched["failure_reason"] = AppTelemetryParameterSanitizer.normalizedValue(reason)
         }
         if isTimeout {
             enriched["timeout"] = "true"
@@ -49,12 +95,15 @@ enum AppTelemetry {
         if let error {
             enriched.merge(errorParameters(for: error), uniquingKeysWith: { _, new in new })
         }
-        enriched.merge(normalized(parameters), uniquingKeysWith: { _, new in new })
+        enriched.merge(
+            AppTelemetryParameterSanitizer.normalizedCustomParameters(parameters),
+            uniquingKeysWith: { _, new in new }
+        )
 
         signal(name, parameters: enriched)
 
         var aggregate = enriched
-        aggregate["failure_event"] = normalizedParameterValue(name)
+        aggregate["failure_event"] = AppTelemetryParameterSanitizer.normalizedValue(name)
         signal("failure_observed", parameters: aggregate)
     }
 
@@ -86,8 +135,8 @@ enum AppTelemetry {
     private static func errorParameters(for error: Error) -> [String: String] {
         let nsError = error as NSError
         var parameters = [
-            "error_type": normalizedParameterValue(String(describing: type(of: error))),
-            "error_domain": normalizedParameterValue(nsError.domain),
+            "error_type": AppTelemetryParameterSanitizer.normalizedValue(String(describing: type(of: error))),
+            "error_domain": AppTelemetryParameterSanitizer.normalizedValue(nsError.domain),
             "error_code": "\(nsError.code)",
         ]
 
@@ -99,25 +148,6 @@ enum AppTelemetry {
         }
 
         return parameters
-    }
-
-    private static func normalized(_ parameters: [String: String]) -> [String: String] {
-        parameters.reduce(into: [:]) { result, element in
-            result[normalizedParameterKey(element.key)] = normalizedParameterValue(element.value)
-        }
-    }
-
-    private static func normalizedParameterKey(_ value: String) -> String {
-        let allowed = CharacterSet(charactersIn: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_")
-        let scalars = value.unicodeScalars.map { allowed.contains($0) ? Character($0) : "_" }
-        let normalized = String(scalars).lowercased()
-        return normalized.isEmpty ? "unknown" : String(normalized.prefix(48))
-    }
-
-    private static func normalizedParameterValue(_ value: String) -> String {
-        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return "unknown" }
-        return String(trimmed.prefix(maxParameterLength))
     }
 
     private static func deviceModelIdentifier() -> String {

--- a/Muesli/DictationCoordinator.swift
+++ b/Muesli/DictationCoordinator.swift
@@ -1075,14 +1075,21 @@ final class DictationCoordinator {
                 self.iCloudSyncTask = nil
                 self.isICloudSyncInProgress = false
                 self.iCloudSyncStatusText = "Sync failed: \(error.localizedDescription)"
-                AppTelemetry.signal(
+                AppTelemetry.failure(
                     "icloud_text_sync_failed",
-                    parameters: ["reason": reason, "error": String(describing: type(of: error))]
+                    domain: .cloudSync,
+                    stage: "sync",
+                    error: error,
+                    reason: reason
                 )
                 if reason == "onboarding_bridge" || reason == "settings_toggle" {
-                    AppTelemetry.signal(
+                    AppTelemetry.failure(
                         "bridge_enable_failed",
-                        parameters: ["platform": "ios", "source": reason, "error": String(describing: type(of: error))]
+                        domain: .cloudSync,
+                        stage: "bridge_enable",
+                        error: error,
+                        reason: reason,
+                        parameters: ["platform": "ios", "source": reason]
                     )
                 }
                 self.runPendingICloudSyncIfNeeded()
@@ -1228,7 +1235,13 @@ final class DictationCoordinator {
                 phase: .failed,
                 message: isRecoverable ? Self.keyboardSessionRetryMessage : error.localizedDescription
             )
-            AppTelemetry.signal("keyboard_session_failed", parameters: ["error": String(describing: type(of: error))])
+            AppTelemetry.failure(
+                "keyboard_session_failed",
+                domain: .keyboardSession,
+                stage: "start",
+                error: error,
+                parameters: ["recoverable": isRecoverable ? "true" : "false"]
+            )
         }
     }
 
@@ -1403,12 +1416,12 @@ final class DictationCoordinator {
                         status: "Model setup paused",
                         detail: "Check your connection and try again"
                     )
-                    AppTelemetry.signal(
+                    AppTelemetry.failure(
                         "model_prepare_failed",
-                        parameters: [
-                            "engine": model.engineIdentifier,
-                            "error": String(describing: type(of: error))
-                        ]
+                        domain: .model,
+                        stage: "prepare",
+                        error: error,
+                        parameters: ["engine": model.engineIdentifier]
                     )
                 }
             }
@@ -1488,13 +1501,13 @@ final class DictationCoordinator {
                         status: "Warmup paused",
                         detail: "Muesli will try again when you record"
                     )
-                    AppTelemetry.signal(
+                    AppTelemetry.failure(
                         "model_prewarm_failed",
-                        parameters: [
-                            "engine": model.engineIdentifier,
-                            "reason": reason,
-                            "error": String(describing: type(of: error))
-                        ]
+                        domain: .model,
+                        stage: "prewarm",
+                        error: error,
+                        reason: reason,
+                        parameters: ["engine": model.engineIdentifier]
                     )
                 }
             }
@@ -1520,7 +1533,13 @@ final class DictationCoordinator {
             } catch {
                 onboardingTestError = error.localizedDescription
                 stopMetering()
-                AppTelemetry.signal("onboarding_test_failed", parameters: ["stage": "recording"])
+                AppTelemetry.failure(
+                    "onboarding_test_failed",
+                    domain: .audio,
+                    stage: "recording",
+                    error: error,
+                    parameters: ["surface": "onboarding"]
+                )
             }
         }
     }
@@ -1542,9 +1561,13 @@ final class DictationCoordinator {
                     guard let self else { return }
                     self.isOnboardingTestTranscribing = false
                     self.onboardingTestError = "Transcription stalled. Try again."
-                    AppTelemetry.signal(
+                    AppTelemetry.failure(
                         "onboarding_test_failed",
-                        parameters: ["stage": "transcription_timeout"]
+                        domain: .transcription,
+                        stage: "transcription_timeout",
+                        reason: "timeout",
+                        isTimeout: true,
+                        parameters: ["surface": "onboarding"]
                     )
                 } operation: { [engine] progress in
                     try await engine.transcribe(audioURL: audioURL, progress: progress)
@@ -1566,12 +1589,14 @@ final class DictationCoordinator {
             } catch {
                 isOnboardingTestTranscribing = false
                 onboardingTestError = error.localizedDescription
-                AppTelemetry.signal(
+                AppTelemetry.failure(
                     "onboarding_test_failed",
+                    domain: .transcription,
+                    stage: "transcription",
+                    error: error,
                     parameters: [
-                        "stage": "transcription",
                         "engine": engine.identifier,
-                        "error": String(describing: type(of: error))
+                        "surface": "onboarding"
                     ]
                 )
             }
@@ -1666,12 +1691,12 @@ final class DictationCoordinator {
                         status: "Model setup paused",
                         detail: "Download finished, but optimization failed"
                     )
-                    AppTelemetry.signal(
+                    AppTelemetry.failure(
                         "model_prepare_failed",
-                        parameters: [
-                            "engine": model.engineIdentifier,
-                            "error": String(describing: type(of: error))
-                        ]
+                        domain: .model,
+                        stage: "prepare_after_download",
+                        error: error,
+                        parameters: ["engine": model.engineIdentifier]
                     )
                 }
             }
@@ -1720,9 +1745,12 @@ final class DictationCoordinator {
                 } catch is CancellationError {
                     return
                 } catch {
-                    AppTelemetry.signal(
+                    AppTelemetry.failure(
                         "realtime_dictation_buffer_failed",
-                        parameters: ["error": String(describing: type(of: error))]
+                        domain: .transcription,
+                        stage: "streaming_buffer",
+                        error: error,
+                        parameters: ["surface": "dictation"]
                     )
                 }
             }
@@ -1909,7 +1937,13 @@ final class DictationCoordinator {
                 if !completedDeferredStop {
                     resumeKeyboardSessionKeeperIfNeeded()
                 }
-                AppTelemetry.signal("dictation_failed", parameters: ["stage": "recording"])
+                AppTelemetry.failure(
+                    "dictation_failed",
+                    domain: .audio,
+                    stage: "recording",
+                    error: error,
+                    parameters: ["source": source]
+                )
                 try? store.saveStatus(.init(requestID: request.id, phase: .failed, message: error.localizedDescription))
                 if source == "keyboard" {
                     saveKeyboardHandoff(
@@ -2055,12 +2089,12 @@ final class DictationCoordinator {
                     )
                     resumeKeyboardSessionKeeperIfNeeded()
                 }
-                AppTelemetry.signal(
+                AppTelemetry.failure(
                     "keyboard_transcription_recovery_failed",
-                    parameters: [
-                        "engine": engine.identifier,
-                        "error": String(describing: type(of: error))
-                    ]
+                    domain: .transcription,
+                    stage: "keyboard_recovery",
+                    error: error,
+                    parameters: ["engine": engine.identifier]
                 )
             }
         }
@@ -2364,13 +2398,12 @@ final class DictationCoordinator {
                 clearKeyboardLiveTranscript()
                 statusText = error.localizedDescription
                 refreshHistory()
-                AppTelemetry.signal(
+                AppTelemetry.failure(
                     "dictation_failed",
-                    parameters: [
-                        "stage": "transcription",
-                        "engine": engine.identifier,
-                        "error": String(describing: type(of: error))
-                    ]
+                    domain: .transcription,
+                    stage: "transcription",
+                    error: error,
+                    parameters: ["engine": engine.identifier]
                 )
                 try? store.saveStatus(.init(requestID: request.id, phase: .failed, message: error.localizedDescription))
                 if startedFromKeyboard {
@@ -2516,7 +2549,12 @@ final class DictationCoordinator {
             stopMetering()
             finishMeetingLifecycle(sessionID: session.id)
             refreshHistory()
-            AppTelemetry.signal("meeting_recording_failed", parameters: ["stage": "recording"])
+            AppTelemetry.failure(
+                "meeting_recording_failed",
+                domain: .meeting,
+                stage: "recording_start",
+                error: error
+            )
         }
     }
 
@@ -2654,7 +2692,12 @@ final class DictationCoordinator {
             meetingStatusText = error.localizedDescription
             finishMeetingLifecycle(sessionID: session.id)
             refreshHistory()
-            AppTelemetry.signal("meeting_recording_failed", parameters: ["stage": "stop"])
+            AppTelemetry.failure(
+                "meeting_recording_failed",
+                domain: .meeting,
+                stage: "stop",
+                error: error
+            )
         }
     }
 
@@ -2672,10 +2715,13 @@ final class DictationCoordinator {
                 try? FileManager.default.removeItem(at: chunk.url)
                 return MeetingChunkTranscription(chunk: chunk, result: result)
             } catch {
-                AppTelemetry.signal("meeting_chunk_transcription_failed", parameters: [
-                    "chunk": "\(chunk.index)",
-                    "error": String(describing: type(of: error))
-                ])
+                AppTelemetry.failure(
+                    "meeting_chunk_transcription_failed",
+                    domain: .transcription,
+                    stage: "meeting_chunk",
+                    error: error,
+                    parameters: ["chunk_index": "\(chunk.index)"]
+                )
                 return nil
             }
         }
@@ -2814,11 +2860,16 @@ final class DictationCoordinator {
                     detail: "Transcription failed",
                     session: session
                 )
-                AppTelemetry.signal("meeting_transcription_failed", parameters: [
-                    "engine": engine.identifier,
-                    "error": String(describing: type(of: error)),
-                    "chunked": "true"
-                ])
+                AppTelemetry.failure(
+                    "meeting_transcription_failed",
+                    domain: .transcription,
+                    stage: "meeting_finalize_chunked",
+                    error: error,
+                    parameters: [
+                        "engine": engine.identifier,
+                        "chunked": "true"
+                    ]
+                )
                 finishMeetingLifecycle(sessionID: session.id)
             }
         }
@@ -2880,9 +2931,13 @@ final class DictationCoordinator {
                             session: session
                         )
                     }
-                    AppTelemetry.signal(
+                    AppTelemetry.failure(
                         "meeting_transcription_failed",
-                        parameters: ["engine": self.engine.identifier, "error": "timeout"]
+                        domain: .transcription,
+                        stage: "meeting_transcription_timeout",
+                        reason: "timeout",
+                        isTimeout: true,
+                        parameters: ["engine": self.engine.identifier]
                     )
                     self.finishMeetingLifecycle(sessionID: session.id)
                 } operation: { [engine] progress in
@@ -2946,10 +3001,13 @@ final class DictationCoordinator {
                     detail: "Transcription failed",
                     session: session
                 )
-                AppTelemetry.signal("meeting_transcription_failed", parameters: [
-                    "engine": engine.identifier,
-                    "error": String(describing: type(of: error))
-                ])
+                AppTelemetry.failure(
+                    "meeting_transcription_failed",
+                    domain: .transcription,
+                    stage: "meeting_transcription",
+                    error: error,
+                    parameters: ["engine": engine.identifier]
+                )
                 finishMeetingLifecycle(sessionID: session.id)
             }
         }
@@ -2989,9 +3047,12 @@ final class DictationCoordinator {
                 speakerTranscript = nil
                 diarizationState = .failed
                 diarizationErrorMessage = error.localizedDescription
-                AppTelemetry.signal("meeting_diarization_failed", parameters: [
-                    "error": String(describing: type(of: error))
-                ])
+                AppTelemetry.failure(
+                    "meeting_diarization_failed",
+                    domain: .transcription,
+                    stage: "meeting_diarization",
+                    error: error
+                )
             }
             try ensureMeetingLifecycleActive(sessionID: session.id)
         }
@@ -3036,10 +3097,16 @@ final class DictationCoordinator {
                     ? MuesliPreferences.chatGPTModel
                     : MuesliPreferences.openRouterModel
                 summaryErrorMessage = error.localizedDescription
-                AppTelemetry.signal("meeting_summary_failed", parameters: [
-                    "backend": summaryBackend ?? "unknown",
-                    "error": String(describing: type(of: error))
-                ])
+                AppTelemetry.failure(
+                    "meeting_summary_failed",
+                    domain: .summary,
+                    stage: "meeting_summary",
+                    error: error,
+                    parameters: [
+                        "backend": summaryBackend ?? "unknown",
+                        "model": summaryModel ?? "unknown"
+                    ]
+                )
             }
             try ensureMeetingLifecycleActive(sessionID: session.id)
         }
@@ -3318,17 +3385,22 @@ final class DictationCoordinator {
         refreshHistory()
         switch source {
         case .activeDictation:
-            AppTelemetry.signal(
+            AppTelemetry.failure(
                 "dictation_failed",
-                parameters: [
-                    "stage": "transcription_timeout",
-                    "engine": engine.identifier
-                ]
+                domain: .transcription,
+                stage: "transcription_timeout",
+                reason: "timeout",
+                isTimeout: true,
+                parameters: ["engine": engine.identifier]
             )
         case .recovery:
-            AppTelemetry.signal(
+            AppTelemetry.failure(
                 "keyboard_transcription_recovery_failed",
-                parameters: ["reason": "timeout"]
+                domain: .transcription,
+                stage: "keyboard_recovery_timeout",
+                reason: "timeout",
+                isTimeout: true,
+                parameters: ["engine": engine.identifier]
             )
         }
     }
@@ -4070,12 +4142,12 @@ extension DictationCoordinator: ModelBackgroundDownloadServiceDelegate {
             status: "Download paused",
             detail: message
         )
-        AppTelemetry.signal(
+        AppTelemetry.failure(
             "model_prepare_failed",
-            parameters: [
-                "engine": model.engineIdentifier,
-                "error": "background_download_failed"
-            ]
+            domain: .model,
+            stage: "background_download",
+            reason: "background_download_failed",
+            parameters: ["engine": model.engineIdentifier]
         )
     }
 }

--- a/Muesli/DictationCoordinator.swift
+++ b/Muesli/DictationCoordinator.swift
@@ -3092,8 +3092,9 @@ final class DictationCoordinator {
                     manualNotes: session.manualNotes
                 )
                 summaryState = .failed
-                summaryBackend = MuesliPreferences.meetingSummaryBackend.rawValue
-                summaryModel = MuesliPreferences.meetingSummaryBackend == .chatGPT
+                let backend = MuesliPreferences.meetingSummaryBackend
+                summaryBackend = backend.rawValue
+                summaryModel = backend == .chatGPT
                     ? MuesliPreferences.chatGPTModel
                     : MuesliPreferences.openRouterModel
                 summaryErrorMessage = error.localizedDescription
@@ -3104,7 +3105,10 @@ final class DictationCoordinator {
                     error: error,
                     parameters: [
                         "backend": summaryBackend ?? "unknown",
-                        "model": summaryModel ?? "unknown"
+                        "model": SummaryModelPreset.telemetryIdentifier(
+                            for: summaryModel ?? "",
+                            backend: backend
+                        )
                     ]
                 )
             }

--- a/Muesli/MuesliLiveActivityController.swift
+++ b/Muesli/MuesliLiveActivityController.swift
@@ -31,9 +31,12 @@ actor MuesliLiveActivityController {
         do {
             activity = try Activity.request(attributes: attributes, content: content, pushType: nil)
         } catch {
-            await AppTelemetry.signal(
+            await AppTelemetry.failure(
                 "live_activity_failed",
-                parameters: ["stage": "request", "error": String(describing: type(of: error))]
+                domain: .audio,
+                stage: "request",
+                error: error,
+                parameters: ["session_kind": session.kind.title]
             )
         }
     }

--- a/Muesli/MuesliLiveActivityController.swift
+++ b/Muesli/MuesliLiveActivityController.swift
@@ -33,7 +33,7 @@ actor MuesliLiveActivityController {
         } catch {
             await AppTelemetry.failure(
                 "live_activity_failed",
-                domain: .audio,
+                domain: .liveActivity,
                 stage: "request",
                 error: error,
                 parameters: ["session_kind": session.kind.title]

--- a/Muesli/MuesliPreferences.swift
+++ b/Muesli/MuesliPreferences.swift
@@ -94,9 +94,12 @@ enum MuesliPreferences {
 
     static var openRouterModel: String {
         let value = UserDefaults.standard.string(forKey: openRouterModelKey) ?? ""
-        return value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-            ? MeetingSummaryBackend.defaultOpenRouterModel
-            : value.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedValue = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedValue.isEmpty else { return MeetingSummaryBackend.defaultOpenRouterModel }
+        guard SummaryModelPreset.openRouterModels.contains(where: { $0.id == trimmedValue }) else {
+            return MeetingSummaryBackend.defaultOpenRouterModel
+        }
+        return trimmedValue
     }
 
     static var chatGPTModel: String {

--- a/Muesli/MuesliPreferences.swift
+++ b/Muesli/MuesliPreferences.swift
@@ -96,9 +96,6 @@ enum MuesliPreferences {
         let value = UserDefaults.standard.string(forKey: openRouterModelKey) ?? ""
         let trimmedValue = value.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmedValue.isEmpty else { return MeetingSummaryBackend.defaultOpenRouterModel }
-        guard SummaryModelPreset.openRouterModels.contains(where: { $0.id == trimmedValue }) else {
-            return MeetingSummaryBackend.defaultOpenRouterModel
-        }
         return trimmedValue
     }
 
@@ -182,6 +179,19 @@ struct SummaryModelPreset: Identifiable, Hashable {
         guard !presets.contains(where: { $0.id == trimmedModel }) else { return presets }
         guard preserveCustomValue else { return presets }
         return presets + [SummaryModelPreset(id: trimmedModel, label: "Custom: \(trimmedModel)")]
+    }
+
+    static func telemetryIdentifier(for model: String, backend: MeetingSummaryBackend) -> String {
+        let trimmedModel = model.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedModel.isEmpty else { return "unknown" }
+
+        let presets = switch backend {
+        case .openRouter:
+            openRouterModels
+        case .chatGPT:
+            chatGPTModels
+        }
+        return presets.contains(where: { $0.id == trimmedModel }) ? trimmedModel : "custom"
     }
 }
 

--- a/Tests/MuesliTests/AppTelemetryTests.swift
+++ b/Tests/MuesliTests/AppTelemetryTests.swift
@@ -1,0 +1,43 @@
+import XCTest
+@testable import Muesli
+
+final class AppTelemetryTests: XCTestCase {
+    func testParameterKeysAreLowercasedSanitizedAndTruncated() {
+        let rawKey = "Error Type / With Spaces / And Symbols " + String(repeating: "x", count: 80)
+
+        let normalized = AppTelemetryParameterSanitizer.normalizedKey(rawKey)
+
+        XCTAssertEqual(normalized.count, AppTelemetryParameterSanitizer.maxKeyLength)
+        XCTAssertTrue(normalized.allSatisfy { $0.isLowercase || $0.isNumber || $0 == "_" })
+        XCTAssertTrue(normalized.hasPrefix("error_type___with_spaces___and_symbols"))
+    }
+
+    func testParameterValuesAreTrimmedAndTruncated() {
+        let rawValue = "  " + String(repeating: "a", count: 120) + "  "
+
+        let normalized = AppTelemetryParameterSanitizer.normalizedValue(rawValue)
+
+        XCTAssertEqual(normalized.count, AppTelemetryParameterSanitizer.maxValueLength)
+        XCTAssertFalse(normalized.hasPrefix(" "))
+        XCTAssertFalse(normalized.hasSuffix(" "))
+    }
+
+    func testEmptyParameterValuesUseUnknown() {
+        XCTAssertEqual(AppTelemetryParameterSanitizer.normalizedKey(""), "unknown")
+        XCTAssertEqual(AppTelemetryParameterSanitizer.normalizedValue("   "), "unknown")
+    }
+
+    func testCustomParametersCannotClobberReservedFailureKeys() {
+        let normalized = AppTelemetryParameterSanitizer.normalizedCustomParameters([
+            "timeout": "false",
+            "error_type": "UserSupplied",
+            "safe custom key": "value",
+        ])
+
+        XCTAssertNil(normalized["timeout"])
+        XCTAssertNil(normalized["error_type"])
+        XCTAssertEqual(normalized["custom_timeout"], "false")
+        XCTAssertEqual(normalized["custom_error_type"], "UserSupplied")
+        XCTAssertEqual(normalized["safe_custom_key"], "value")
+    }
+}

--- a/Tests/MuesliTests/MuesliPreferencesTests.swift
+++ b/Tests/MuesliTests/MuesliPreferencesTests.swift
@@ -2,7 +2,7 @@ import XCTest
 @testable import Muesli
 
 final class MuesliPreferencesTests: XCTestCase {
-    func testOpenRouterModelFallsBackWhenStoredValueIsNotAPreset() {
+    func testOpenRouterModelReturnsCustomStoredValue() {
         let defaults = UserDefaults.standard
         let originalValue = defaults.object(forKey: MuesliPreferences.openRouterModelKey)
         defer {
@@ -15,7 +15,7 @@ final class MuesliPreferencesTests: XCTestCase {
 
         defaults.set("custom/open-router-model-from-debug-tooling", forKey: MuesliPreferences.openRouterModelKey)
 
-        XCTAssertEqual(MuesliPreferences.openRouterModel, MeetingSummaryBackend.defaultOpenRouterModel)
+        XCTAssertEqual(MuesliPreferences.openRouterModel, "custom/open-router-model-from-debug-tooling")
     }
 
     func testOpenRouterModelReturnsStoredPreset() throws {
@@ -33,5 +33,31 @@ final class MuesliPreferencesTests: XCTestCase {
         defaults.set(preset.id, forKey: MuesliPreferences.openRouterModelKey)
 
         XCTAssertEqual(MuesliPreferences.openRouterModel, preset.id)
+    }
+
+    func testSummaryModelTelemetryIdentifierPreservesPreset() throws {
+        let preset = try XCTUnwrap(SummaryModelPreset.openRouterModels.last)
+
+        XCTAssertEqual(
+            SummaryModelPreset.telemetryIdentifier(for: preset.id, backend: .openRouter),
+            preset.id
+        )
+    }
+
+    func testSummaryModelTelemetryIdentifierBucketsCustomModel() {
+        XCTAssertEqual(
+            SummaryModelPreset.telemetryIdentifier(
+                for: "custom/open-router-model-from-debug-tooling",
+                backend: .openRouter
+            ),
+            "custom"
+        )
+    }
+
+    func testSummaryModelTelemetryIdentifierBucketsEmptyModel() {
+        XCTAssertEqual(
+            SummaryModelPreset.telemetryIdentifier(for: "  \n", backend: .openRouter),
+            "unknown"
+        )
     }
 }

--- a/Tests/MuesliTests/MuesliPreferencesTests.swift
+++ b/Tests/MuesliTests/MuesliPreferencesTests.swift
@@ -1,0 +1,37 @@
+import XCTest
+@testable import Muesli
+
+final class MuesliPreferencesTests: XCTestCase {
+    func testOpenRouterModelFallsBackWhenStoredValueIsNotAPreset() {
+        let defaults = UserDefaults.standard
+        let originalValue = defaults.object(forKey: MuesliPreferences.openRouterModelKey)
+        defer {
+            if let originalValue {
+                defaults.set(originalValue, forKey: MuesliPreferences.openRouterModelKey)
+            } else {
+                defaults.removeObject(forKey: MuesliPreferences.openRouterModelKey)
+            }
+        }
+
+        defaults.set("custom/open-router-model-from-debug-tooling", forKey: MuesliPreferences.openRouterModelKey)
+
+        XCTAssertEqual(MuesliPreferences.openRouterModel, MeetingSummaryBackend.defaultOpenRouterModel)
+    }
+
+    func testOpenRouterModelReturnsStoredPreset() throws {
+        let defaults = UserDefaults.standard
+        let originalValue = defaults.object(forKey: MuesliPreferences.openRouterModelKey)
+        defer {
+            if let originalValue {
+                defaults.set(originalValue, forKey: MuesliPreferences.openRouterModelKey)
+            } else {
+                defaults.removeObject(forKey: MuesliPreferences.openRouterModelKey)
+            }
+        }
+        let preset = try XCTUnwrap(SummaryModelPreset.openRouterModels.last)
+
+        defaults.set(preset.id, forKey: MuesliPreferences.openRouterModelKey)
+
+        XCTAssertEqual(MuesliPreferences.openRouterModel, preset.id)
+    }
+}


### PR DESCRIPTION
## Summary
- Add a centralized `AppTelemetry.failure` helper that emits privacy-safe failure dimensions and a normalized `failure_observed` aggregate signal.
- Attach runtime context for debugging common failures: app version/build, iOS version, hardware model, device family, error type/domain/code, timeout, CloudKit, and network classifications.
- Replace ad hoc deterministic failure telemetry across model prep, iCloud sync, keyboard sessions, dictation, meeting recording/transcription/diarization/summary, and Live Activity setup.

## Why
TestFlight crash feedback is not enough to understand non-crash failures like stuck transcription, failed model warmup, CloudKit sync problems, or meeting summary failures. This keeps existing event names for dashboard continuity while adding consistent dimensions for TelemetryDeck analysis.

## Privacy
No transcript text, titles, file paths, record IDs, API keys, or raw localized error messages are sent. Custom parameters are normalized and capped to low-cardinality strings.

## Validation
- `xcodebuild -project MuesliiOS.xcodeproj -scheme Muesli -destination 'platform=iOS Simulator,name=iPhone 17 Pro' build`
- `xcodebuild test -project MuesliiOS.xcodeproj -scheme Muesli -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -only-testing:MuesliTests`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli-ios/pr/18"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786172128&installation_id=136549638&pr_number=18&repository=Muesli-HQ%2Fmuesli-ios&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli-ios%2Fpull%2F18&signature=5305c2bd991248f0d56665909806c5c2e0e0b1deff5362bdad30cb9570ffbd7b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->