### PR TITLE
Add long voice note reliability mode

### DIFF
--- a/Muesli/AppTelemetry.swift
+++ b/Muesli/AppTelemetry.swift
@@ -9,6 +9,7 @@ enum AppTelemetryFailureDomain: String {
     case liveActivity = "live_activity"
     case meeting
     case model
+    case persistence
     case stateMachine = "state_machine"
     case summary
     case transcription

--- a/Muesli/AppTelemetry.swift
+++ b/Muesli/AppTelemetry.swift
@@ -74,6 +74,15 @@ enum AppTelemetry {
         TelemetryDeck.signal("Muesli.iOS.\(name)", parameters: parameters)
     }
 
+    static func contextualSignal(_ name: String, parameters: [String: String] = [:]) {
+        var enriched = runtimeParameters()
+        enriched.merge(
+            AppTelemetryParameterSanitizer.normalizedCustomParameters(parameters),
+            uniquingKeysWith: { _, new in new }
+        )
+        signal(name, parameters: enriched)
+    }
+
     static func failure(
         _ name: String,
         domain: AppTelemetryFailureDomain,

--- a/Muesli/AppTelemetry.swift
+++ b/Muesli/AppTelemetry.swift
@@ -9,6 +9,7 @@ enum AppTelemetryFailureDomain: String {
     case liveActivity = "live_activity"
     case meeting
     case model
+    case stateMachine = "state_machine"
     case summary
     case transcription
 }

--- a/Muesli/CheckpointingAudioWriter.swift
+++ b/Muesli/CheckpointingAudioWriter.swift
@@ -1,0 +1,206 @@
+import AVFoundation
+import Foundation
+
+enum CheckpointingAudioWriterFailure: Error, Sendable, Equatable {
+    case continuousWrite
+    case checkpointWrite
+    case checkpointRotation
+}
+
+struct CheckpointingAudioWriterResult: Sendable {
+    let finalCheckpoint: MeetingAudioChunk?
+    let continuousAudioURL: URL?
+    let failure: CheckpointingAudioWriterFailure?
+    let totalFrames: AVAudioFramePosition
+}
+
+final class CheckpointingAudioWriter: @unchecked Sendable {
+    var onFailure: (@Sendable (CheckpointingAudioWriterFailure) -> Void)?
+
+    private struct State {
+        var continuousFile: AVAudioFile?
+        var continuousURL: URL?
+        var checkpointFile: AVAudioFile?
+        var checkpointURL: URL?
+        var checkpointIndex = 0
+        var checkpointStartFrame: AVAudioFramePosition = 0
+        var checkpointFrames: AVAudioFramePosition = 0
+        var totalFrames: AVAudioFramePosition = 0
+        var failure: CheckpointingAudioWriterFailure?
+        var isClosed = false
+    }
+
+    private let queue = DispatchQueue(label: "com.muesli.checkpointingAudioWriter")
+    private let checkpointDirectory: URL
+    private let format: AVAudioFormat
+    private var state: State
+
+    init(
+        continuousAudioURL: URL?,
+        checkpointDirectory: URL,
+        format: AVAudioFormat
+    ) throws {
+        self.checkpointDirectory = checkpointDirectory
+        self.format = format
+        if let continuousAudioURL {
+            try FileManager.default.createDirectory(
+                at: continuousAudioURL.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+        }
+        try FileManager.default.createDirectory(at: checkpointDirectory, withIntermediateDirectories: true)
+        let checkpointURL = Self.checkpointURL(directory: checkpointDirectory, index: 0)
+        state = State(
+            continuousFile: try continuousAudioURL.map {
+                try AVAudioFile(forWriting: $0, settings: format.settings)
+            },
+            continuousURL: continuousAudioURL,
+            checkpointFile: try AVAudioFile(forWriting: checkpointURL, settings: format.settings),
+            checkpointURL: checkpointURL
+        )
+    }
+
+    func append(_ buffer: AVAudioPCMBuffer) {
+        guard let copy = Self.copyBuffer(buffer), copy.frameLength > 0 else { return }
+        queue.async { [weak self] in
+            self?.write(copy)
+        }
+    }
+
+    func rotateCheckpoint() -> MeetingAudioChunk? {
+        queue.sync {
+            guard !state.isClosed,
+                  let completedURL = state.checkpointURL,
+                  state.checkpointFrames > 0
+            else { return nil }
+
+            state.checkpointFile = nil
+            let completed = MeetingAudioChunk(
+                index: state.checkpointIndex,
+                url: completedURL,
+                startTime: Double(state.checkpointStartFrame) / format.sampleRate,
+                duration: Double(state.checkpointFrames) / format.sampleRate
+            )
+
+            let nextIndex = state.checkpointIndex + 1
+            let nextURL = Self.checkpointURL(directory: checkpointDirectory, index: nextIndex)
+            do {
+                state.checkpointFile = try AVAudioFile(forWriting: nextURL, settings: format.settings)
+                state.checkpointURL = nextURL
+                state.checkpointIndex = nextIndex
+                state.checkpointStartFrame = state.totalFrames
+                state.checkpointFrames = 0
+            } catch {
+                report(.checkpointRotation)
+            }
+            return completed
+        }
+    }
+
+    func finish() -> CheckpointingAudioWriterResult {
+        queue.sync {
+            guard !state.isClosed else {
+                return CheckpointingAudioWriterResult(
+                    finalCheckpoint: nil,
+                    continuousAudioURL: state.continuousURL,
+                    failure: state.failure,
+                    totalFrames: state.totalFrames
+                )
+            }
+            state.isClosed = true
+            let finalCheckpoint: MeetingAudioChunk?
+            if let checkpointURL = state.checkpointURL, state.checkpointFrames > 0 {
+                finalCheckpoint = MeetingAudioChunk(
+                    index: state.checkpointIndex,
+                    url: checkpointURL,
+                    startTime: Double(state.checkpointStartFrame) / format.sampleRate,
+                    duration: Double(state.checkpointFrames) / format.sampleRate
+                )
+            } else {
+                finalCheckpoint = nil
+            }
+            state.checkpointFile = nil
+            state.continuousFile = nil
+            return CheckpointingAudioWriterResult(
+                finalCheckpoint: finalCheckpoint,
+                continuousAudioURL: state.continuousURL,
+                failure: state.failure,
+                totalFrames: state.totalFrames
+            )
+        }
+    }
+
+    func cancel() {
+        let urls = queue.sync { () -> [URL] in
+            state.isClosed = true
+            state.checkpointFile = nil
+            state.continuousFile = nil
+            return [state.checkpointURL, state.continuousURL].compactMap { $0 }
+        }
+        for url in urls where FileManager.default.fileExists(atPath: url.path) {
+            try? FileManager.default.removeItem(at: url)
+        }
+    }
+
+    private func write(_ buffer: AVAudioPCMBuffer) {
+        guard !state.isClosed else { return }
+        let frameCount = AVAudioFramePosition(buffer.frameLength)
+        guard frameCount > 0 else { return }
+
+        if let continuousFile = state.continuousFile {
+            do {
+                try continuousFile.write(from: buffer)
+            } catch {
+                state.continuousFile = nil
+                report(.continuousWrite)
+            }
+        }
+
+        if let checkpointFile = state.checkpointFile {
+            do {
+                try checkpointFile.write(from: buffer)
+                state.checkpointFrames += frameCount
+            } catch {
+                state.checkpointFile = nil
+                report(.checkpointWrite)
+            }
+        }
+        state.totalFrames += frameCount
+    }
+
+    private func report(_ failure: CheckpointingAudioWriterFailure) {
+        if state.failure == nil {
+            state.failure = failure
+        }
+        onFailure?(failure)
+    }
+
+    private static func checkpointURL(directory: URL, index: Int) -> URL {
+        directory
+            .appendingPathComponent("chunk-\(String(format: "%04d", index))")
+            .appendingPathExtension("wav")
+    }
+
+    private static func copyBuffer(_ buffer: AVAudioPCMBuffer) -> AVAudioPCMBuffer? {
+        guard let copy = AVAudioPCMBuffer(
+            pcmFormat: buffer.format,
+            frameCapacity: buffer.frameLength
+        ) else { return nil }
+        copy.frameLength = buffer.frameLength
+
+        let channelCount = Int(buffer.format.channelCount)
+        let frameCount = Int(buffer.frameLength)
+        if let source = buffer.floatChannelData, let destination = copy.floatChannelData {
+            for channel in 0..<channelCount {
+                destination[channel].update(from: source[channel], count: frameCount)
+            }
+        } else if let source = buffer.int16ChannelData, let destination = copy.int16ChannelData {
+            for channel in 0..<channelCount {
+                destination[channel].update(from: source[channel], count: frameCount)
+            }
+        } else {
+            return nil
+        }
+        return copy
+    }
+}

--- a/Muesli/CheckpointingAudioWriter.swift
+++ b/Muesli/CheckpointingAudioWriter.swift
@@ -131,6 +131,8 @@ final class CheckpointingAudioWriter: @unchecked Sendable {
     }
 
     func cancel() {
+        // Cancellation owns the entire per-recording checkpoint directory. Callers
+        // should not need a second cleanup pass to remove already-rotated chunks.
         let urls = queue.sync { () -> [URL] in
             state.isClosed = true
             state.checkpointFile = nil
@@ -139,6 +141,9 @@ final class CheckpointingAudioWriter: @unchecked Sendable {
         }
         for url in urls where FileManager.default.fileExists(atPath: url.path) {
             try? FileManager.default.removeItem(at: url)
+        }
+        if FileManager.default.fileExists(atPath: checkpointDirectory.path) {
+            try? FileManager.default.removeItem(at: checkpointDirectory)
         }
     }
 

--- a/Muesli/CheckpointingAudioWriter.swift
+++ b/Muesli/CheckpointingAudioWriter.swift
@@ -146,10 +146,12 @@ final class CheckpointingAudioWriter: @unchecked Sendable {
         guard !state.isClosed else { return }
         let frameCount = AVAudioFramePosition(buffer.frameLength)
         guard frameCount > 0 else { return }
+        var wroteFrames = false
 
         if let continuousFile = state.continuousFile {
             do {
                 try continuousFile.write(from: buffer)
+                wroteFrames = true
             } catch {
                 state.continuousFile = nil
                 report(.continuousWrite)
@@ -160,12 +162,15 @@ final class CheckpointingAudioWriter: @unchecked Sendable {
             do {
                 try checkpointFile.write(from: buffer)
                 state.checkpointFrames += frameCount
+                wroteFrames = true
             } catch {
                 state.checkpointFile = nil
                 report(.checkpointWrite)
             }
         }
-        state.totalFrames += frameCount
+        if wroteFrames {
+            state.totalFrames += frameCount
+        }
     }
 
     private func report(_ failure: CheckpointingAudioWriterFailure) {

--- a/Muesli/DictationCoordinator.swift
+++ b/Muesli/DictationCoordinator.swift
@@ -553,29 +553,40 @@ final class DictationCoordinator {
         longVoiceNoteDurabilityError = nil
 
         guard let threshold else { return true }
-        let checkpointTask = Task { @MainActor [weak self] in
+        let recordingScheduleTask = Task { @MainActor [weak self] in
+            let clock = ContinuousClock()
+            let startedAt = clock.now
+            var schedule = VoiceNoteRecordingSchedule(thresholdSeconds: threshold)
             while !Task.isCancelled {
-                try? await Task.sleep(for: .seconds(30))
+                let deadline = startedAt.advanced(by: .seconds(schedule.nextDeadlineSeconds))
+                do {
+                    try await clock.sleep(until: deadline)
+                } catch {
+                    return
+                }
                 guard !Task.isCancelled, let self else { return }
-                await self.rotateActiveVoiceNoteCheckpoint(sessionID: sessionID, isFinal: false)
+                for event in schedule.consumeNextDeadline() {
+                    guard !Task.isCancelled,
+                          self.voiceNoteLifecycleRunner?.sessionID == sessionID,
+                          self.isRecording
+                    else { return }
+                    switch event {
+                    case .checkpoint:
+                        await self.rotateActiveVoiceNoteCheckpoint(sessionID: sessionID)
+                    case .activateLongForm:
+                        await self.activateLongVoiceNote(sessionID: sessionID)
+                    }
+                }
             }
         }
-        let thresholdTask = Task { @MainActor [weak self] in
-            try? await Task.sleep(for: .seconds(threshold))
-            guard !Task.isCancelled, let self else { return }
-            await self.activateLongVoiceNote(sessionID: sessionID)
-        }
-        voiceNoteLifecycleRunner?.checkpointTask = checkpointTask
-        voiceNoteLifecycleRunner?.thresholdTask = thresholdTask
+        voiceNoteLifecycleRunner?.recordingScheduleTask = recordingScheduleTask
         return true
     }
 
     private func stopVoiceNoteRecordingTasks(sessionID: UUID) {
         guard voiceNoteLifecycleRunner?.sessionID == sessionID else { return }
-        voiceNoteLifecycleRunner?.checkpointTask?.cancel()
-        voiceNoteLifecycleRunner?.thresholdTask?.cancel()
-        voiceNoteLifecycleRunner?.checkpointTask = nil
-        voiceNoteLifecycleRunner?.thresholdTask = nil
+        voiceNoteLifecycleRunner?.recordingScheduleTask?.cancel()
+        voiceNoteLifecycleRunner?.recordingScheduleTask = nil
     }
 
     private func finishVoiceNoteLifecycle(sessionID: UUID) {
@@ -717,10 +728,12 @@ final class DictationCoordinator {
         }
     }
 
-    private func rotateActiveVoiceNoteCheckpoint(sessionID: UUID, isFinal: Bool) async {
-        guard voiceNoteLifecycleRunner?.sessionID == sessionID,
+    private func rotateActiveVoiceNoteCheckpoint(sessionID: UUID) async {
+        guard let runner = voiceNoteLifecycleRunner,
+              runner.sessionID == sessionID,
               activeSession?.id == sessionID,
-              activeSession?.longFormThresholdSeconds != nil
+              activeSession?.longFormThresholdSeconds != nil,
+              isRecording
         else { return }
 
         let checkpoint = keyboardSessionKeeper.rotateSegmentCheckpoint()
@@ -729,8 +742,15 @@ final class DictationCoordinator {
 
         do {
             let manifest = try await voiceNoteCheckpointStore.record(checkpoint, sessionID: sessionID)
-            guard var securedSession = activeSession,
-                  securedSession.id == sessionID
+            guard isCurrentVoiceNoteLifecycle(
+                sessionID: sessionID,
+                requestID: runner.requestID,
+                runnerID: runner.id
+            ),
+            voiceNoteLifecycleState.isRecording,
+            isRecording,
+            var securedSession = activeSession,
+            securedSession.id == sessionID
             else { return }
             longVoiceNoteCheckpointCount = manifest.entries.count
             longVoiceNoteAudioIsSecured = !manifest.entries.isEmpty
@@ -738,15 +758,6 @@ final class DictationCoordinator {
                 securedSession.hasDurableAudioCheckpoint = true
                 activeSession = securedSession
                 try? store.saveSession(securedSession)
-            }
-            if activeSession?.isLongForm == true, manifest.entries.count == 1 || isFinal {
-                AppTelemetry.contextualSignal(
-                    "long_voice_note_audio_checkpoint_saved",
-                    parameters: voiceNoteTelemetryParameters(
-                        session: activeSession,
-                        checkpointCount: manifest.entries.count
-                    )
-                )
             }
         } catch {
             handleVoiceNoteWriterFailure(.checkpointWrite)
@@ -760,10 +771,6 @@ final class DictationCoordinator {
               initialStateSessionID == sessionID,
               isRecording
         else { return }
-
-        if longVoiceNoteCheckpointCount == 0 {
-            await rotateActiveVoiceNoteCheckpoint(sessionID: sessionID, isFinal: false)
-        }
 
         guard isCurrentVoiceNoteLifecycle(
             sessionID: sessionID,

--- a/Muesli/DictationCoordinator.swift
+++ b/Muesli/DictationCoordinator.swift
@@ -514,19 +514,42 @@ final class DictationCoordinator {
         meetingLifecycleState = MeetingLifecycleReducer.reduce(meetingLifecycleState, event: event)
     }
 
-    private func transitionVoiceNoteLifecycle(_ event: VoiceNoteLifecycleEvent) {
-        voiceNoteLifecycleState = VoiceNoteLifecycleReducer.reduce(voiceNoteLifecycleState, event: event)
+    @discardableResult
+    private func transitionVoiceNoteLifecycle(_ event: VoiceNoteLifecycleEvent) -> Bool {
+        let previousState = voiceNoteLifecycleState
+        let transition = VoiceNoteLifecycleReducer.transition(previousState, event: event)
+        voiceNoteLifecycleState = transition.state
+        if !transition.accepted {
+            AppTelemetry.failure(
+                "voice_note_lifecycle_transition_rejected",
+                domain: .stateMachine,
+                stage: "voice_note_lifecycle",
+                reason: "invalid_transition",
+                parameters: [
+                    "from_phase": previousState.phase.telemetryName,
+                    "event": event.telemetryName,
+                ]
+            )
+        }
+        return transition.accepted
     }
 
-    private func beginVoiceNoteLifecycle(sessionID: UUID, requestID: UUID, threshold: Int?) {
+    private func beginVoiceNoteLifecycle(
+        sessionID: UUID,
+        requestID: UUID,
+        threshold: Int?
+    ) -> Bool {
         voiceNoteLifecycleRunner?.cancelAll()
         voiceNoteLifecycleRunner = VoiceNoteLifecycleRunner(sessionID: sessionID, requestID: requestID)
-        transitionVoiceNoteLifecycle(.recordingStarted(sessionID))
+        guard transitionVoiceNoteLifecycle(.recordingStarted(sessionID)) else {
+            voiceNoteLifecycleRunner = nil
+            return false
+        }
         longVoiceNoteCheckpointCount = 0
         longVoiceNoteAudioIsSecured = false
         longVoiceNoteDurabilityError = nil
 
-        guard let threshold else { return }
+        guard let threshold else { return true }
         let checkpointTask = Task { @MainActor [weak self] in
             while !Task.isCancelled {
                 try? await Task.sleep(for: .seconds(30))
@@ -541,6 +564,7 @@ final class DictationCoordinator {
         }
         voiceNoteLifecycleRunner?.checkpointTask = checkpointTask
         voiceNoteLifecycleRunner?.thresholdTask = thresholdTask
+        return true
     }
 
     private func stopVoiceNoteRecordingTasks(sessionID: UUID) {
@@ -628,6 +652,44 @@ final class DictationCoordinator {
         return true
     }
 
+    private func voiceNoteFailureReason(for error: Error) -> VoiceNoteTranscriptionFailureReason {
+        if let captureFailure = error as? VoiceNoteCaptureFailure {
+            return captureFailure.failureReason
+        }
+        if error is VoiceNoteCheckpointStore.StoreError {
+            return .checkpointFailure
+        }
+        if error is VoiceNoteRetryError {
+            return .timeout
+        }
+        return .engineFailure
+    }
+
+    private func hasRecoverableAudio(for session: RecordingSession) async -> Bool {
+        if session.hasDurableAudioCheckpoint {
+            return true
+        }
+        guard let audioFileName = session.audioFileName,
+              let audioURL = try? store.audioFileURL(fileName: audioFileName)
+        else { return false }
+        return await voiceNoteCheckpointStore.isReadableAudio(at: audioURL)
+    }
+
+    private func settleVoiceNoteLifecycleAfterFailure(_ session: RecordingSession) {
+        if VoiceNoteCheckpointRetentionPolicy.shouldDeleteCheckpoints(for: session) {
+            let checkpointStore = voiceNoteCheckpointStore
+            Task {
+                try? await checkpointStore.delete(sessionID: session.id)
+            }
+        }
+        switch VoiceNoteFailureLifecycleDisposition.resolve(for: session) {
+        case .retryable:
+            transitionVoiceNoteLifecycle(.transcriptionFailed(session.id))
+        case .finished:
+            finishVoiceNoteLifecycle(sessionID: session.id)
+        }
+    }
+
     private func rotateActiveVoiceNoteCheckpoint(sessionID: UUID, isFinal: Bool) async {
         guard voiceNoteLifecycleRunner?.sessionID == sessionID,
               activeSession?.id == sessionID,
@@ -640,9 +702,16 @@ final class DictationCoordinator {
 
         do {
             let manifest = try await voiceNoteCheckpointStore.record(checkpoint, sessionID: sessionID)
-            guard activeSession?.id == sessionID else { return }
+            guard var securedSession = activeSession,
+                  securedSession.id == sessionID
+            else { return }
             longVoiceNoteCheckpointCount = manifest.entries.count
             longVoiceNoteAudioIsSecured = !manifest.entries.isEmpty
+            if longVoiceNoteAudioIsSecured {
+                securedSession.hasDurableAudioCheckpoint = true
+                activeSession = securedSession
+                try? store.saveSession(securedSession)
+            }
             if activeSession?.isLongForm == true, manifest.entries.count == 1 || isFinal {
                 AppTelemetry.contextualSignal(
                     "long_voice_note_audio_checkpoint_saved",
@@ -658,15 +727,36 @@ final class DictationCoordinator {
     }
 
     private func activateLongVoiceNote(sessionID: UUID) async {
-        guard voiceNoteLifecycleRunner?.sessionID == sessionID,
-              var session = activeSession,
-              session.id == sessionID,
+        guard let runner = voiceNoteLifecycleRunner,
+              runner.sessionID == sessionID,
+              case .recordingShort(let initialStateSessionID) = voiceNoteLifecycleState.phase,
+              initialStateSessionID == sessionID,
               isRecording
         else { return }
 
         if longVoiceNoteCheckpointCount == 0 {
             await rotateActiveVoiceNoteCheckpoint(sessionID: sessionID, isFinal: false)
         }
+
+        guard isCurrentVoiceNoteLifecycle(
+            sessionID: sessionID,
+            requestID: runner.requestID,
+            runnerID: runner.id
+        ),
+        case .recordingShort(let currentStateSessionID) = voiceNoteLifecycleState.phase,
+        currentStateSessionID == sessionID,
+        isRecording,
+        var session = activeSession,
+        session.id == sessionID
+        else { return }
+
+        guard longVoiceNoteAudioIsSecured,
+              session.hasDurableAudioCheckpoint
+        else {
+            handleVoiceNoteWriterFailure(.checkpointRotation)
+            return
+        }
+        guard transitionVoiceNoteLifecycle(.longFormActivated(sessionID)) else { return }
 
         session.isLongForm = true
         session.longFormActivatedAt = .now
@@ -677,8 +767,7 @@ final class DictationCoordinator {
             presentedLongVoiceNoteSessionID = session.id
         }
         try? store.saveSession(session)
-        transitionVoiceNoteLifecycle(.longFormActivated(sessionID))
-        statusText = longVoiceNoteAudioIsSecured ? "Audio saved locally" : "Securing audio"
+        statusText = "Audio saved locally"
 
         if longVoiceNoteAudioIsSecured {
             var parameters = voiceNoteTelemetryParameters(
@@ -717,7 +806,12 @@ final class DictationCoordinator {
 
     private func handleVoiceNoteWriterFailure(_ failure: CheckpointingAudioWriterFailure) {
         guard isRecording, var session = activeSession, session.kind != .meeting else { return }
-        longVoiceNoteAudioIsSecured = false
+        if failure == .continuousWrite {
+            longVoiceNoteAudioIsSecured = session.hasDurableAudioCheckpoint
+        } else {
+            longVoiceNoteAudioIsSecured = false
+            session.hasDurableAudioCheckpoint = false
+        }
         longVoiceNoteDurabilityError = "Audio could not be saved reliably. The recording was stopped."
         session.lastTranscriptionFailureReason = .checkpointFailure
         session.errorMessage = longVoiceNoteDurabilityError
@@ -751,7 +845,7 @@ final class DictationCoordinator {
            recordingElapsedTime >= Double(threshold) {
             session.isLongForm = true
             session.longFormActivatedAt = session.longFormActivatedAt ?? .now
-            session.protectedAudioUntilTranscriptCompletes = true
+            session.protectedAudioUntilTranscriptCompletes = session.hasDurableAudioCheckpoint
         }
         session.lastTranscriptionFailureReason = .interrupted
         session.errorMessage = message
@@ -813,7 +907,10 @@ final class DictationCoordinator {
                 session.isLongForm = true
                 session.longFormActivatedAt = session.longFormActivatedAt ?? .now
             }
-            _ = try? await voiceNoteCheckpointStore.salvageTrailingCheckpoint(sessionID: session.id)
+            let recoveredManifest = try? await voiceNoteCheckpointStore.salvageTrailingCheckpoint(
+                sessionID: session.id
+            )
+            session.hasDurableAudioCheckpoint = !(recoveredManifest?.entries.isEmpty ?? true)
             if session.phase == .recording || session.phase == .transcribing {
                 session.phase = .failed
                 session.lastTranscriptionFailureReason = .interrupted
@@ -844,6 +941,7 @@ final class DictationCoordinator {
             } else {
                 session.phase = .failed
                 session.protectedAudioUntilTranscriptCompletes = false
+                session.hasDurableAudioCheckpoint = false
                 session.lastTranscriptionFailureReason = .audioUnavailable
                 session.errorMessage = "The saved audio is unavailable."
                 session.audioFileName = nil
@@ -1377,6 +1475,7 @@ final class DictationCoordinator {
             session.audioFileName = nil
             session.keepsAudioRecording = false
             session.protectedAudioUntilTranscriptCompletes = false
+            session.hasDurableAudioCheckpoint = false
             session.lastTranscriptionFailureReason = .audioUnavailable
             try store.saveSession(session)
             if session.longFormThresholdSeconds != nil {
@@ -1444,6 +1543,7 @@ final class DictationCoordinator {
                 session.audioFileName = nil
                 session.keepsAudioRecording = false
                 session.protectedAudioUntilTranscriptCompletes = false
+                session.hasDurableAudioCheckpoint = false
                 session.lastTranscriptionFailureReason = .audioUnavailable
                 session.errorMessage = "The saved audio was deleted."
                 try store.saveSession(session)
@@ -1590,6 +1690,7 @@ final class DictationCoordinator {
                 session.engineIdentifier = engine.identifier
                 session.errorMessage = nil
                 session.protectedAudioUntilTranscriptCompletes = false
+                session.hasDurableAudioCheckpoint = false
                 session.lastTranscriptionFailureReason = nil
                 cleanupNonRetainedAudio(for: &session)
                 try store.saveSession(session)
@@ -1619,14 +1720,18 @@ final class DictationCoordinator {
                 ) else {
                     return
                 }
+                let audioIsRecoverable = await hasRecoverableAudio(for: session)
                 session.phase = .failed
-                session.errorMessage = "Your audio is safe. Transcription was interrupted."
+                session.errorMessage = audioIsRecoverable
+                    ? "Your audio is safe. Transcription was interrupted."
+                    : "Transcription was interrupted and the audio could not be recovered."
                 session.lastTranscriptionFailureReason = .interrupted
-                session.protectedAudioUntilTranscriptCompletes = session.audioFileName != nil
+                session.protectedAudioUntilTranscriptCompletes = audioIsRecoverable
+                cleanupNonRetainedAudio(for: &session)
                 try? store.saveSession(session)
                 activeSession = nil
                 statusText = session.errorMessage ?? "Transcription interrupted"
-                transitionVoiceNoteLifecycle(.transcriptionFailed(sessionID))
+                settleVoiceNoteLifecycleAfterFailure(session)
                 refreshHistory()
             } catch {
                 guard isCurrentVoiceNoteLifecycle(
@@ -1636,16 +1741,20 @@ final class DictationCoordinator {
                 ) else {
                     return
                 }
+                let audioIsRecoverable = await hasRecoverableAudio(for: session)
                 session.phase = .failed
-                session.errorMessage = "Your audio is safe. We couldn't finish transcribing this note."
+                session.errorMessage = audioIsRecoverable
+                    ? "Your audio is safe. We couldn't finish transcribing this note."
+                    : "We couldn't finish transcribing this note or recover its audio."
                 session.lastTranscriptionFailureReason = error is VoiceNoteRetryError
                     ? .timeout
                     : .engineFailure
-                session.protectedAudioUntilTranscriptCompletes = session.audioFileName != nil
+                session.protectedAudioUntilTranscriptCompletes = audioIsRecoverable
+                cleanupNonRetainedAudio(for: &session)
                 try? store.saveSession(session)
                 activeSession = nil
                 statusText = session.errorMessage ?? "Transcription failed"
-                transitionVoiceNoteLifecycle(.transcriptionFailed(sessionID))
+                settleVoiceNoteLifecycleAfterFailure(session)
                 refreshHistory()
                 AppTelemetry.failure(
                     "long_voice_note_transcription_failed",
@@ -2716,11 +2825,13 @@ final class DictationCoordinator {
                 refreshAudioInputRoute()
                 activeSession = session
                 isRecording = true
-                beginVoiceNoteLifecycle(
+                guard beginVoiceNoteLifecycle(
                     sessionID: session.id,
                     requestID: request.id,
                     threshold: longModeThreshold
-                )
+                ) else {
+                    throw VoiceNoteCaptureFailure.invalidLifecycleTransition
+                }
                 if source == "keyboard", !usesKeyboardSessionLiveActivity {
                     transitionKeyboardSession(.recordingStarted(request.id))
                 }
@@ -2901,6 +3012,7 @@ final class DictationCoordinator {
                 completedSession.engineIdentifier = engine.identifier
                 completedSession.errorMessage = nil
                 completedSession.protectedAudioUntilTranscriptCompletes = false
+                completedSession.hasDurableAudioCheckpoint = false
                 completedSession.lastTranscriptionFailureReason = nil
                 cleanupNonRetainedAudio(for: &completedSession)
                 try store.saveSession(completedSession)
@@ -2957,18 +3069,14 @@ final class DictationCoordinator {
                 var failedSession = session
                 failedSession.phase = .failed
                 failedSession.errorMessage = error.localizedDescription
-                failedSession.lastTranscriptionFailureReason = error is VoiceNoteRetryError
-                    ? .timeout
-                    : .engineFailure
+                failedSession.lastTranscriptionFailureReason = voiceNoteFailureReason(for: error)
                 if failedSession.isLongForm {
-                    failedSession.protectedAudioUntilTranscriptCompletes = failedSession.audioFileName != nil
-                    transitionVoiceNoteLifecycle(.transcriptionFailed(failedSession.id))
-                } else if failedSession.longFormThresholdSeconds != nil {
-                    try? await voiceNoteCheckpointStore.delete(sessionID: failedSession.id)
-                    finishVoiceNoteLifecycle(sessionID: failedSession.id)
+                    failedSession.protectedAudioUntilTranscriptCompletes =
+                        await hasRecoverableAudio(for: failedSession)
                 }
                 cleanupNonRetainedAudio(for: &failedSession)
                 try? store.saveSession(failedSession)
+                settleVoiceNoteLifecycleAfterFailure(failedSession)
                 try? store.saveStatus(.init(
                     requestID: request.id,
                     phase: .failed,
@@ -3030,14 +3138,15 @@ final class DictationCoordinator {
         if var thresholdSession = session,
            !thresholdSession.isLongForm,
            let threshold = thresholdSession.longFormThresholdSeconds,
-           recordingElapsedTime >= Double(threshold) {
+           recordingElapsedTime >= Double(threshold),
+           transitionVoiceNoteLifecycle(.longFormActivated(thresholdSession.id)) {
             thresholdSession.isLongForm = true
             thresholdSession.longFormActivatedAt = .now
-            thresholdSession.protectedAudioUntilTranscriptCompletes = true
+            thresholdSession.protectedAudioUntilTranscriptCompletes =
+                thresholdSession.hasDurableAudioCheckpoint
             session = thresholdSession
             activeSession = thresholdSession
             try? store.saveSession(thresholdSession)
-            transitionVoiceNoteLifecycle(.longFormActivated(thresholdSession.id))
             if thresholdSession.kind == .quickDictation {
                 presentedLongVoiceNoteSessionID = thresholdSession.id
             }
@@ -3123,16 +3232,19 @@ final class DictationCoordinator {
                 let usesRealtimeStreaming = usesCheckpointingRecorder && isRealtimeDictationSessionActive
                 let audioURL: URL
                 var finalCheckpoint: MeetingAudioChunk?
+                var finalWriterFailure: CheckpointingAudioWriterFailure?
                 var realtimeText = ""
 
                 if usesKeyboardSessionLiveActivity {
                     let segment = try keyboardSessionKeeper.finishSegment()
                     audioURL = segment.audioURL
                     finalCheckpoint = segment.finalCheckpoint
+                    finalWriterFailure = segment.writerFailure
                 } else if usesCheckpointingRecorder {
                     let stoppedAudio = realtimeDictationRecorder?.stop()
                     realtimeDictationRecorder = nil
                     finalCheckpoint = stoppedAudio?.finalChunk
+                    finalWriterFailure = stoppedAudio?.writerFailure
                     if usesRealtimeStreaming {
                         realtimeDictationBufferPipe?.finish()
                         await realtimeDictationProcessingTask?.value
@@ -3158,9 +3270,23 @@ final class DictationCoordinator {
                         finalCheckpoint: finalCheckpoint
                     )
                     longVoiceNoteCheckpointCount = manifest.entries.count
+                    let checkpointFinalizationFailed = finalWriterFailure == .checkpointWrite
+                        || finalWriterFailure == .checkpointRotation
                     longVoiceNoteAudioIsSecured = !manifest.entries.isEmpty
-                    transitionVoiceNoteLifecycle(.audioFinalized(currentSession.id))
-                    transitionVoiceNoteLifecycle(.transcriptionQueued(currentSession.id))
+                        && !checkpointFinalizationFailed
+                    var finalizedSession = activeSession ?? currentSession
+                    finalizedSession.hasDurableAudioCheckpoint = longVoiceNoteAudioIsSecured
+                    if finalizedSession.isLongForm {
+                        finalizedSession.protectedAudioUntilTranscriptCompletes =
+                            longVoiceNoteAudioIsSecured
+                    }
+                    activeSession = finalizedSession
+                    try? store.saveSession(finalizedSession)
+                    guard transitionVoiceNoteLifecycle(.audioFinalized(currentSession.id)),
+                          transitionVoiceNoteLifecycle(.transcriptionQueued(currentSession.id))
+                    else {
+                        throw VoiceNoteCaptureFailure.invalidLifecycleTransition
+                    }
                     if currentSession.isLongForm, !manifest.entries.isEmpty {
                         var checkpointParameters = voiceNoteTelemetryParameters(
                             session: currentSession,
@@ -3173,6 +3299,9 @@ final class DictationCoordinator {
                         )
                     }
                     if currentSession.isLongForm {
+                        guard longVoiceNoteAudioIsSecured else {
+                            throw VoiceNoteCaptureFailure.missingDurableCheckpoint
+                        }
                         AppTelemetry.contextualSignal(
                             "long_voice_note_transcription_queued",
                             parameters: voiceNoteTelemetryParameters(
@@ -3182,12 +3311,17 @@ final class DictationCoordinator {
                         )
                     }
                 }
+                if let finalWriterFailure {
+                    throw VoiceNoteCaptureFailure.writer(finalWriterFailure)
+                }
                 if var currentSession = activeSession ?? session {
                     currentSession.phase = .transcribing
                     currentSession.lastTranscriptionAttemptAt = .now
                     activeSession = currentSession
                     try? store.saveSession(currentSession)
-                    transitionVoiceNoteLifecycle(.transcriptionStarted(currentSession.id))
+                    guard transitionVoiceNoteLifecycle(.transcriptionStarted(currentSession.id)) else {
+                        throw VoiceNoteCaptureFailure.invalidLifecycleTransition
+                    }
                 }
                 statusText = "Transcribing"
                 if startedFromKeyboard {
@@ -3249,6 +3383,7 @@ final class DictationCoordinator {
                     completedSession.engineIdentifier = engine.identifier
                     completedSession.errorMessage = nil
                     completedSession.protectedAudioUntilTranscriptCompletes = false
+                    completedSession.hasDurableAudioCheckpoint = false
                     completedSession.lastTranscriptionFailureReason = nil
                     cleanupNonRetainedAudio(for: &completedSession)
                     try store.saveSession(completedSession)
@@ -3333,12 +3468,16 @@ final class DictationCoordinator {
                 if var session = activeSession ?? session {
                     session.phase = .failed
                     session.errorMessage = error.localizedDescription
-                    session.lastTranscriptionFailureReason = .engineFailure
+                    session.lastTranscriptionFailureReason = voiceNoteFailureReason(for: error)
+                    if session.isLongForm {
+                        session.protectedAudioUntilTranscriptCompletes =
+                            await hasRecoverableAudio(for: session)
+                    }
                     cleanupNonRetainedAudio(for: &session)
                     try? store.saveSession(session)
                     failedVoiceNoteSession = session
+                    settleVoiceNoteLifecycleAfterFailure(session)
                     if session.isLongForm {
-                        transitionVoiceNoteLifecycle(.transcriptionFailed(session.id))
                         AppTelemetry.failure(
                             "long_voice_note_transcription_failed",
                             domain: .transcription,
@@ -3349,9 +3488,6 @@ final class DictationCoordinator {
                                 checkpointCount: longVoiceNoteCheckpointCount
                             )
                         )
-                    } else if session.longFormThresholdSeconds != nil {
-                        try? await voiceNoteCheckpointStore.delete(sessionID: session.id)
-                        finishVoiceNoteLifecycle(sessionID: session.id)
                     }
                 }
                 activeRequest = nil
@@ -3484,6 +3620,11 @@ final class DictationCoordinator {
 
             let vadController = StreamingVadController(vadManager: vadManager)
             let streamingRecorder = StreamingMeetingRecorder()
+            streamingRecorder.onRecordingFailure = { [weak self] failure in
+                Task { @MainActor in
+                    self?.handleMeetingRecordingWriterFailure(failure)
+                }
+            }
             vadController.onChunkBoundary = { [weak self] in
                 Task { @MainActor [weak self] in
                     self?.rotateActiveMeetingChunk()
@@ -3660,6 +3801,9 @@ final class DictationCoordinator {
             let stoppedAudio = meetingRecorder?.stop()
             meetingRecorder = nil
             meetingVadController = nil
+            if let writerFailure = stoppedAudio?.writerFailure {
+                throw VoiceNoteCaptureFailure.writer(writerFailure)
+            }
             if let finalChunk = stoppedAudio?.finalChunk {
                 scheduleMeetingChunkTranscription(finalChunk, sessionID: session.id)
             }
@@ -3699,6 +3843,18 @@ final class DictationCoordinator {
                 error: error
             )
         }
+    }
+
+    private func handleMeetingRecordingWriterFailure(_ failure: CheckpointingAudioWriterFailure) {
+        guard isMeetingRecording else { return }
+        meetingStatusText = "Audio could not be saved reliably. Finishing the meeting."
+        AppTelemetry.failure(
+            "meeting_recording_writer_failed",
+            domain: .meeting,
+            stage: "audio_write",
+            reason: String(describing: failure)
+        )
+        stopMeetingRecording()
     }
 
     private func rotateActiveMeetingChunk() {
@@ -4359,7 +4515,6 @@ final class DictationCoordinator {
             failedSession.lastTranscriptionFailureReason = .timeout
             try? store.saveSession(failedSession)
             if failedSession.isLongForm {
-                transitionVoiceNoteLifecycle(.transcriptionFailed(failedSession.id))
                 AppTelemetry.failure(
                     "long_voice_note_transcription_failed",
                     domain: .transcription,
@@ -4371,14 +4526,8 @@ final class DictationCoordinator {
                         checkpointCount: longVoiceNoteCheckpointCount
                     )
                 )
-            } else if failedSession.longFormThresholdSeconds != nil {
-                let sessionID = failedSession.id
-                Task { @MainActor [weak self] in
-                    guard let self else { return }
-                    try? await voiceNoteCheckpointStore.delete(sessionID: sessionID)
-                    finishVoiceNoteLifecycle(sessionID: sessionID)
-                }
             }
+            settleVoiceNoteLifecycleAfterFailure(failedSession)
         }
         activeRequest = nil
         activeSession = nil
@@ -5028,6 +5177,32 @@ private enum KeyboardTranscriptionTimeoutSource {
 
 private enum VoiceNoteRetryError: Error {
     case timeout
+}
+
+private enum VoiceNoteCaptureFailure: LocalizedError {
+    case writer(CheckpointingAudioWriterFailure)
+    case missingDurableCheckpoint
+    case invalidLifecycleTransition
+
+    var failureReason: VoiceNoteTranscriptionFailureReason {
+        switch self {
+        case .writer, .missingDurableCheckpoint:
+            .checkpointFailure
+        case .invalidLifecycleTransition:
+            .unknown
+        }
+    }
+
+    var errorDescription: String? {
+        switch self {
+        case .writer:
+            "Audio could not be finalized reliably. Your recoverable audio was kept."
+        case .missingDurableCheckpoint:
+            "No durable audio checkpoint was available. Any recoverable audio was kept."
+        case .invalidLifecycleTransition:
+            "Voice note processing stopped because its lifecycle changed unexpectedly."
+        }
+    }
 }
 
 private final class OfflineTranscriptionJobControl<Output: Sendable>: @unchecked Sendable {

--- a/Muesli/DictationCoordinator.swift
+++ b/Muesli/DictationCoordinator.swift
@@ -225,6 +225,7 @@ final class DictationCoordinator {
     private static let offlineTranscriptionNoProgressTimeout: TimeInterval = 90
 
     private let store: SharedStore
+    private let eventBus: any CrossProcessEventStreaming
     private let voiceNoteCheckpointStore: VoiceNoteCheckpointStore
     private let engine = FluidAudioTranscriptionEngine()
     private let recorder = AudioRecorder()
@@ -242,15 +243,15 @@ final class DictationCoordinator {
     private var modelPrewarmTask: Task<Void, Never>?
     private var meteringTask: Task<Void, Never>?
     private var recordingTimerTask: Task<Void, Never>?
-    private var commandPollingTask: Task<Void, Never>?
-    private var keyboardRuntimePollingTask: Task<Void, Never>?
-    private var keyboardRuntimeTickInProgress = false
+    @ObservationIgnored nonisolated(unsafe) private var sharedEventObservationTask: Task<Void, Never>?
+    @ObservationIgnored nonisolated(unsafe) private var longVoiceNoteRecoveryTask: Task<Void, Never>?
+    private var keyboardCommandProcessingInProgress = false
     private var keyboardSessionRetryTask: Task<Void, Never>?
     private var keyboardSessionRetryAttempt = 0
+    private var lastKeyboardRuntimeHeartbeatAt = Date.distantPast
     private var keyboardSessionLiveActivityRequestIDs = Set<UUID>()
     private var iCloudSyncTask: Task<Void, Never>?
     private var iCloudSyncDebounceTask: Task<Void, Never>?
-    private var lastKeyboardRuntimeLevelWriteAt = Date.distantPast
     private var pendingICloudSyncReason: String?
     private var onboardingModelReadyCueModel: LocalTranscriptionModel?
     private var meetingChunkTasks: [Task<MeetingChunkTranscription?, Never>] = []
@@ -417,9 +418,13 @@ final class DictationCoordinator {
         }
     }
 
-    init() {
-        let store = SharedStore()
+    init(
+        store: SharedStore? = nil,
+        eventBus: any CrossProcessEventStreaming = DarwinCrossProcessEventBus.shared
+    ) {
+        let store = store ?? SharedStore(eventPoster: eventBus)
         self.store = store
+        self.eventBus = eventBus
         voiceNoteCheckpointStore = VoiceNoteCheckpointStore(store: store)
         ModelBackgroundDownloadService.shared.delegate = self
 
@@ -469,17 +474,11 @@ final class DictationCoordinator {
                 self?.handleVoiceNoteWriterFailure(failure)
             }
         }
-        keyboardSessionKeeper.setInputActivityHandler { [weak self] powerDB, isCapturing in
-            Task { @MainActor in
-                await self?.handleKeyboardSessionInputActivity(powerDB: powerDB, isCapturing: isCapturing)
-            }
-        }
+        startSharedEventObservation()
 
         refreshAudioInputRoute()
         refreshHistory()
-        Task { @MainActor in
-            await recoverLongVoiceNotesOnLaunch()
-        }
+        recoverLongVoiceNotesIfNeeded()
         Task {
             await liveActivityController.endAllActivities(
                 detail: "Recovered from interrupted session"
@@ -494,6 +493,8 @@ final class DictationCoordinator {
     }
 
     deinit {
+        sharedEventObservationTask?.cancel()
+        longVoiceNoteRecoveryTask?.cancel()
         if let audioRouteObserver {
             NotificationCenter.default.removeObserver(audioRouteObserver)
         }
@@ -774,7 +775,7 @@ final class DictationCoordinator {
         case .recordingShort(let currentStateSessionID) = voiceNoteLifecycleState.phase,
         currentStateSessionID == sessionID,
         isRecording,
-        var session = activeSession,
+        let session = activeSession,
         session.id == sessionID
         else { return }
 
@@ -784,20 +785,41 @@ final class DictationCoordinator {
             handleVoiceNoteWriterFailure(.checkpointRotation)
             return
         }
-        guard transitionVoiceNoteLifecycle(.longFormActivated(sessionID)) else { return }
+        _ = promoteActiveVoiceNoteToLongForm(sessionID: sessionID)
+    }
 
+    @discardableResult
+    private func promoteActiveVoiceNoteToLongForm(sessionID: UUID) -> RecordingSession? {
+        guard let runner = voiceNoteLifecycleRunner,
+              runner.sessionID == sessionID,
+              isRecording,
+              var session = activeSession,
+              session.id == sessionID
+        else { return nil }
+
+        switch voiceNoteLifecycleState.phase {
+        case .recordingShort(let activeID) where activeID == sessionID:
+            guard transitionVoiceNoteLifecycle(.longFormActivated(sessionID)) else { return nil }
+        case .recordingLongProtected(let activeID) where activeID == sessionID:
+            break
+        default:
+            return nil
+        }
+
+        let isFirstActivation = !session.isLongForm
         session.isLongForm = true
-        session.longFormActivatedAt = .now
-        session.protectedAudioUntilTranscriptCompletes = true
+        session.longFormActivatedAt = session.longFormActivatedAt ?? .now
+        session.protectedAudioUntilTranscriptCompletes = session.hasDurableAudioCheckpoint
         session.lastTranscriptionFailureReason = nil
         activeSession = session
+        try? store.saveSession(session)
+
+        guard isFirstActivation else { return session }
         if session.kind == .quickDictation {
             presentedLongVoiceNoteSessionID = session.id
         }
-        try? store.saveSession(session)
-        statusText = "Audio saved locally"
-
-        if longVoiceNoteAudioIsSecured {
+        if session.hasDurableAudioCheckpoint {
+            statusText = "Audio saved locally"
             var parameters = voiceNoteTelemetryParameters(
                 session: session,
                 checkpointCount: longVoiceNoteCheckpointCount
@@ -808,7 +830,6 @@ final class DictationCoordinator {
                 parameters: parameters
             )
         }
-
         AppTelemetry.contextualSignal(
             "long_voice_note_activated",
             parameters: voiceNoteTelemetryParameters(
@@ -816,20 +837,25 @@ final class DictationCoordinator {
                 checkpointCount: longVoiceNoteCheckpointCount
             )
         )
+
+        let durabilityDetail = session.hasDurableAudioCheckpoint
+            ? "Audio protected locally"
+            : "Securing audio"
         if session.kind == .keyboardDictation {
             refreshKeyboardSessionLiveActivity(
                 phase: "Long voice note",
-                detail: longVoiceNoteAudioIsSecured ? "Audio protected locally" : "Securing audio"
+                detail: durabilityDetail
             )
         } else {
             Task {
                 await liveActivityController.update(
                     phase: "Long voice note",
-                    detail: longVoiceNoteAudioIsSecured ? "Audio protected locally" : "Securing audio",
+                    detail: durabilityDetail,
                     session: session
                 )
             }
         }
+        return session
     }
 
     private func handleVoiceNoteWriterFailure(_ failure: CheckpointingAudioWriterFailure) {
@@ -876,10 +902,9 @@ final class DictationCoordinator {
         else { return }
 
         if let threshold = session.longFormThresholdSeconds,
-           recordingElapsedTime >= Double(threshold) {
-            session.isLongForm = true
-            session.longFormActivatedAt = session.longFormActivatedAt ?? .now
-            session.protectedAudioUntilTranscriptCompletes = session.hasDurableAudioCheckpoint
+           recordingElapsedTime >= Double(threshold),
+           let promotedSession = promoteActiveVoiceNoteToLongForm(sessionID: session.id) {
+            session = promotedSession
         }
         session.lastTranscriptionFailureReason = cause.failureReason
         session.errorMessage = message
@@ -889,8 +914,11 @@ final class DictationCoordinator {
     }
 
     func recoverLongVoiceNotesIfNeeded() {
-        Task { @MainActor in
+        guard longVoiceNoteRecoveryTask == nil else { return }
+        longVoiceNoteRecoveryTask = Task { @MainActor [weak self] in
+            guard let self else { return }
             await recoverLongVoiceNotesOnLaunch()
+            longVoiceNoteRecoveryTask = nil
         }
     }
 
@@ -933,7 +961,8 @@ final class DictationCoordinator {
                 && original.longFormThresholdSeconds != nil
             guard original.isLongForm || isCheckpointArmedRecording else { continue }
             guard [.recording, .transcriptionQueued, .transcribing, .failed].contains(original.phase),
-                  voiceNoteLifecycleRunner?.sessionID != original.id
+                  voiceNoteLifecycleRunner?.sessionID != original.id,
+                  original.phase != .failed || original.longFormRecoveryValidatedAt == nil
             else { continue }
 
             var session = original
@@ -979,7 +1008,9 @@ final class DictationCoordinator {
                 session.lastTranscriptionFailureReason = .audioUnavailable
                 session.errorMessage = "The saved audio is unavailable."
                 session.audioFileName = nil
+                try? await voiceNoteCheckpointStore.delete(sessionID: session.id)
             }
+            session.longFormRecoveryValidatedAt = .now
             try? store.saveSession(session)
             didChange = true
         }
@@ -1115,18 +1146,40 @@ final class DictationCoordinator {
 
         let action = components.queryItems?.first(where: { $0.name == MuesliAppConstants.actionQueryItem })?.value
             ?? MuesliAppConstants.startAction
+        if action == MuesliAppConstants.cancelAction {
+            guard !rejectConflictingKeyboardCommand(requestID: requestID, action: .cancel) else {
+                try? store.clearPendingCommand()
+                return
+            }
+            saveKeyboardHandoff(
+                requestID: requestID,
+                phase: .cancelled,
+                message: "Cancelled"
+            )
+            cancelRecording(requestID: requestID)
+            try? store.clearPendingCommand()
+            return
+        }
         if action == MuesliAppConstants.stopAction {
-            guard !rejectConflictingKeyboardCommand(requestID: requestID, action: .stop) else { return }
+            guard !rejectConflictingKeyboardCommand(requestID: requestID, action: .stop) else {
+                try? store.clearPendingCommand()
+                return
+            }
             saveKeyboardHandoff(
                 requestID: requestID,
                 phase: .stopAcknowledged,
                 message: "Stopping"
             )
             stopRecording(requestID: requestID)
+            try? store.clearPendingCommand()
             return
         }
 
-        guard !rejectConflictingKeyboardCommand(requestID: requestID, action: .start) else { return }
+        guard !rejectConflictingKeyboardCommand(requestID: requestID, action: .start) else {
+            try? store.clearPendingCommand()
+            return
+        }
+        defer { try? store.clearPendingCommand() }
 
         let pendingRequest = try? store.pendingRequest()
         let request = pendingRequest?.id == requestID
@@ -1139,7 +1192,6 @@ final class DictationCoordinator {
             return
         }
         transitionKeyboardSession(.handoffStarted(request.id))
-        startKeyboardRuntimePolling()
         startRecording(for: request, source: "keyboard")
     }
 
@@ -1160,8 +1212,6 @@ final class DictationCoordinator {
         guard activeRequest?.id == request.id else { return false }
 
         transitionKeyboardSession(.handoffStarted(request.id))
-        startKeyboardRuntimePolling()
-
         if isRecording {
             transitionKeyboardSession(.recordingStarted(request.id))
             saveKeyboardHandoff(
@@ -2120,8 +2170,7 @@ final class DictationCoordinator {
                     activeRequestID: activeRequest?.id,
                     phase: isRecording ? .recording : .transcribing,
                     message: "Turns off after this keyboard voice note",
-                    supportsBackgroundStart: false,
-                    inputLevel: inputLevel
+                    supportsBackgroundStart: false
                 )
                 return
             }
@@ -2172,8 +2221,6 @@ final class DictationCoordinator {
             keyboardSessionRetryAttempt = 0
             prewarmModelIfNeeded(reason: "keyboard_session")
             transitionKeyboardSession(.startSucceeded)
-            startKeyboardRuntimePolling()
-
             let session = RecordingSession(
                 kind: .keyboardDictation,
                 title: "Keyboard Session",
@@ -2904,7 +2951,6 @@ final class DictationCoordinator {
                         phase: .recordingStarted,
                         message: "Listening"
                     )
-                    startKeyboardRuntimePolling()
                     saveKeyboardRuntimeStatus(
                         isActive: true,
                         activeRequestID: request.id,
@@ -2917,16 +2963,16 @@ final class DictationCoordinator {
                     guard let self else { return }
                     self.inputLevel = level
                     if source == "keyboard" {
-                        self.publishKeyboardRuntimeLevel(level, requestID: request.id)
+                        self.publishKeyboardRecordingHeartbeat(requestID: request.id)
                     }
-                }
-                if source == "keyboard" {
-                    startCommandPolling(for: request.id)
                 }
                 statusText = "Recording"
                 AppTelemetry.signal("dictation_started", parameters: ["source": source])
                 try store.saveRequest(request)
                 try store.saveStatus(.init(requestID: request.id, phase: .recording))
+                if source == "keyboard" {
+                    await processPendingKeyboardCommand()
+                }
                 Task {
                     if usesKeyboardSessionLiveActivity {
                         refreshKeyboardSessionLiveActivity(
@@ -2976,6 +3022,9 @@ final class DictationCoordinator {
                 )
                 try? store.saveStatus(.init(requestID: request.id, phase: .failed, message: error.localizedDescription))
                 if source == "keyboard" {
+                    if let command = try? store.pendingCommand(), command.requestID == request.id {
+                        try? store.clearPendingCommand()
+                    }
                     saveKeyboardHandoff(
                         requestID: request.id,
                         phase: .failed,
@@ -3189,28 +3238,12 @@ final class DictationCoordinator {
 
         guard isRecording else { return }
 
-        if var thresholdSession = session,
+        if let thresholdSession = session,
            !thresholdSession.isLongForm,
            let threshold = thresholdSession.longFormThresholdSeconds,
            recordingElapsedTime >= Double(threshold),
-           transitionVoiceNoteLifecycle(.longFormActivated(thresholdSession.id)) {
-            thresholdSession.isLongForm = true
-            thresholdSession.longFormActivatedAt = .now
-            thresholdSession.protectedAudioUntilTranscriptCompletes =
-                thresholdSession.hasDurableAudioCheckpoint
-            session = thresholdSession
-            activeSession = thresholdSession
-            try? store.saveSession(thresholdSession)
-            if thresholdSession.kind == .quickDictation {
-                presentedLongVoiceNoteSessionID = thresholdSession.id
-            }
-            AppTelemetry.contextualSignal(
-                "long_voice_note_activated",
-                parameters: voiceNoteTelemetryParameters(
-                    session: thresholdSession,
-                    checkpointCount: longVoiceNoteCheckpointCount
-                )
-            )
+           let promotedSession = promoteActiveVoiceNoteToLongForm(sessionID: thresholdSession.id) {
+            session = promotedSession
         }
 
         let usesKeyboardSessionLiveActivity = usesKeyboardSessionLiveActivity(for: request.id)
@@ -3238,9 +3271,6 @@ final class DictationCoordinator {
         isRecording = false
         stopMetering()
         stopRecordingTimer()
-        if !usesKeyboardSessionLiveActivity {
-            stopCommandPolling()
-        }
         statusText = "Saving audio"
         if isKeyboardHandoffActive {
             transitionKeyboardSession(.transcribing(request.id))
@@ -3284,7 +3314,6 @@ final class DictationCoordinator {
         beginTranscriptionBackgroundTask()
         let transcriptionTask = Task {
             defer {
-                stopCommandPolling()
                 endTranscriptionBackgroundTask()
             }
             let startedFromKeyboard = isKeyboardHandoffActive
@@ -4659,83 +4688,40 @@ final class DictationCoordinator {
         onboardingTestInputLevel = 0
     }
 
-    private func startCommandPolling(for requestID: UUID) {
-        commandPollingTask?.cancel()
-        commandPollingTask = Task { @MainActor [weak self] in
-            while !Task.isCancelled {
-                guard let self else { return }
-                if let command = try? self.store.pendingCommand(), command.requestID == requestID {
-                    try? self.store.clearPendingCommand()
-                    switch command.action {
-                    case .start:
-                        break
-                    case .stop:
-                        self.saveKeyboardHandoff(
-                            requestID: requestID,
-                            phase: .stopAcknowledged,
-                            message: "Stopping"
-                        )
-                        self.stopRecording(requestID: requestID)
-                    case .cancel:
-                        self.saveKeyboardHandoff(
-                            requestID: requestID,
-                            phase: .cancelled,
-                            message: "Cancelled"
-                        )
-                        self.cancelRecording(requestID: requestID)
-                    }
-                    return
-                }
-                try? await Task.sleep(for: .milliseconds(250))
+    private func startSharedEventObservation() {
+        sharedEventObservationTask?.cancel()
+        sharedEventObservationTask = Task { @MainActor [weak self, eventBus] in
+            for await event in eventBus.events() {
+                guard !Task.isCancelled, let self else { return }
+                guard event == .commandChanged else { continue }
+                await self.processPendingKeyboardCommand()
             }
         }
     }
 
-    private func stopCommandPolling() {
-        commandPollingTask?.cancel()
-        commandPollingTask = nil
-    }
-
-    private func startKeyboardRuntimePolling() {
-        guard keyboardRuntimePollingTask == nil else { return }
-        refreshKeyboardRuntimeHeartbeat()
-
-        keyboardRuntimePollingTask = Task { @MainActor [weak self] in
-            while !Task.isCancelled {
-                guard let self else { return }
-                await self.processKeyboardRuntimeTick()
-                try? await Task.sleep(for: .milliseconds(500))
-            }
-        }
-    }
-
-    private func handleKeyboardSessionInputActivity(powerDB: Float, isCapturing: Bool) async {
-        guard MuesliPreferences.keyboardSessionModeEnabled || isCapturing else { return }
-        let normalized = min(max((Double(powerDB) + 50) / 50, 0), 1)
-        await processKeyboardRuntimeTick(inputLevel: normalized)
-    }
-
-    private func processKeyboardRuntimeTick(inputLevel: Double? = nil) async {
-        guard !keyboardRuntimeTickInProgress else { return }
-        keyboardRuntimeTickInProgress = true
-        defer { keyboardRuntimeTickInProgress = false }
-
-        if isKeyboardSessionArmed,
-           !keyboardSessionKeeper.isRunning,
-           !isRecording,
-           !hasMeetingRecordingInProgress,
-           activeRequest == nil
-        {
-            _ = await ensureKeyboardSessionKeeperRunning(publishReady: false)
-        }
-        refreshKeyboardRuntimeHeartbeat(inputLevel: inputLevel)
+    private func processPendingKeyboardCommand() async {
+        guard !keyboardCommandProcessingInProgress else { return }
+        keyboardCommandProcessingInProgress = true
+        defer { keyboardCommandProcessingInProgress = false }
 
         guard let command = try? store.pendingCommand() else { return }
-        try? store.clearPendingCommand()
         guard !rejectConflictingKeyboardCommand(
             requestID: command.requestID,
             action: command.action
-        ) else { return }
+        ) else {
+            try? store.clearPendingCommand()
+            return
+        }
+        if KeyboardCommandArbitration.shouldDeferUntilRecorderStarts(
+            action: command.action,
+            activeRequestMatches: activeRequest?.id == command.requestID,
+            hasActiveSession: activeSession != nil,
+            isRecording: isRecording
+        ) {
+            // Recorder startup is still awaiting permission or audio setup. Keep
+            // the durable command in SQLite and consume it after startup settles.
+            return
+        }
         switch command.action {
         case .start:
             break
@@ -4746,6 +4732,7 @@ final class DictationCoordinator {
                 message: "Stopping"
             )
             stopRecording(requestID: command.requestID)
+            try? store.clearPendingCommand()
             return
         case .cancel:
             saveKeyboardHandoff(
@@ -4754,6 +4741,7 @@ final class DictationCoordinator {
                 message: "Cancelled"
             )
             cancelRecording(requestID: command.requestID)
+            try? store.clearPendingCommand()
             return
         }
 
@@ -4777,44 +4765,17 @@ final class DictationCoordinator {
                 phase: .failed,
                 message: "Muesli is busy"
             ))
+            try? store.clearPendingCommand()
             return
         }
 
         transitionKeyboardSession(.handoffStarted(request.id))
         startRecording(for: request, source: "keyboard")
-    }
-
-    private func refreshKeyboardRuntimeHeartbeat(inputLevel: Double? = nil) {
-        let phase: DictationPhase
-        let message: String
-
-        if isRecording {
-            phase = .recording
-            message = "Listening"
-        } else if activeRequest != nil && statusText == "Transcribing" {
-            phase = .transcribing
-            message = "Transcribing"
-        } else if isKeyboardSessionArmed {
-            phase = .idle
-            message = "Keyboard session ready"
-        } else {
-            phase = .idle
-            message = "Ready"
-        }
-
-        saveKeyboardRuntimeStatus(
-            isActive: isKeyboardHotMicEngineReady || isRecording || activeRequest != nil,
-            activeRequestID: activeRequest?.id,
-            phase: phase,
-            message: message,
-            supportsBackgroundStart: canStartKeyboardRequestsInBackground,
-            inputLevel: inputLevel
-        )
+        try? store.clearPendingCommand()
     }
 
     private func publishKeyboardSessionReadyIfAvailable() {
         guard MuesliPreferences.keyboardSessionModeEnabled, canStartKeyboardRequestsInBackground else { return }
-        startKeyboardRuntimePolling()
         saveKeyboardRuntimeStatus(
             isActive: true,
             activeRequestID: nil,
@@ -4900,10 +4861,8 @@ final class DictationCoordinator {
         activeRequestID: UUID?,
         phase: DictationPhase,
         message: String?,
-        supportsBackgroundStart: Bool = false,
-        inputLevel: Double? = nil
+        supportsBackgroundStart: Bool = false
     ) {
-        let runtimeInputLevel = inputLevel ?? (phase == .recording ? self.inputLevel : 0)
         let canAcceptStartCommand = isActive
             && supportsBackgroundStart
             && activeRequestID == nil
@@ -4915,23 +4874,21 @@ final class DictationCoordinator {
             message: message,
             supportsBackgroundStart: supportsBackgroundStart,
             canAcceptStartCommand: canAcceptStartCommand,
-            inputLevel: runtimeInputLevel
+            inputLevel: 0
         ))
     }
 
-    private func publishKeyboardRuntimeLevel(_ level: Double, requestID: UUID) {
+    private func publishKeyboardRecordingHeartbeat(requestID: UUID) {
         guard activeRequest?.id == requestID, isRecording else { return }
-
         let now = Date()
-        guard now.timeIntervalSince(lastKeyboardRuntimeLevelWriteAt) >= 0.08 else { return }
-        lastKeyboardRuntimeLevelWriteAt = now
+        guard now.timeIntervalSince(lastKeyboardRuntimeHeartbeatAt) >= 10 else { return }
+        lastKeyboardRuntimeHeartbeatAt = now
         saveKeyboardRuntimeStatus(
             isActive: true,
             activeRequestID: requestID,
             phase: .recording,
             message: "Listening",
-            supportsBackgroundStart: canStartKeyboardRequestsInBackground,
-            inputLevel: level
+            supportsBackgroundStart: false
         )
     }
 
@@ -5081,7 +5038,6 @@ final class DictationCoordinator {
         let usesKeyboardSessionLiveActivity = usesKeyboardSessionLiveActivity(for: requestID)
         stopMetering()
         stopRecordingTimer()
-        stopCommandPolling()
         if usesKeyboardSessionLiveActivity {
             keyboardSessionKeeper.cancelSegment()
         } else {

--- a/Muesli/DictationCoordinator.swift
+++ b/Muesli/DictationCoordinator.swift
@@ -517,7 +517,6 @@ final class DictationCoordinator {
         meetingLifecycleState = MeetingLifecycleReducer.reduce(meetingLifecycleState, event: event)
     }
 
-    @discardableResult
     private func transitionVoiceNoteLifecycle(_ event: VoiceNoteLifecycleEvent) -> Bool {
         let previousState = voiceNoteLifecycleState
         let transition = VoiceNoteLifecycleReducer.transition(previousState, event: event)
@@ -591,8 +590,12 @@ final class DictationCoordinator {
 
     private func finishVoiceNoteLifecycle(sessionID: UUID) {
         guard voiceNoteLifecycleRunner?.sessionID == sessionID else { return }
+        if voiceNoteLifecycleState.activeSessionID == sessionID {
+            guard transitionVoiceNoteLifecycle(.finished(sessionID)) else { return }
+        } else if voiceNoteLifecycleState.activeSessionID != nil {
+            return
+        }
         voiceNoteLifecycleRunner?.cancelAll()
-        transitionVoiceNoteLifecycle(.finished(sessionID))
         voiceNoteLifecycleRunner = nil
         longVoiceNoteCheckpointCount = 0
         longVoiceNoteAudioIsSecured = false
@@ -619,19 +622,6 @@ final class DictationCoordinator {
             && voiceNoteLifecycleRunner?.sessionID == sessionID
             && voiceNoteLifecycleRunner?.requestID == requestID
             && voiceNoteLifecycleState.activeSessionID == sessionID
-    }
-
-    private func isCurrentVoiceNoteLifecycle(
-        sessionID: UUID,
-        requestID: UUID,
-        runnerID: UUID?
-    ) -> Bool {
-        guard let runnerID else { return true }
-        return isCurrentVoiceNoteLifecycle(
-            sessionID: sessionID,
-            requestID: requestID,
-            runnerID: runnerID
-        )
     }
 
     @discardableResult
@@ -722,7 +712,11 @@ final class DictationCoordinator {
         }
         switch VoiceNoteFailureLifecycleDisposition.resolve(for: session) {
         case .retryable:
-            transitionVoiceNoteLifecycle(.transcriptionFailed(session.id))
+            if case .failedRetryable(let activeID) = voiceNoteLifecycleState.phase,
+               activeID == session.id {
+                return
+            }
+            guard transitionVoiceNoteLifecycle(.transcriptionFailed(session.id)) else { return }
         case .finished:
             finishVoiceNoteLifecycle(sessionID: session.id)
         }
@@ -1247,17 +1241,22 @@ final class DictationCoordinator {
         transitionKeyboardSession(.transcribing(request.id))
         activeRequest = request
         activeSession = session
-        var lifecycleRunnerID: UUID?
-        if session.isLongForm {
+        voiceNoteLifecycleRunner?.cancelAll()
+        voiceNoteLifecycleState = VoiceNoteLifecycleState()
+        voiceNoteLifecycleRunner = VoiceNoteLifecycleRunner(
+            sessionID: session.id,
+            requestID: request.id
+        )
+        guard let lifecycleRunnerID = voiceNoteLifecycleRunner?.id,
+              transitionVoiceNoteLifecycle(.retryRequested(session.id)),
+              transitionVoiceNoteLifecycle(.transcriptionStarted(session.id))
+        else {
             voiceNoteLifecycleRunner?.cancelAll()
+            voiceNoteLifecycleRunner = nil
             voiceNoteLifecycleState = VoiceNoteLifecycleState()
-            voiceNoteLifecycleRunner = VoiceNoteLifecycleRunner(
-                sessionID: session.id,
-                requestID: request.id
-            )
-            lifecycleRunnerID = voiceNoteLifecycleRunner?.id
-            transitionVoiceNoteLifecycle(.retryRequested(session.id))
-            transitionVoiceNoteLifecycle(.transcriptionStarted(session.id))
+            activeRequest = nil
+            activeSession = nil
+            return true
         }
         statusText = "Transcribing"
         try? store.saveStatus(.init(requestID: request.id, phase: .transcribing, message: "Recovering transcription"))
@@ -1645,7 +1644,11 @@ final class DictationCoordinator {
             requestID: requestID
         )
         guard let runnerID = voiceNoteLifecycleRunner?.id else { return }
-        transitionVoiceNoteLifecycle(.retryRequested(sessionID))
+        guard transitionVoiceNoteLifecycle(.retryRequested(sessionID)) else {
+            voiceNoteLifecycleRunner?.cancelAll()
+            voiceNoteLifecycleRunner = nil
+            return
+        }
         session.phase = .transcriptionQueued
         session.transcriptionRetryCount += 1
         session.lastTranscriptionAttemptAt = .now
@@ -1679,10 +1682,12 @@ final class DictationCoordinator {
                     return
                 }
 
+                guard transitionVoiceNoteLifecycle(.transcriptionStarted(sessionID)) else {
+                    return
+                }
                 session.phase = .transcribing
                 try store.saveSession(session)
                 activeSession = session
-                transitionVoiceNoteLifecycle(.transcriptionStarted(sessionID))
                 statusText = "Transcribing"
                 await engine.selectModel(selectedTranscriptionModel)
                 let transcriptionURL = usableURL
@@ -2964,7 +2969,7 @@ final class DictationCoordinator {
         request: DictationRequest,
         session: RecordingSession,
         audioURL: URL,
-        lifecycleRunnerID: UUID?
+        lifecycleRunnerID: UUID
     ) {
         beginTranscriptionBackgroundTask()
         let task = Task {
@@ -3038,8 +3043,8 @@ final class DictationCoordinator {
                 try store.saveSession(completedSession)
                 if completedSession.longFormThresholdSeconds != nil {
                     try? await voiceNoteCheckpointStore.delete(sessionID: completedSession.id)
-                    finishVoiceNoteLifecycle(sessionID: completedSession.id)
                 }
+                finishVoiceNoteLifecycle(sessionID: completedSession.id)
                 exportRetainedAudioIfNeeded(for: completedSession)
 
                 let existingResult = try? store.result(for: request.id)
@@ -3134,9 +3139,7 @@ final class DictationCoordinator {
                 )
             }
         }
-        if lifecycleRunnerID != nil {
-            voiceNoteLifecycleRunner?.transcriptionTask = task
-        }
+        voiceNoteLifecycleRunner?.transcriptionTask = task
     }
 
     private func stopRecording(requestID: UUID) {
@@ -3157,6 +3160,8 @@ final class DictationCoordinator {
             saveKeyboardHandoff(requestID: requestID, phase: .failed, message: message)
             return
         }
+
+        guard isRecording else { return }
 
         if var thresholdSession = session,
            !thresholdSession.isLongForm,
@@ -3183,8 +3188,14 @@ final class DictationCoordinator {
         }
 
         let usesKeyboardSessionLiveActivity = usesKeyboardSessionLiveActivity(for: request.id)
+        let lifecycleRunnerID: UUID?
         if let session {
-            transitionVoiceNoteLifecycle(.stopRequested(session.id))
+            guard let runner = voiceNoteLifecycleRunner,
+                  runner.sessionID == session.id,
+                  runner.requestID == request.id,
+                  transitionVoiceNoteLifecycle(.stopRequested(session.id))
+            else { return }
+            lifecycleRunnerID = runner.id
             stopVoiceNoteRecordingTasks(sessionID: session.id)
             if session.isLongForm {
                 AppTelemetry.contextualSignal(
@@ -3195,6 +3206,8 @@ final class DictationCoordinator {
                     )
                 )
             }
+        } else {
+            lifecycleRunnerID = nil
         }
         isRecording = false
         stopMetering()
@@ -3292,6 +3305,13 @@ final class DictationCoordinator {
                         sessionID: currentSession.id,
                         finalCheckpoint: finalCheckpoint
                     )
+                    guard let lifecycleRunnerID,
+                          isCurrentVoiceNoteLifecycle(
+                              sessionID: currentSession.id,
+                              requestID: request.id,
+                              runnerID: lifecycleRunnerID
+                          )
+                    else { return }
                     longVoiceNoteCheckpointCount = manifest.entries.count
                     let checkpointFinalizationFailed = finalWriterFailure == .checkpointWrite
                         || finalWriterFailure == .checkpointRotation
@@ -3338,6 +3358,13 @@ final class DictationCoordinator {
                     throw VoiceNoteCaptureFailure.writer(finalWriterFailure)
                 }
                 if var currentSession = activeSession ?? session {
+                    guard let lifecycleRunnerID,
+                          isCurrentVoiceNoteLifecycle(
+                              sessionID: currentSession.id,
+                              requestID: request.id,
+                              runnerID: lifecycleRunnerID
+                          )
+                    else { return }
                     currentSession.phase = .transcribing
                     currentSession.lastTranscriptionAttemptAt = .now
                     activeSession = currentSession
@@ -3368,6 +3395,15 @@ final class DictationCoordinator {
                     text = postProcessTranscript(rawText)
                 } else {
                     text = realtimeText
+                }
+                if let currentSession = activeSession ?? session {
+                    guard let lifecycleRunnerID,
+                          isCurrentVoiceNoteLifecycle(
+                              sessionID: currentSession.id,
+                              requestID: request.id,
+                              runnerID: lifecycleRunnerID
+                          )
+                    else { return }
                 }
                 liveDictationTranscript = text
                 guard !isRecordingSessionCancelled(requestID: request.id) else {
@@ -3488,6 +3524,15 @@ final class DictationCoordinator {
                     ]
                 )
             } catch {
+                if let currentSession = activeSession ?? session {
+                    guard let lifecycleRunnerID,
+                          isCurrentVoiceNoteLifecycle(
+                              sessionID: currentSession.id,
+                              requestID: request.id,
+                              runnerID: lifecycleRunnerID
+                          )
+                    else { return }
+                }
                 var failedVoiceNoteSession: RecordingSession?
                 let failureReason = voiceNoteFailureReason(for: error)
                 if var session = activeSession ?? session {
@@ -5001,6 +5046,11 @@ final class DictationCoordinator {
             saveKeyboardHandoff(requestID: requestID, phase: .cancelled, message: "Cancelled")
             return
         }
+        if let session = activeSession {
+            guard transitionVoiceNoteLifecycle(.cancelRequested(session.id)) else { return }
+        } else {
+            guard isRecording else { return }
+        }
         isRecording = false
         let usesKeyboardSessionLiveActivity = usesKeyboardSessionLiveActivity(for: requestID)
         stopMetering()
@@ -5013,7 +5063,6 @@ final class DictationCoordinator {
             cleanupRealtimeDictationRecorder()
         }
         if var session = activeSession {
-            transitionVoiceNoteLifecycle(.cancelRequested(session.id))
             stopVoiceNoteRecordingTasks(sessionID: session.id)
             session.phase = .cancelled
             session.endedAt = .now

--- a/Muesli/DictationCoordinator.swift
+++ b/Muesli/DictationCoordinator.swift
@@ -429,11 +429,14 @@ final class DictationCoordinator {
         ModelBackgroundDownloadService.shared.delegate = self
 
         #if DEBUG
-        if Self.shouldConfigureForUITestingFromLaunchArguments() {
+        let isConfiguringForUITesting = Self.shouldConfigureForUITestingFromLaunchArguments()
+        if isConfiguringForUITesting {
             configureForUITesting()
         } else if Self.shouldResetOnboardingFromLaunchArguments() {
             resetOnboardingForTesting()
         }
+        #else
+        let isConfiguringForUITesting = false
         #endif
 
         audioRouteObserver = NotificationCenter.default.addObserver(
@@ -477,8 +480,10 @@ final class DictationCoordinator {
         startSharedEventObservation()
 
         refreshAudioInputRoute()
-        refreshHistory()
-        recoverLongVoiceNotesIfNeeded()
+        if !isConfiguringForUITesting {
+            refreshHistory()
+            recoverLongVoiceNotesIfNeeded()
+        }
         Task {
             await liveActivityController.endAllActivities(
                 detail: "Recovered from interrupted session"
@@ -535,6 +540,14 @@ final class DictationCoordinator {
             )
         }
         return transition.accepted
+    }
+
+    private func prepareVoiceNoteLifecycleForPersistedRetry(sessionID: UUID) -> Bool {
+        guard !voiceNoteLifecycleState.isWorkActive else { return false }
+        guard let previousSessionID = voiceNoteLifecycleState.activeSessionID,
+              previousSessionID != sessionID
+        else { return true }
+        return transitionVoiceNoteLifecycle(.finished(previousSessionID))
     }
 
     private func beginVoiceNoteLifecycle(
@@ -938,7 +951,22 @@ final class DictationCoordinator {
     }
 
     private func recoverLongVoiceNotesOnLaunch() async {
-        let sessions = (try? store.recordingSessions()) ?? []
+        let inventoryResult = VoiceNoteRecoveryInventory.load {
+            try store.recordingSessions()
+        }
+        let sessions: [RecordingSession]
+        switch inventoryResult {
+        case .success(let inventory):
+            sessions = inventory.sessions
+        case .failure(let error):
+            AppTelemetry.failure(
+                "long_voice_note_recovery_inventory_failed",
+                domain: .persistence,
+                stage: "load_sessions",
+                error: error
+            )
+            return
+        }
         let sessionsByID = Dictionary(uniqueKeysWithValues: sessions.map { ($0.id, $0) })
         let validIDs = Set(sessions.map(\.id))
         if let checkpointIDs = try? await voiceNoteCheckpointStore.checkpointSessionIDs() {
@@ -1288,11 +1316,15 @@ final class DictationCoordinator {
             return true
         }
 
+        guard prepareVoiceNoteLifecycleForPersistedRetry(sessionID: session.id) else {
+            let message = "Finish the active voice note first"
+            saveKeyboardHandoff(requestID: request.id, phase: .failed, message: message)
+            return true
+        }
         transitionKeyboardSession(.transcribing(request.id))
         activeRequest = request
         activeSession = session
         voiceNoteLifecycleRunner?.cancelAll()
-        voiceNoteLifecycleState = VoiceNoteLifecycleState()
         voiceNoteLifecycleRunner = VoiceNoteLifecycleRunner(
             sessionID: session.id,
             requestID: request.id
@@ -1301,9 +1333,7 @@ final class DictationCoordinator {
               transitionVoiceNoteLifecycle(.retryRequested(session.id)),
               transitionVoiceNoteLifecycle(.transcriptionStarted(session.id))
         else {
-            voiceNoteLifecycleRunner?.cancelAll()
-            voiceNoteLifecycleRunner = nil
-            voiceNoteLifecycleState = VoiceNoteLifecycleState()
+            finishVoiceNoteLifecycle(sessionID: session.id)
             activeRequest = nil
             activeSession = nil
             return true
@@ -1508,6 +1538,9 @@ final class DictationCoordinator {
     }
 
     func refreshHistory() {
+        #if DEBUG
+        guard !Self.shouldConfigureForUITestingFromLaunchArguments() else { return }
+        #endif
         do {
             dictationHistory = try store.resultsHistory()
             recordingSessions = try store.recordingSessions()
@@ -1713,16 +1746,15 @@ final class DictationCoordinator {
               let audioURL = try? store.audioFileURL(fileName: audioFileName)
         else { return }
 
+        guard prepareVoiceNoteLifecycleForPersistedRetry(sessionID: sessionID) else { return }
         voiceNoteLifecycleRunner?.cancelAll()
-        voiceNoteLifecycleState = VoiceNoteLifecycleState()
         voiceNoteLifecycleRunner = VoiceNoteLifecycleRunner(
             sessionID: sessionID,
             requestID: requestID
         )
         guard let runnerID = voiceNoteLifecycleRunner?.id else { return }
         guard transitionVoiceNoteLifecycle(.retryRequested(sessionID)) else {
-            voiceNoteLifecycleRunner?.cancelAll()
-            voiceNoteLifecycleRunner = nil
+            finishVoiceNoteLifecycle(sessionID: sessionID)
             return
         }
         session.phase = .transcriptionQueued

--- a/Muesli/DictationCoordinator.swift
+++ b/Muesli/DictationCoordinator.swift
@@ -1109,6 +1109,44 @@ final class DictationCoordinator {
             status: "\(selectedTranscriptionModel.shortName) ready",
             detail: "UI testing"
         )
+
+        if ProcessInfo.processInfo.arguments.contains(MuesliAppConstants.longVoiceNoteUITestLaunchArgument) {
+            configureLongVoiceNoteUITestFixture()
+        }
+    }
+
+    private func configureLongVoiceNoteUITestFixture() {
+        let request = DictationRequest()
+        let session = RecordingSession(
+            requestID: request.id,
+            kind: .quickDictation,
+            startedAt: Date.now.addingTimeInterval(-61),
+            phase: .recording,
+            source: "app",
+            isLongForm: true,
+            longFormActivatedAt: .now,
+            longFormThresholdSeconds: 60,
+            protectedAudioUntilTranscriptCompletes: true
+        )
+
+        activeRequest = request
+        activeSession = session
+        recordingSessions = [session]
+        isRecording = true
+        recordingElapsedTime = 61
+        longVoiceNoteCheckpointCount = 2
+        longVoiceNoteAudioIsSecured = true
+        voiceNoteLifecycleRunner = VoiceNoteLifecycleRunner(sessionID: session.id)
+        voiceNoteLifecycleState = VoiceNoteLifecycleReducer.reduce(
+            voiceNoteLifecycleState,
+            event: .recordingStarted(session.id)
+        )
+        voiceNoteLifecycleState = VoiceNoteLifecycleReducer.reduce(
+            voiceNoteLifecycleState,
+            event: .longFormActivated(session.id)
+        )
+        presentedLongVoiceNoteSessionID = session.id
+        statusText = "Audio saved locally"
     }
     #endif
 

--- a/Muesli/DictationCoordinator.swift
+++ b/Muesli/DictationCoordinator.swift
@@ -458,7 +458,10 @@ final class DictationCoordinator {
             queue: .main
         ) { [weak self] _ in
             Task { @MainActor in
-                self?.handleVoiceNoteRecordingInterruption(message: "Audio services restarted")
+                self?.handleVoiceNoteRecordingInterruption(
+                    message: "Audio services restarted",
+                    cause: .interrupted
+                )
             }
         }
         keyboardSessionKeeper.onRecordingFailure = { [weak self] failure in
@@ -675,6 +678,30 @@ final class DictationCoordinator {
         return await voiceNoteCheckpointStore.isReadableAudio(at: audioURL)
     }
 
+    private func persistVoiceNoteFailure(
+        _ session: RecordingSession,
+        reason: VoiceNoteTranscriptionFailureReason,
+        message: String,
+        unavailableAudioMessage: String? = nil
+    ) async -> RecordingSession {
+        let audioIsRecoverable = session.isLongForm
+            ? await hasRecoverableAudio(for: session)
+            : false
+        let resolvedMessage = session.isLongForm && !audioIsRecoverable
+            ? unavailableAudioMessage ?? message
+            : message
+        var failedSession = VoiceNoteFailureSessionPolicy.prepare(
+            session,
+            reason: reason,
+            message: resolvedMessage,
+            hasRecoverableAudio: audioIsRecoverable
+        )
+        cleanupNonRetainedAudio(for: &failedSession)
+        try? store.saveSession(failedSession)
+        settleVoiceNoteLifecycleAfterFailure(failedSession)
+        return failedSession
+    }
+
     private func settleVoiceNoteLifecycleAfterFailure(_ session: RecordingSession) {
         if VoiceNoteCheckpointRetentionPolicy.shouldDeleteCheckpoints(for: session) {
             let checkpointStore = voiceNoteCheckpointStore
@@ -813,10 +840,7 @@ final class DictationCoordinator {
             session.hasDurableAudioCheckpoint = false
         }
         longVoiceNoteDurabilityError = "Audio could not be saved reliably. The recording was stopped."
-        session.lastTranscriptionFailureReason = .checkpointFailure
-        session.errorMessage = longVoiceNoteDurabilityError
         activeSession = session
-        try? store.saveSession(session)
         AppTelemetry.failure(
             "long_voice_note_checkpoint_failed",
             domain: .audio,
@@ -827,14 +851,23 @@ final class DictationCoordinator {
                 checkpointCount: longVoiceNoteCheckpointCount
             )
         )
-        handleVoiceNoteRecordingInterruption(message: longVoiceNoteDurabilityError ?? "Audio save failed")
+        handleVoiceNoteRecordingInterruption(
+            message: longVoiceNoteDurabilityError ?? "Audio save failed",
+            cause: .checkpointFailure
+        )
     }
 
     private func handleAudioSessionInterruption() {
-        handleVoiceNoteRecordingInterruption(message: "Recording was interrupted by the system")
+        handleVoiceNoteRecordingInterruption(
+            message: "Recording was interrupted by the system",
+            cause: .interrupted
+        )
     }
 
-    private func handleVoiceNoteRecordingInterruption(message: String) {
+    private func handleVoiceNoteRecordingInterruption(
+        message: String,
+        cause: VoiceNoteRecordingTerminationCause
+    ) {
         guard isRecording,
               var session = activeSession,
               session.kind != .meeting,
@@ -847,7 +880,7 @@ final class DictationCoordinator {
             session.longFormActivatedAt = session.longFormActivatedAt ?? .now
             session.protectedAudioUntilTranscriptCompletes = session.hasDurableAudioCheckpoint
         }
-        session.lastTranscriptionFailureReason = .interrupted
+        session.lastTranscriptionFailureReason = cause.failureReason
         session.errorMessage = message
         activeSession = session
         try? store.saveSession(session)
@@ -1720,18 +1753,14 @@ final class DictationCoordinator {
                 ) else {
                     return
                 }
-                let audioIsRecoverable = await hasRecoverableAudio(for: session)
-                session.phase = .failed
-                session.errorMessage = audioIsRecoverable
-                    ? "Your audio is safe. Transcription was interrupted."
-                    : "Transcription was interrupted and the audio could not be recovered."
-                session.lastTranscriptionFailureReason = .interrupted
-                session.protectedAudioUntilTranscriptCompletes = audioIsRecoverable
-                cleanupNonRetainedAudio(for: &session)
-                try? store.saveSession(session)
+                session = await persistVoiceNoteFailure(
+                    session,
+                    reason: .interrupted,
+                    message: "Your audio is safe. Transcription was interrupted.",
+                    unavailableAudioMessage: "Transcription was interrupted and the audio could not be recovered."
+                )
                 activeSession = nil
                 statusText = session.errorMessage ?? "Transcription interrupted"
-                settleVoiceNoteLifecycleAfterFailure(session)
                 refreshHistory()
             } catch {
                 guard isCurrentVoiceNoteLifecycle(
@@ -1741,28 +1770,23 @@ final class DictationCoordinator {
                 ) else {
                     return
                 }
-                let audioIsRecoverable = await hasRecoverableAudio(for: session)
-                session.phase = .failed
-                session.errorMessage = audioIsRecoverable
-                    ? "Your audio is safe. We couldn't finish transcribing this note."
-                    : "We couldn't finish transcribing this note or recover its audio."
-                session.lastTranscriptionFailureReason = error is VoiceNoteRetryError
-                    ? .timeout
-                    : .engineFailure
-                session.protectedAudioUntilTranscriptCompletes = audioIsRecoverable
-                cleanupNonRetainedAudio(for: &session)
-                try? store.saveSession(session)
+                let failureReason = voiceNoteFailureReason(for: error)
+                session = await persistVoiceNoteFailure(
+                    session,
+                    reason: failureReason,
+                    message: "Your audio is safe. We couldn't finish transcribing this note.",
+                    unavailableAudioMessage: "We couldn't finish transcribing this note or recover its audio."
+                )
                 activeSession = nil
                 statusText = session.errorMessage ?? "Transcription failed"
-                settleVoiceNoteLifecycleAfterFailure(session)
                 refreshHistory()
                 AppTelemetry.failure(
                     "long_voice_note_transcription_failed",
                     domain: .transcription,
                     stage: "retry",
                     error: error,
-                    reason: session.lastTranscriptionFailureReason?.rawValue,
-                    isTimeout: session.lastTranscriptionFailureReason == .timeout,
+                    reason: failureReason.rawValue,
+                    isTimeout: failureReason == .timeout,
                     parameters: voiceNoteTelemetryParameters(session: session)
                 )
             }
@@ -2972,25 +2996,14 @@ final class DictationCoordinator {
                             message: message,
                             supportsBackgroundStart: self.canStartKeyboardRequestsInBackground
                         )
-                    }
-                ) { [weak self] in
-                    guard let self,
-                          self.isCurrentVoiceNoteLifecycle(
-                              sessionID: session.id,
-                              requestID: request.id,
-                              runnerID: lifecycleRunnerID
-                          )
-                    else { return }
-                    self.handleKeyboardTranscriptionTimeout(
-                        request: request,
-                        session: session,
-                        startedFromKeyboard: true,
-                        source: .recovery
-                    )
-                } operation: { [engine] progress in
+                    },
+                    onTimeout: {}
+                ) { [engine] progress in
                     try await engine.transcribe(audioURL: audioURL, progress: progress)
                 }
-                guard case .completed(let rawText) = outcome else { return }
+                guard case .completed(let rawText) = outcome else {
+                    throw VoiceNoteRetryError.timeout
+                }
                 guard isCurrentVoiceNoteLifecycle(
                     sessionID: session.id,
                     requestID: request.id,
@@ -3066,17 +3079,12 @@ final class DictationCoordinator {
                     requestID: request.id,
                     runnerID: lifecycleRunnerID
                 ) else { return }
-                var failedSession = session
-                failedSession.phase = .failed
-                failedSession.errorMessage = error.localizedDescription
-                failedSession.lastTranscriptionFailureReason = voiceNoteFailureReason(for: error)
-                if failedSession.isLongForm {
-                    failedSession.protectedAudioUntilTranscriptCompletes =
-                        await hasRecoverableAudio(for: failedSession)
-                }
-                cleanupNonRetainedAudio(for: &failedSession)
-                try? store.saveSession(failedSession)
-                settleVoiceNoteLifecycleAfterFailure(failedSession)
+                let failureReason = voiceNoteFailureReason(for: error)
+                _ = await persistVoiceNoteFailure(
+                    session,
+                    reason: failureReason,
+                    message: error.localizedDescription
+                )
                 try? store.saveStatus(.init(
                     requestID: request.id,
                     phase: .failed,
@@ -3089,6 +3097,8 @@ final class DictationCoordinator {
                 )
                 activeRequest = nil
                 activeSession = nil
+                try? store.clearPendingRequest()
+                try? store.clearPendingCommand()
                 let completedDeferredStop = completeDeferredKeyboardSessionStopIfNeeded()
                 transitionKeyboardSession(.requestFinished)
                 statusText = error.localizedDescription
@@ -3107,6 +3117,8 @@ final class DictationCoordinator {
                     domain: .transcription,
                     stage: "keyboard_recovery",
                     error: error,
+                    reason: failureReason.rawValue,
+                    isTimeout: failureReason == .timeout,
                     parameters: ["engine": engine.identifier]
                 )
             }
@@ -3337,10 +3349,11 @@ final class DictationCoordinator {
                     let outcome = try await runKeyboardTranscriptionJob(
                         audioURL: audioURL,
                         request: request,
-                        session: activeSession ?? session,
                         startedFromKeyboard: startedFromKeyboard
                     )
-                    guard case .completed(let rawText) = outcome else { return }
+                    guard case .completed(let rawText) = outcome else {
+                        throw VoiceNoteRetryError.timeout
+                    }
                     text = postProcessTranscript(rawText)
                 } else {
                     text = realtimeText
@@ -3465,24 +3478,22 @@ final class DictationCoordinator {
                 )
             } catch {
                 var failedVoiceNoteSession: RecordingSession?
+                let failureReason = voiceNoteFailureReason(for: error)
                 if var session = activeSession ?? session {
-                    session.phase = .failed
-                    session.errorMessage = error.localizedDescription
-                    session.lastTranscriptionFailureReason = voiceNoteFailureReason(for: error)
-                    if session.isLongForm {
-                        session.protectedAudioUntilTranscriptCompletes =
-                            await hasRecoverableAudio(for: session)
-                    }
-                    cleanupNonRetainedAudio(for: &session)
-                    try? store.saveSession(session)
+                    session = await persistVoiceNoteFailure(
+                        session,
+                        reason: failureReason,
+                        message: error.localizedDescription
+                    )
                     failedVoiceNoteSession = session
-                    settleVoiceNoteLifecycleAfterFailure(session)
                     if session.isLongForm {
                         AppTelemetry.failure(
                             "long_voice_note_transcription_failed",
                             domain: .transcription,
                             stage: "offline_transcription",
                             error: error,
+                            reason: failureReason.rawValue,
+                            isTimeout: failureReason == .timeout,
                             parameters: voiceNoteTelemetryParameters(
                                 session: session,
                                 checkpointCount: longVoiceNoteCheckpointCount
@@ -3492,6 +3503,8 @@ final class DictationCoordinator {
                 }
                 activeRequest = nil
                 activeSession = nil
+                try? store.clearPendingRequest()
+                try? store.clearPendingCommand()
                 let completedDeferredStop = completeDeferredKeyboardSessionStopIfNeeded()
                 if !completedDeferredStop {
                     saveKeyboardRuntimeStatus(
@@ -3535,6 +3548,8 @@ final class DictationCoordinator {
                     domain: .transcription,
                     stage: "transcription",
                     error: error,
+                    reason: failureReason.rawValue,
+                    isTimeout: failureReason == .timeout,
                     parameters: ["engine": engine.identifier]
                 )
                 try? store.saveStatus(.init(requestID: request.id, phase: .failed, message: error.localizedDescription))
@@ -4479,7 +4494,6 @@ final class DictationCoordinator {
     private func runKeyboardTranscriptionJob(
         audioURL: URL,
         request: DictationRequest,
-        session: RecordingSession?,
         startedFromKeyboard: Bool
     ) async throws -> OfflineTranscriptionJobOutcome<String> {
         try await runOfflineTranscriptionJob(
@@ -4490,93 +4504,10 @@ final class DictationCoordinator {
                     startedFromKeyboard: startedFromKeyboard,
                     update: update
                 )
-            }
-        ) { [weak self] in
-            self?.handleKeyboardTranscriptionTimeout(
-                request: request,
-                session: session,
-                startedFromKeyboard: startedFromKeyboard
-            )
-        } operation: { [engine] progress in
+            },
+            onTimeout: {}
+        ) { [engine] progress in
             try await engine.transcribe(audioURL: audioURL, progress: progress)
-        }
-    }
-
-    private func handleKeyboardTranscriptionTimeout(
-        request: DictationRequest,
-        session: RecordingSession?,
-        startedFromKeyboard: Bool,
-        source: KeyboardTranscriptionTimeoutSource = .activeDictation
-    ) {
-        let message = "Transcription stalled. Open Muesli to try again."
-        if var failedSession = activeSession ?? session {
-            failedSession.phase = .failed
-            failedSession.errorMessage = message
-            failedSession.lastTranscriptionFailureReason = .timeout
-            try? store.saveSession(failedSession)
-            if failedSession.isLongForm {
-                AppTelemetry.failure(
-                    "long_voice_note_transcription_failed",
-                    domain: .transcription,
-                    stage: "offline_transcription_timeout",
-                    reason: "timeout",
-                    isTimeout: true,
-                    parameters: voiceNoteTelemetryParameters(
-                        session: failedSession,
-                        checkpointCount: longVoiceNoteCheckpointCount
-                    )
-                )
-            }
-            settleVoiceNoteLifecycleAfterFailure(failedSession)
-        }
-        activeRequest = nil
-        activeSession = nil
-        liveDictationTranscript = ""
-        realtimeDictationCommittedText = ""
-        clearKeyboardLiveTranscript()
-        statusText = message
-        let completedDeferredStop = completeDeferredKeyboardSessionStopIfNeeded()
-        try? store.clearPendingRequest()
-        try? store.clearPendingCommand()
-        try? store.saveStatus(.init(requestID: request.id, phase: .failed, message: message))
-        if startedFromKeyboard {
-            saveKeyboardHandoff(requestID: request.id, phase: .failed, message: message)
-            if !completedDeferredStop {
-                saveKeyboardRuntimeStatus(
-                    isActive: canStartKeyboardRequestsInBackground,
-                    activeRequestID: nil,
-                    phase: .failed,
-                    message: message,
-                    supportsBackgroundStart: canStartKeyboardRequestsInBackground
-                )
-            }
-        }
-        transitionKeyboardSession(.requestFinished)
-        if !completedDeferredStop {
-            resumeKeyboardSessionKeeperIfNeeded()
-            publishKeyboardSessionReadyIfAvailable()
-        }
-        clearKeyboardSessionLiveActivityRoute(for: request.id)
-        refreshHistory()
-        switch source {
-        case .activeDictation:
-            AppTelemetry.failure(
-                "dictation_failed",
-                domain: .transcription,
-                stage: "transcription_timeout",
-                reason: "timeout",
-                isTimeout: true,
-                parameters: ["engine": engine.identifier]
-            )
-        case .recovery:
-            AppTelemetry.failure(
-                "keyboard_transcription_recovery_failed",
-                domain: .transcription,
-                stage: "keyboard_recovery_timeout",
-                reason: "timeout",
-                isTimeout: true,
-                parameters: ["engine": engine.identifier]
-            )
         }
     }
 
@@ -5170,13 +5101,15 @@ private enum OfflineTranscriptionJobOutcome<Output: Sendable>: Sendable {
     case timedOut
 }
 
-private enum KeyboardTranscriptionTimeoutSource {
-    case activeDictation
-    case recovery
-}
-
-private enum VoiceNoteRetryError: Error {
+private enum VoiceNoteRetryError: LocalizedError {
     case timeout
+
+    var errorDescription: String? {
+        switch self {
+        case .timeout:
+            "Transcription stalled. Open Muesli to try again."
+        }
+    }
 }
 
 private enum VoiceNoteCaptureFailure: LocalizedError {

--- a/Muesli/DictationCoordinator.swift
+++ b/Muesli/DictationCoordinator.swift
@@ -3115,7 +3115,11 @@ final class DictationCoordinator {
                 AppTelemetry.failure(
                     "keyboard_transcription_recovery_failed",
                     domain: .transcription,
-                    stage: "keyboard_recovery",
+                    stage: VoiceNoteFailureTelemetryPolicy.stage(
+                        for: failureReason,
+                        standard: "keyboard_recovery",
+                        timeout: "keyboard_recovery_timeout"
+                    ),
                     error: error,
                     reason: failureReason.rawValue,
                     isTimeout: failureReason == .timeout,
@@ -3490,7 +3494,11 @@ final class DictationCoordinator {
                         AppTelemetry.failure(
                             "long_voice_note_transcription_failed",
                             domain: .transcription,
-                            stage: "offline_transcription",
+                            stage: VoiceNoteFailureTelemetryPolicy.stage(
+                                for: failureReason,
+                                standard: "offline_transcription",
+                                timeout: "offline_transcription_timeout"
+                            ),
                             error: error,
                             reason: failureReason.rawValue,
                             isTimeout: failureReason == .timeout,
@@ -3546,7 +3554,11 @@ final class DictationCoordinator {
                 AppTelemetry.failure(
                     "dictation_failed",
                     domain: .transcription,
-                    stage: "transcription",
+                    stage: VoiceNoteFailureTelemetryPolicy.stage(
+                        for: failureReason,
+                        standard: "transcription",
+                        timeout: "transcription_timeout"
+                    ),
                     error: error,
                     reason: failureReason.rawValue,
                     isTimeout: failureReason == .timeout,

--- a/Muesli/DictationCoordinator.swift
+++ b/Muesli/DictationCoordinator.swift
@@ -518,9 +518,9 @@ final class DictationCoordinator {
         voiceNoteLifecycleState = VoiceNoteLifecycleReducer.reduce(voiceNoteLifecycleState, event: event)
     }
 
-    private func beginVoiceNoteLifecycle(sessionID: UUID, threshold: Int?) {
+    private func beginVoiceNoteLifecycle(sessionID: UUID, requestID: UUID, threshold: Int?) {
         voiceNoteLifecycleRunner?.cancelAll()
-        voiceNoteLifecycleRunner = VoiceNoteLifecycleRunner(sessionID: sessionID)
+        voiceNoteLifecycleRunner = VoiceNoteLifecycleRunner(sessionID: sessionID, requestID: requestID)
         transitionVoiceNoteLifecycle(.recordingStarted(sessionID))
         longVoiceNoteCheckpointCount = 0
         longVoiceNoteAudioIsSecured = false
@@ -559,6 +559,73 @@ final class DictationCoordinator {
         longVoiceNoteCheckpointCount = 0
         longVoiceNoteAudioIsSecured = false
         longVoiceNoteDurabilityError = nil
+    }
+
+    private var voiceNoteRequestOwnership: VoiceNoteRequestOwnership {
+        VoiceNoteRequestOwnership(
+            requestID: voiceNoteLifecycleRunner?.requestID
+                ?? activeSession?.requestID
+                ?? activeRequest?.id,
+            isWorkActive: voiceNoteLifecycleState.isWorkActive
+                || isRecording
+                || activeRequest != nil
+        )
+    }
+
+    private func isCurrentVoiceNoteLifecycle(
+        sessionID: UUID,
+        requestID: UUID,
+        runnerID: UUID
+    ) -> Bool {
+        voiceNoteLifecycleRunner?.id == runnerID
+            && voiceNoteLifecycleRunner?.sessionID == sessionID
+            && voiceNoteLifecycleRunner?.requestID == requestID
+            && voiceNoteLifecycleState.activeSessionID == sessionID
+    }
+
+    private func isCurrentVoiceNoteLifecycle(
+        sessionID: UUID,
+        requestID: UUID,
+        runnerID: UUID?
+    ) -> Bool {
+        guard let runnerID else { return true }
+        return isCurrentVoiceNoteLifecycle(
+            sessionID: sessionID,
+            requestID: requestID,
+            runnerID: runnerID
+        )
+    }
+
+    @discardableResult
+    private func rejectConflictingKeyboardCommand(
+        requestID: UUID,
+        action: DictationCommandAction
+    ) -> Bool {
+        let hasMeetingConflict = hasMeetingRecordingInProgress
+        let hasVoiceNoteConflict = !voiceNoteRequestOwnership.accepts(requestID: requestID)
+        guard hasMeetingConflict || hasVoiceNoteConflict else { return false }
+
+        let message = hasMeetingConflict
+            ? "Finish the active meeting first"
+            : "Finish the active voice note first"
+        saveKeyboardHandoff(requestID: requestID, phase: .failed, message: message)
+        if let pendingRequest = try? store.pendingRequest(), pendingRequest.id == requestID {
+            try? store.clearPendingRequest()
+        }
+        saveKeyboardRuntimeStatus(
+            isActive: false,
+            activeRequestID: nil,
+            phase: .failed,
+            message: message
+        )
+        AppTelemetry.failure(
+            "keyboard_dictation_rejected",
+            domain: .keyboardSession,
+            stage: "voice_note_ownership",
+            reason: hasMeetingConflict ? "active_meeting" : "active_voice_note",
+            parameters: ["action": action.rawValue]
+        )
+        return true
     }
 
     private func rotateActiveVoiceNoteCheckpoint(sessionID: UUID, isFinal: Bool) async {
@@ -722,8 +789,7 @@ final class DictationCoordinator {
             for sessionID in checkpointIDs {
                 let session = sessionsByID[sessionID]
                 if !validIDs.contains(sessionID)
-                    || session?.phase == .completed
-                    || session?.phase == .cancelled {
+                    || VoiceNoteCheckpointRetentionPolicy.shouldDeleteCheckpoints(for: session) {
                     try? await voiceNoteCheckpointStore.delete(sessionID: sessionID)
                 }
             }
@@ -731,6 +797,10 @@ final class DictationCoordinator {
 
         var didChange = false
         for original in sessions where original.kind != .meeting {
+            if original.audioFileName == nil,
+               !original.protectedAudioUntilTranscriptCompletes {
+                continue
+            }
             let isCheckpointArmedRecording = original.phase == .recording
                 && original.longFormThresholdSeconds != nil
             guard original.isLongForm || isCheckpointArmedRecording else { continue }
@@ -914,6 +984,7 @@ final class DictationCoordinator {
         let action = components.queryItems?.first(where: { $0.name == MuesliAppConstants.actionQueryItem })?.value
             ?? MuesliAppConstants.startAction
         if action == MuesliAppConstants.stopAction {
+            guard !rejectConflictingKeyboardCommand(requestID: requestID, action: .stop) else { return }
             saveKeyboardHandoff(
                 requestID: requestID,
                 phase: .stopAcknowledged,
@@ -922,6 +993,8 @@ final class DictationCoordinator {
             stopRecording(requestID: requestID)
             return
         }
+
+        guard !rejectConflictingKeyboardCommand(requestID: requestID, action: .start) else { return }
 
         let pendingRequest = try? store.pendingRequest()
         let request = pendingRequest?.id == requestID
@@ -934,7 +1007,6 @@ final class DictationCoordinator {
             return
         }
         transitionKeyboardSession(.handoffStarted(request.id))
-        activeRequest = request
         startKeyboardRuntimePolling()
         startRecording(for: request, source: "keyboard")
     }
@@ -1037,6 +1109,18 @@ final class DictationCoordinator {
         transitionKeyboardSession(.transcribing(request.id))
         activeRequest = request
         activeSession = session
+        var lifecycleRunnerID: UUID?
+        if session.isLongForm {
+            voiceNoteLifecycleRunner?.cancelAll()
+            voiceNoteLifecycleState = VoiceNoteLifecycleState()
+            voiceNoteLifecycleRunner = VoiceNoteLifecycleRunner(
+                sessionID: session.id,
+                requestID: request.id
+            )
+            lifecycleRunnerID = voiceNoteLifecycleRunner?.id
+            transitionVoiceNoteLifecycle(.retryRequested(session.id))
+            transitionVoiceNoteLifecycle(.transcriptionStarted(session.id))
+        }
         statusText = "Transcribing"
         try? store.saveStatus(.init(requestID: request.id, phase: .transcribing, message: "Recovering transcription"))
         saveKeyboardHandoff(
@@ -1051,7 +1135,12 @@ final class DictationCoordinator {
             message: "Recovering transcription",
             supportsBackgroundStart: canStartKeyboardRequestsInBackground
         )
-        recoverKeyboardTranscription(request: request, session: session, audioURL: audioURL)
+        recoverKeyboardTranscription(
+            request: request,
+            session: session,
+            audioURL: audioURL,
+            lifecycleRunnerID: lifecycleRunnerID
+        )
         return true
     }
 
@@ -1136,7 +1225,10 @@ final class DictationCoordinator {
         recordingElapsedTime = 61
         longVoiceNoteCheckpointCount = 2
         longVoiceNoteAudioIsSecured = true
-        voiceNoteLifecycleRunner = VoiceNoteLifecycleRunner(sessionID: session.id)
+        voiceNoteLifecycleRunner = VoiceNoteLifecycleRunner(
+            sessionID: session.id,
+            requestID: request.id
+        )
         voiceNoteLifecycleState = VoiceNoteLifecycleReducer.reduce(
             voiceNoteLifecycleState,
             event: .recordingStarted(session.id)
@@ -1248,7 +1340,7 @@ final class DictationCoordinator {
                 removeCachedTranscript(for: session.id)
                 try? store.deleteRecordingSession(id: session.id)
                 recordingSessions.removeAll { $0.id == session.id }
-                if session.isLongForm {
+                if session.longFormThresholdSeconds != nil {
                     Task {
                         try? await voiceNoteCheckpointStore.delete(sessionID: session.id)
                     }
@@ -1287,7 +1379,7 @@ final class DictationCoordinator {
             session.protectedAudioUntilTranscriptCompletes = false
             session.lastTranscriptionFailureReason = .audioUnavailable
             try store.saveSession(session)
-            if session.isLongForm {
+            if session.longFormThresholdSeconds != nil {
                 Task {
                     try? await voiceNoteCheckpointStore.delete(sessionID: session.id)
                 }
@@ -1342,30 +1434,62 @@ final class DictationCoordinator {
     }
 
     func deleteVoiceNoteAudio(sessionID: UUID) {
-        guard var session = try? store.activeRecordingSession(id: sessionID),
-              session.kind != .meeting
-        else { return }
-        if let audioFileName = session.audioFileName {
-            try? store.deleteAudioFile(fileName: audioFileName)
+        var primaryDeletionSucceeded = false
+        do {
+            if var session = try store.activeRecordingSession(id: sessionID),
+               session.kind != .meeting {
+                if let audioFileName = session.audioFileName {
+                    try store.deleteAudioFile(fileName: audioFileName)
+                }
+                session.audioFileName = nil
+                session.keepsAudioRecording = false
+                session.protectedAudioUntilTranscriptCompletes = false
+                session.lastTranscriptionFailureReason = .audioUnavailable
+                session.errorMessage = "The saved audio was deleted."
+                try store.saveSession(session)
+                if let index = recordingSessions.firstIndex(where: { $0.id == sessionID }) {
+                    recordingSessions[index] = session
+                }
+                primaryDeletionSucceeded = true
+            }
+        } catch {
+            AppTelemetry.failure(
+                "long_voice_note_audio_delete_failed",
+                domain: .audio,
+                stage: "continuous_audio_delete",
+                error: error
+            )
         }
-        session.audioFileName = nil
-        session.keepsAudioRecording = false
-        session.protectedAudioUntilTranscriptCompletes = false
-        session.lastTranscriptionFailureReason = .audioUnavailable
-        session.errorMessage = "The saved audio was deleted."
-        try? store.saveSession(session)
-        Task {
-            try? await voiceNoteCheckpointStore.delete(sessionID: sessionID)
+
+        clipboardStatusText = primaryDeletionSucceeded ? "Deleting audio" : "Audio delete incomplete"
+        let didDeletePrimaryAudio = primaryDeletionSucceeded
+        let checkpointStore = voiceNoteCheckpointStore
+        Task { @MainActor [weak self] in
+            do {
+                try await checkpointStore.delete(sessionID: sessionID)
+                self?.clipboardStatusText = didDeletePrimaryAudio
+                    ? "Audio deleted"
+                    : "Audio delete incomplete"
+            } catch {
+                self?.clipboardStatusText = didDeletePrimaryAudio
+                    ? "Audio deletion pending"
+                    : "Audio delete incomplete"
+                AppTelemetry.failure(
+                    "long_voice_note_audio_delete_deferred",
+                    domain: .audio,
+                    stage: "checkpoint_delete",
+                    error: error
+                )
+            }
+            self?.clearClipboardStatusSoon()
         }
-        if let index = recordingSessions.firstIndex(where: { $0.id == sessionID }) {
-            recordingSessions[index] = session
-        }
-        clipboardStatusText = "Audio deleted"
-        clearClipboardStatusSoon()
     }
 
     func retryVoiceNoteTranscription(sessionID: UUID) {
-        guard !isRecording, !hasMeetingRecordingInProgress, statusText != "Transcribing",
+        guard !isRecording,
+              !hasMeetingRecordingInProgress,
+              !voiceNoteLifecycleState.isWorkActive,
+              statusText != "Transcribing",
               var session = try? store.activeRecordingSession(id: sessionID),
               session.kind != .meeting,
               session.isLongForm,
@@ -1376,7 +1500,11 @@ final class DictationCoordinator {
 
         voiceNoteLifecycleRunner?.cancelAll()
         voiceNoteLifecycleState = VoiceNoteLifecycleState()
-        voiceNoteLifecycleRunner = VoiceNoteLifecycleRunner(sessionID: sessionID)
+        voiceNoteLifecycleRunner = VoiceNoteLifecycleRunner(
+            sessionID: sessionID,
+            requestID: requestID
+        )
+        guard let runnerID = voiceNoteLifecycleRunner?.id else { return }
         transitionVoiceNoteLifecycle(.retryRequested(sessionID))
         session.phase = .transcriptionQueued
         session.transcriptionRetryCount += 1
@@ -1403,6 +1531,13 @@ final class DictationCoordinator {
                         destinationURL: audioURL
                     )
                 }
+                guard isCurrentVoiceNoteLifecycle(
+                    sessionID: sessionID,
+                    requestID: requestID,
+                    runnerID: runnerID
+                ) else {
+                    return
+                }
 
                 session.phase = .transcribing
                 try store.saveSession(session)
@@ -1414,7 +1549,14 @@ final class DictationCoordinator {
                 let outcome = try await runOfflineTranscriptionJob(
                     audioURL: transcriptionURL,
                     onProgress: { [weak self] update in
-                        self?.statusText = self?.transcriptionStatusMessage(for: update) ?? "Transcribing"
+                        guard let self,
+                              self.isCurrentVoiceNoteLifecycle(
+                                  sessionID: sessionID,
+                                  requestID: requestID,
+                                  runnerID: runnerID
+                              )
+                        else { return }
+                        self.statusText = self.transcriptionStatusMessage(for: update)
                     },
                     onTimeout: {}
                 ) { [engine] progress in
@@ -1422,6 +1564,13 @@ final class DictationCoordinator {
                 }
                 guard case .completed(let rawText) = outcome else {
                     throw VoiceNoteRetryError.timeout
+                }
+                guard isCurrentVoiceNoteLifecycle(
+                    sessionID: sessionID,
+                    requestID: requestID,
+                    runnerID: runnerID
+                ) else {
+                    return
                 }
                 let text = postProcessTranscript(rawText)
                 let existingTranscript = try? store.transcript(for: sessionID)
@@ -1462,7 +1611,31 @@ final class DictationCoordinator {
                 statusText = "Ready"
                 finishVoiceNoteLifecycle(sessionID: sessionID)
                 refreshHistory()
+            } catch is CancellationError {
+                guard isCurrentVoiceNoteLifecycle(
+                    sessionID: sessionID,
+                    requestID: requestID,
+                    runnerID: runnerID
+                ) else {
+                    return
+                }
+                session.phase = .failed
+                session.errorMessage = "Your audio is safe. Transcription was interrupted."
+                session.lastTranscriptionFailureReason = .interrupted
+                session.protectedAudioUntilTranscriptCompletes = session.audioFileName != nil
+                try? store.saveSession(session)
+                activeSession = nil
+                statusText = session.errorMessage ?? "Transcription interrupted"
+                transitionVoiceNoteLifecycle(.transcriptionFailed(sessionID))
+                refreshHistory()
             } catch {
+                guard isCurrentVoiceNoteLifecycle(
+                    sessionID: sessionID,
+                    requestID: requestID,
+                    runnerID: runnerID
+                ) else {
+                    return
+                }
                 session.phase = .failed
                 session.errorMessage = "Your audio is safe. We couldn't finish transcribing this note."
                 session.lastTranscriptionFailureReason = error is VoiceNoteRetryError
@@ -2444,7 +2617,11 @@ final class DictationCoordinator {
     }
 
     private func startRecording(for request: DictationRequest, source: String) {
-        guard !isRecording, !hasMeetingRecordingInProgress, statusText != "Transcribing" else {
+        guard !isRecording,
+              !hasMeetingRecordingInProgress,
+              !voiceNoteLifecycleState.isWorkActive,
+              statusText != "Transcribing"
+        else {
             if source == "keyboard" {
                 if refreshActiveKeyboardRequestIfNeeded(request) {
                     return
@@ -2539,7 +2716,11 @@ final class DictationCoordinator {
                 refreshAudioInputRoute()
                 activeSession = session
                 isRecording = true
-                beginVoiceNoteLifecycle(sessionID: session.id, threshold: longModeThreshold)
+                beginVoiceNoteLifecycle(
+                    sessionID: session.id,
+                    requestID: request.id,
+                    threshold: longModeThreshold
+                )
                 if source == "keyboard", !usesKeyboardSessionLiveActivity {
                     transitionKeyboardSession(.recordingStarted(request.id))
                 }
@@ -2640,14 +2821,20 @@ final class DictationCoordinator {
     private func recoverKeyboardTranscription(
         request: DictationRequest,
         session: RecordingSession,
-        audioURL: URL
+        audioURL: URL,
+        lifecycleRunnerID: UUID?
     ) {
         beginTranscriptionBackgroundTask()
-        Task {
+        let task = Task {
             defer { endTranscriptionBackgroundTask() }
 
             do {
                 await engine.selectModel(selectedTranscriptionModel)
+                guard isCurrentVoiceNoteLifecycle(
+                    sessionID: session.id,
+                    requestID: request.id,
+                    runnerID: lifecycleRunnerID
+                ) else { return }
                 saveKeyboardHandoff(
                     requestID: request.id,
                     phase: .transcribingStarted,
@@ -2656,7 +2843,13 @@ final class DictationCoordinator {
                 let outcome = try await runOfflineTranscriptionJob(
                     audioURL: audioURL,
                     onProgress: { [weak self] update in
-                        guard let self else { return }
+                        guard let self,
+                              self.isCurrentVoiceNoteLifecycle(
+                                  sessionID: session.id,
+                                  requestID: request.id,
+                                  runnerID: lifecycleRunnerID
+                              )
+                        else { return }
                         let message = self.transcriptionStatusMessage(for: update)
                         self.statusText = message
                         try? self.store.saveStatus(.init(requestID: request.id, phase: .transcribing, message: message))
@@ -2670,7 +2863,14 @@ final class DictationCoordinator {
                         )
                     }
                 ) { [weak self] in
-                    self?.handleKeyboardTranscriptionTimeout(
+                    guard let self,
+                          self.isCurrentVoiceNoteLifecycle(
+                              sessionID: session.id,
+                              requestID: request.id,
+                              runnerID: lifecycleRunnerID
+                          )
+                    else { return }
+                    self.handleKeyboardTranscriptionTimeout(
                         request: request,
                         session: session,
                         startedFromKeyboard: true,
@@ -2680,6 +2880,11 @@ final class DictationCoordinator {
                     try await engine.transcribe(audioURL: audioURL, progress: progress)
                 }
                 guard case .completed(let rawText) = outcome else { return }
+                guard isCurrentVoiceNoteLifecycle(
+                    sessionID: session.id,
+                    requestID: request.id,
+                    runnerID: lifecycleRunnerID
+                ) else { return }
                 let text = postProcessTranscript(rawText)
                 let savedTranscript = Transcript(
                     sessionID: session.id,
@@ -2695,16 +2900,25 @@ final class DictationCoordinator {
                 completedSession.transcriptID = savedTranscript.id
                 completedSession.engineIdentifier = engine.identifier
                 completedSession.errorMessage = nil
+                completedSession.protectedAudioUntilTranscriptCompletes = false
+                completedSession.lastTranscriptionFailureReason = nil
                 cleanupNonRetainedAudio(for: &completedSession)
                 try store.saveSession(completedSession)
+                if completedSession.longFormThresholdSeconds != nil {
+                    try? await voiceNoteCheckpointStore.delete(sessionID: completedSession.id)
+                    finishVoiceNoteLifecycle(sessionID: completedSession.id)
+                }
                 exportRetainedAudioIfNeeded(for: completedSession)
 
+                let existingResult = try? store.result(for: request.id)
                 let result = DictationResult(
+                    id: existingResult?.id ?? UUID(),
                     requestID: request.id,
                     sessionID: savedTranscript.sessionID,
                     text: text,
                     createdAt: completedSession.createdAt,
-                    engineIdentifier: engine.identifier
+                    engineIdentifier: engine.identifier,
+                    source: completedSession.source
                 )
                 try store.saveResult(result)
                 scheduleICloudSyncAfterLocalChange(reason: "dictation_completed")
@@ -2735,9 +2949,24 @@ final class DictationCoordinator {
                     ]
                 )
             } catch {
+                guard isCurrentVoiceNoteLifecycle(
+                    sessionID: session.id,
+                    requestID: request.id,
+                    runnerID: lifecycleRunnerID
+                ) else { return }
                 var failedSession = session
                 failedSession.phase = .failed
                 failedSession.errorMessage = error.localizedDescription
+                failedSession.lastTranscriptionFailureReason = error is VoiceNoteRetryError
+                    ? .timeout
+                    : .engineFailure
+                if failedSession.isLongForm {
+                    failedSession.protectedAudioUntilTranscriptCompletes = failedSession.audioFileName != nil
+                    transitionVoiceNoteLifecycle(.transcriptionFailed(failedSession.id))
+                } else if failedSession.longFormThresholdSeconds != nil {
+                    try? await voiceNoteCheckpointStore.delete(sessionID: failedSession.id)
+                    finishVoiceNoteLifecycle(sessionID: failedSession.id)
+                }
                 cleanupNonRetainedAudio(for: &failedSession)
                 try? store.saveSession(failedSession)
                 try? store.saveStatus(.init(
@@ -2774,9 +3003,14 @@ final class DictationCoordinator {
                 )
             }
         }
+        if lifecycleRunnerID != nil {
+            voiceNoteLifecycleRunner?.transcriptionTask = task
+        }
     }
 
     private func stopRecording(requestID: UUID) {
+        guard !rejectConflictingKeyboardCommand(requestID: requestID, action: .stop) else { return }
+
         let request: DictationRequest
         var session = activeSession
         if let activeRequest, activeRequest.id == requestID {
@@ -3187,6 +3421,7 @@ final class DictationCoordinator {
         guard !isRecording,
               !hasMeetingRecordingInProgress,
               !isMeetingTranscribing,
+              !voiceNoteLifecycleState.isWorkActive,
               activeRequest == nil,
               statusText != "Transcribing"
         else { return nil }
@@ -4136,6 +4371,13 @@ final class DictationCoordinator {
                         checkpointCount: longVoiceNoteCheckpointCount
                     )
                 )
+            } else if failedSession.longFormThresholdSeconds != nil {
+                let sessionID = failedSession.id
+                Task { @MainActor [weak self] in
+                    guard let self else { return }
+                    try? await voiceNoteCheckpointStore.delete(sessionID: sessionID)
+                    finishVoiceNoteLifecycle(sessionID: sessionID)
+                }
             }
         }
         activeRequest = nil
@@ -4320,6 +4562,10 @@ final class DictationCoordinator {
 
         guard let command = try? store.pendingCommand() else { return }
         try? store.clearPendingCommand()
+        guard !rejectConflictingKeyboardCommand(
+            requestID: command.requestID,
+            action: command.action
+        ) else { return }
         switch command.action {
         case .start:
             break
@@ -4365,7 +4611,6 @@ final class DictationCoordinator {
         }
 
         transitionKeyboardSession(.handoffStarted(request.id))
-        activeRequest = request
         startRecording(for: request, source: "keyboard")
     }
 

--- a/Muesli/DictationCoordinator.swift
+++ b/Muesli/DictationCoordinator.swift
@@ -224,7 +224,8 @@ final class DictationCoordinator {
     private static let useCaseKey = "muesli.onboarding.useCase"
     private static let offlineTranscriptionNoProgressTimeout: TimeInterval = 90
 
-    private let store = SharedStore()
+    private let store: SharedStore
+    private let voiceNoteCheckpointStore: VoiceNoteCheckpointStore
     private let engine = FluidAudioTranscriptionEngine()
     private let recorder = AudioRecorder()
     private var meetingRecorder: StreamingMeetingRecorder?
@@ -232,6 +233,7 @@ final class DictationCoordinator {
     private var realtimeDictationBufferPipe: RealtimeAudioBufferPipe?
     private var realtimeDictationProcessingTask: Task<Void, Never>?
     private var realtimeDictationChunksDirectory: URL?
+    private var isRealtimeDictationSessionActive = false
     private var realtimeDictationCommittedText = ""
     private var meetingVadController: StreamingVadController?
     private let keyboardSessionKeeper = KeyboardSessionKeeper()
@@ -256,9 +258,13 @@ final class DictationCoordinator {
     private var meetingChunksDirectory: URL?
     private var meetingLifecycleState = MeetingLifecycleState()
     private var meetingLifecycleRunner: MeetingLifecycleRunner?
+    private var voiceNoteLifecycleState = VoiceNoteLifecycleState()
+    private var voiceNoteLifecycleRunner: VoiceNoteLifecycleRunner?
     private let meetingVadQueue = DispatchQueue(label: "com.phequals7.muesli.meeting-vad")
     private var transcriptionBackgroundTask: UIBackgroundTaskIdentifier = .invalid
     nonisolated(unsafe) private var audioRouteObserver: NSObjectProtocol?
+    nonisolated(unsafe) private var audioInterruptionObserver: NSObjectProtocol?
+    nonisolated(unsafe) private var mediaServicesResetObserver: NSObjectProtocol?
 
     private var activeRequest: DictationRequest?
     private var activeSession: RecordingSession?
@@ -288,6 +294,7 @@ final class DictationCoordinator {
     var iCloudSyncStatusText: String?
     var isICloudSyncInProgress = false
     var settingsNavigationRequestID: UUID?
+    var inputSettingsNavigationRequestID: UUID?
     var syncSetupRequestID: UUID? {
         didSet {
             if syncSetupRequestID == nil {
@@ -350,6 +357,36 @@ final class DictationCoordinator {
     var isMeetingTranscribing = false
     var activeMeetingTitle = "Untitled Meeting"
     var clipboardStatusText: String?
+    var longVoiceNoteCheckpointCount = 0
+    var longVoiceNoteAudioIsSecured = false
+    var longVoiceNoteDurabilityError: String?
+    var presentedLongVoiceNoteSessionID: UUID?
+
+    var activeLongVoiceNoteSession: RecordingSession? {
+        guard voiceNoteLifecycleState.isLongFormVisible,
+              let session = activeSession,
+              session.kind != .meeting,
+              session.isLongForm
+        else { return nil }
+        return session
+    }
+
+    var presentedLongVoiceNoteSession: RecordingSession? {
+        guard let sessionID = presentedLongVoiceNoteSessionID else { return nil }
+        if activeSession?.id == sessionID {
+            return activeSession
+        }
+        return recordingSessions.first(where: { $0.id == sessionID })
+            ?? (try? store.activeRecordingSession(id: sessionID))
+    }
+
+    var recoverableVoiceNoteSessions: [RecordingSession] {
+        recordingSessions.filter { session in
+            session.kind != .meeting
+                && session.isLongForm
+                && [.recording, .transcriptionQueued, .transcribing, .failed].contains(session.phase)
+        }
+    }
 
     var hasMeetingRecordingInProgress: Bool {
         meetingLifecycleState.isRecordingVisible
@@ -381,6 +418,9 @@ final class DictationCoordinator {
     }
 
     init() {
+        let store = SharedStore()
+        self.store = store
+        voiceNoteCheckpointStore = VoiceNoteCheckpointStore(store: store)
         ModelBackgroundDownloadService.shared.delegate = self
 
         #if DEBUG
@@ -400,6 +440,32 @@ final class DictationCoordinator {
                 self?.refreshAudioInputRoute()
             }
         }
+        audioInterruptionObserver = NotificationCenter.default.addObserver(
+            forName: AVAudioSession.interruptionNotification,
+            object: AVAudioSession.sharedInstance(),
+            queue: .main
+        ) { [weak self] notification in
+            let rawType = notification.userInfo?[AVAudioSessionInterruptionTypeKey] as? UInt
+            let didBegin = rawType.flatMap(AVAudioSession.InterruptionType.init(rawValue:)) == .began
+            guard didBegin else { return }
+            Task { @MainActor in
+                self?.handleAudioSessionInterruption()
+            }
+        }
+        mediaServicesResetObserver = NotificationCenter.default.addObserver(
+            forName: AVAudioSession.mediaServicesWereResetNotification,
+            object: AVAudioSession.sharedInstance(),
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor in
+                self?.handleVoiceNoteRecordingInterruption(message: "Audio services restarted")
+            }
+        }
+        keyboardSessionKeeper.onRecordingFailure = { [weak self] failure in
+            Task { @MainActor in
+                self?.handleVoiceNoteWriterFailure(failure)
+            }
+        }
         keyboardSessionKeeper.setInputActivityHandler { [weak self] powerDB, isCapturing in
             Task { @MainActor in
                 await self?.handleKeyboardSessionInputActivity(powerDB: powerDB, isCapturing: isCapturing)
@@ -408,6 +474,9 @@ final class DictationCoordinator {
 
         refreshAudioInputRoute()
         refreshHistory()
+        Task { @MainActor in
+            await recoverLongVoiceNotesOnLaunch()
+        }
         Task {
             await liveActivityController.endAllActivities(
                 detail: "Recovered from interrupted session"
@@ -425,6 +494,12 @@ final class DictationCoordinator {
         if let audioRouteObserver {
             NotificationCenter.default.removeObserver(audioRouteObserver)
         }
+        if let audioInterruptionObserver {
+            NotificationCenter.default.removeObserver(audioInterruptionObserver)
+        }
+        if let mediaServicesResetObserver {
+            NotificationCenter.default.removeObserver(mediaServicesResetObserver)
+        }
     }
 
     func refreshAudioInputRoute() {
@@ -437,6 +512,330 @@ final class DictationCoordinator {
 
     private func transitionMeetingLifecycle(_ event: MeetingLifecycleEvent) {
         meetingLifecycleState = MeetingLifecycleReducer.reduce(meetingLifecycleState, event: event)
+    }
+
+    private func transitionVoiceNoteLifecycle(_ event: VoiceNoteLifecycleEvent) {
+        voiceNoteLifecycleState = VoiceNoteLifecycleReducer.reduce(voiceNoteLifecycleState, event: event)
+    }
+
+    private func beginVoiceNoteLifecycle(sessionID: UUID, threshold: Int?) {
+        voiceNoteLifecycleRunner?.cancelAll()
+        voiceNoteLifecycleRunner = VoiceNoteLifecycleRunner(sessionID: sessionID)
+        transitionVoiceNoteLifecycle(.recordingStarted(sessionID))
+        longVoiceNoteCheckpointCount = 0
+        longVoiceNoteAudioIsSecured = false
+        longVoiceNoteDurabilityError = nil
+
+        guard let threshold else { return }
+        let checkpointTask = Task { @MainActor [weak self] in
+            while !Task.isCancelled {
+                try? await Task.sleep(for: .seconds(30))
+                guard !Task.isCancelled, let self else { return }
+                await self.rotateActiveVoiceNoteCheckpoint(sessionID: sessionID, isFinal: false)
+            }
+        }
+        let thresholdTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .seconds(threshold))
+            guard !Task.isCancelled, let self else { return }
+            await self.activateLongVoiceNote(sessionID: sessionID)
+        }
+        voiceNoteLifecycleRunner?.checkpointTask = checkpointTask
+        voiceNoteLifecycleRunner?.thresholdTask = thresholdTask
+    }
+
+    private func stopVoiceNoteRecordingTasks(sessionID: UUID) {
+        guard voiceNoteLifecycleRunner?.sessionID == sessionID else { return }
+        voiceNoteLifecycleRunner?.checkpointTask?.cancel()
+        voiceNoteLifecycleRunner?.thresholdTask?.cancel()
+        voiceNoteLifecycleRunner?.checkpointTask = nil
+        voiceNoteLifecycleRunner?.thresholdTask = nil
+    }
+
+    private func finishVoiceNoteLifecycle(sessionID: UUID) {
+        guard voiceNoteLifecycleRunner?.sessionID == sessionID else { return }
+        voiceNoteLifecycleRunner?.cancelAll()
+        transitionVoiceNoteLifecycle(.finished(sessionID))
+        voiceNoteLifecycleRunner = nil
+        longVoiceNoteCheckpointCount = 0
+        longVoiceNoteAudioIsSecured = false
+        longVoiceNoteDurabilityError = nil
+    }
+
+    private func rotateActiveVoiceNoteCheckpoint(sessionID: UUID, isFinal: Bool) async {
+        guard voiceNoteLifecycleRunner?.sessionID == sessionID,
+              activeSession?.id == sessionID,
+              activeSession?.longFormThresholdSeconds != nil
+        else { return }
+
+        let checkpoint = keyboardSessionKeeper.rotateSegmentCheckpoint()
+            ?? realtimeDictationRecorder?.rotateChunk()
+        guard let checkpoint else { return }
+
+        do {
+            let manifest = try await voiceNoteCheckpointStore.record(checkpoint, sessionID: sessionID)
+            guard activeSession?.id == sessionID else { return }
+            longVoiceNoteCheckpointCount = manifest.entries.count
+            longVoiceNoteAudioIsSecured = !manifest.entries.isEmpty
+            if activeSession?.isLongForm == true, manifest.entries.count == 1 || isFinal {
+                AppTelemetry.contextualSignal(
+                    "long_voice_note_audio_checkpoint_saved",
+                    parameters: voiceNoteTelemetryParameters(
+                        session: activeSession,
+                        checkpointCount: manifest.entries.count
+                    )
+                )
+            }
+        } catch {
+            handleVoiceNoteWriterFailure(.checkpointWrite)
+        }
+    }
+
+    private func activateLongVoiceNote(sessionID: UUID) async {
+        guard voiceNoteLifecycleRunner?.sessionID == sessionID,
+              var session = activeSession,
+              session.id == sessionID,
+              isRecording
+        else { return }
+
+        if longVoiceNoteCheckpointCount == 0 {
+            await rotateActiveVoiceNoteCheckpoint(sessionID: sessionID, isFinal: false)
+        }
+
+        session.isLongForm = true
+        session.longFormActivatedAt = .now
+        session.protectedAudioUntilTranscriptCompletes = true
+        session.lastTranscriptionFailureReason = nil
+        activeSession = session
+        if session.kind == .quickDictation {
+            presentedLongVoiceNoteSessionID = session.id
+        }
+        try? store.saveSession(session)
+        transitionVoiceNoteLifecycle(.longFormActivated(sessionID))
+        statusText = longVoiceNoteAudioIsSecured ? "Audio saved locally" : "Securing audio"
+
+        if longVoiceNoteAudioIsSecured {
+            var parameters = voiceNoteTelemetryParameters(
+                session: session,
+                checkpointCount: longVoiceNoteCheckpointCount
+            )
+            parameters["checkpoint_kind"] = "first_protected"
+            AppTelemetry.contextualSignal(
+                "long_voice_note_audio_checkpoint_saved",
+                parameters: parameters
+            )
+        }
+
+        AppTelemetry.contextualSignal(
+            "long_voice_note_activated",
+            parameters: voiceNoteTelemetryParameters(
+                session: session,
+                checkpointCount: longVoiceNoteCheckpointCount
+            )
+        )
+        if session.kind == .keyboardDictation {
+            refreshKeyboardSessionLiveActivity(
+                phase: "Long voice note",
+                detail: longVoiceNoteAudioIsSecured ? "Audio protected locally" : "Securing audio"
+            )
+        } else {
+            Task {
+                await liveActivityController.update(
+                    phase: "Long voice note",
+                    detail: longVoiceNoteAudioIsSecured ? "Audio protected locally" : "Securing audio",
+                    session: session
+                )
+            }
+        }
+    }
+
+    private func handleVoiceNoteWriterFailure(_ failure: CheckpointingAudioWriterFailure) {
+        guard isRecording, var session = activeSession, session.kind != .meeting else { return }
+        longVoiceNoteAudioIsSecured = false
+        longVoiceNoteDurabilityError = "Audio could not be saved reliably. The recording was stopped."
+        session.lastTranscriptionFailureReason = .checkpointFailure
+        session.errorMessage = longVoiceNoteDurabilityError
+        activeSession = session
+        try? store.saveSession(session)
+        AppTelemetry.failure(
+            "long_voice_note_checkpoint_failed",
+            domain: .audio,
+            stage: "checkpoint_write",
+            reason: String(describing: failure),
+            parameters: voiceNoteTelemetryParameters(
+                session: session,
+                checkpointCount: longVoiceNoteCheckpointCount
+            )
+        )
+        handleVoiceNoteRecordingInterruption(message: longVoiceNoteDurabilityError ?? "Audio save failed")
+    }
+
+    private func handleAudioSessionInterruption() {
+        handleVoiceNoteRecordingInterruption(message: "Recording was interrupted by the system")
+    }
+
+    private func handleVoiceNoteRecordingInterruption(message: String) {
+        guard isRecording,
+              var session = activeSession,
+              session.kind != .meeting,
+              let requestID = session.requestID
+        else { return }
+
+        if let threshold = session.longFormThresholdSeconds,
+           recordingElapsedTime >= Double(threshold) {
+            session.isLongForm = true
+            session.longFormActivatedAt = session.longFormActivatedAt ?? .now
+            session.protectedAudioUntilTranscriptCompletes = true
+        }
+        session.lastTranscriptionFailureReason = .interrupted
+        session.errorMessage = message
+        activeSession = session
+        try? store.saveSession(session)
+        stopRecording(requestID: requestID)
+    }
+
+    func recoverLongVoiceNotesIfNeeded() {
+        Task { @MainActor in
+            await recoverLongVoiceNotesOnLaunch()
+        }
+    }
+
+    func dismissLongVoiceNote() {
+        guard !isRecording || activeSession?.id != presentedLongVoiceNoteSessionID else { return }
+        presentedLongVoiceNoteSessionID = nil
+    }
+
+    func openLongVoiceNote(_ session: RecordingSession) {
+        guard session.kind != .meeting, session.isLongForm else { return }
+        presentedLongVoiceNoteSessionID = session.id
+    }
+
+    func openLongVoiceNoteSettings() {
+        inputSettingsNavigationRequestID = UUID()
+        settingsNavigationRequestID = UUID()
+    }
+
+    private func recoverLongVoiceNotesOnLaunch() async {
+        let sessions = (try? store.recordingSessions()) ?? []
+        let sessionsByID = Dictionary(uniqueKeysWithValues: sessions.map { ($0.id, $0) })
+        let validIDs = Set(sessions.map(\.id))
+        if let checkpointIDs = try? await voiceNoteCheckpointStore.checkpointSessionIDs() {
+            for sessionID in checkpointIDs {
+                let session = sessionsByID[sessionID]
+                if !validIDs.contains(sessionID)
+                    || session?.phase == .completed
+                    || session?.phase == .cancelled {
+                    try? await voiceNoteCheckpointStore.delete(sessionID: sessionID)
+                }
+            }
+        }
+
+        var didChange = false
+        for original in sessions where original.kind != .meeting {
+            let isCheckpointArmedRecording = original.phase == .recording
+                && original.longFormThresholdSeconds != nil
+            guard original.isLongForm || isCheckpointArmedRecording else { continue }
+            guard [.recording, .transcriptionQueued, .transcribing, .failed].contains(original.phase),
+                  voiceNoteLifecycleRunner?.sessionID != original.id
+            else { continue }
+
+            var session = original
+            if isCheckpointArmedRecording {
+                session.isLongForm = true
+                session.longFormActivatedAt = session.longFormActivatedAt ?? .now
+            }
+            _ = try? await voiceNoteCheckpointStore.salvageTrailingCheckpoint(sessionID: session.id)
+            if session.phase == .recording || session.phase == .transcribing {
+                session.phase = .failed
+                session.lastTranscriptionFailureReason = .interrupted
+                session.errorMessage = "Your audio is safe. Transcription needs to be retried."
+            }
+
+            var hasAudio = false
+            if let fileName = session.audioFileName,
+               let audioURL = try? store.audioFileURL(fileName: fileName) {
+                hasAudio = await voiceNoteCheckpointStore.isReadableAudio(at: audioURL)
+                if !hasAudio,
+                   (try? await voiceNoteCheckpointStore.reconstructAudio(
+                       sessionID: session.id,
+                       destinationURL: audioURL
+                   )) != nil {
+                    hasAudio = true
+                }
+            }
+
+            if hasAudio {
+                session.phase = .failed
+                session.protectedAudioUntilTranscriptCompletes = true
+                session.errorMessage = "Your audio is safe. We couldn't finish transcribing this note."
+                AppTelemetry.contextualSignal(
+                    "long_voice_note_recovered_on_launch",
+                    parameters: voiceNoteTelemetryParameters(session: session)
+                )
+            } else {
+                session.phase = .failed
+                session.protectedAudioUntilTranscriptCompletes = false
+                session.lastTranscriptionFailureReason = .audioUnavailable
+                session.errorMessage = "The saved audio is unavailable."
+                session.audioFileName = nil
+            }
+            try? store.saveSession(session)
+            didChange = true
+        }
+        if didChange {
+            refreshHistory()
+        }
+    }
+
+    private func voiceNoteTelemetryParameters(
+        session: RecordingSession?,
+        checkpointCount: Int? = nil
+    ) -> [String: String] {
+        guard let session else { return [:] }
+        let duration = max(0, session.duration ?? recordingElapsedTime)
+        let durationBucket: String
+        switch duration {
+        case ..<60: durationBucket = "under_60"
+        case ..<120: durationBucket = "60_119"
+        case ..<300: durationBucket = "120_299"
+        case ..<600: durationBucket = "300_599"
+        default: durationBucket = "600_plus"
+        }
+        var parameters = [
+            "source": session.kind == .keyboardDictation ? "keyboard" : "in_app",
+            "duration_bucket": durationBucket,
+            "threshold_seconds": "\(session.longFormThresholdSeconds ?? 0)",
+            "threshold_bucket": thresholdTelemetryBucket(session.longFormThresholdSeconds),
+            "engine": session.engineIdentifier ?? selectedTranscriptionModel.engineIdentifier,
+            "retry_count": "\(session.transcriptionRetryCount)",
+            "timeout": session.lastTranscriptionFailureReason == .timeout ? "true" : "false",
+        ]
+        if let checkpointCount {
+            parameters["checkpoint_count"] = "\(checkpointCount)"
+        }
+        return parameters
+    }
+
+    private func thresholdTelemetryBucket(_ threshold: Int?) -> String {
+        switch threshold ?? 0 {
+        case ...30: "30"
+        case ...60: "31_60"
+        case ...120: "61_120"
+        case ...300: "121_300"
+        default: "301_600"
+        }
+    }
+
+    private func configuredLongVoiceNoteThreshold() -> Int? {
+        guard MuesliPreferences.longVoiceNoteModeEnabled else { return nil }
+        #if DEBUG
+        let prefix = "--muesli-long-note-threshold-seconds="
+        if let argument = ProcessInfo.processInfo.arguments.first(where: { $0.hasPrefix(prefix) }),
+           let injected = Int(argument.dropFirst(prefix.count)),
+           (1...600).contains(injected) {
+            return injected
+        }
+        #endif
+        return MuesliPreferences.longVoiceNoteThresholdSeconds
     }
 
     private func beginMeetingLifecycle(sessionID: UUID, event: MeetingLifecycleEvent) {
@@ -702,6 +1101,8 @@ final class DictationCoordinator {
         UserDefaults.standard.set(userName, forKey: Self.userNameKey)
         UserDefaults.standard.set(selectedUseCase.rawValue, forKey: Self.useCaseKey)
         UserDefaults.standard.set(AppSection.defaultPinnedStorage, forKey: MuesliPreferences.pinnedSectionsKey)
+        UserDefaults.standard.set(true, forKey: MuesliPreferences.longVoiceNoteModeEnabledKey)
+        UserDefaults.standard.set(60, forKey: MuesliPreferences.longVoiceNoteThresholdSecondsKey)
         modelPreparation = ModelPreparationState(
             phase: .ready,
             progress: 1,
@@ -809,6 +1210,11 @@ final class DictationCoordinator {
                 removeCachedTranscript(for: session.id)
                 try? store.deleteRecordingSession(id: session.id)
                 recordingSessions.removeAll { $0.id == session.id }
+                if session.isLongForm {
+                    Task {
+                        try? await voiceNoteCheckpointStore.delete(sessionID: session.id)
+                    }
+                }
             }
             try store.deleteResult(result)
             dictationHistory.removeAll { $0.id == result.id || $0.requestID == result.requestID }
@@ -840,7 +1246,14 @@ final class DictationCoordinator {
             try store.deleteAudioFile(fileName: audioFileName)
             session.audioFileName = nil
             session.keepsAudioRecording = false
+            session.protectedAudioUntilTranscriptCompletes = false
+            session.lastTranscriptionFailureReason = .audioUnavailable
             try store.saveSession(session)
+            if session.isLongForm {
+                Task {
+                    try? await voiceNoteCheckpointStore.delete(sessionID: session.id)
+                }
+            }
 
             if let index = recordingSessions.firstIndex(where: { $0.id == session.id }) {
                 recordingSessions[index] = session
@@ -855,6 +1268,186 @@ final class DictationCoordinator {
             clearClipboardStatusSoon()
             return false
         }
+    }
+
+    func updateVoiceNoteScratchpad(sessionID: UUID, text: String) {
+        do {
+            guard var session = try store.activeRecordingSession(id: sessionID),
+                  session.kind != .meeting
+            else { return }
+            session.scratchpadText = text
+            try store.saveSession(session)
+            if activeSession?.id == sessionID {
+                activeSession = session
+            }
+            if let index = recordingSessions.firstIndex(where: { $0.id == sessionID }) {
+                recordingSessions[index] = session
+            }
+        } catch {
+            clipboardStatusText = "Notes save failed"
+            clearClipboardStatusSoon()
+        }
+    }
+
+    func keepVoiceNoteAudio(sessionID: UUID) {
+        guard var session = try? store.activeRecordingSession(id: sessionID),
+              session.kind != .meeting,
+              session.audioFileName != nil
+        else { return }
+        session.keepsAudioRecording = true
+        try? store.saveSession(session)
+        if let index = recordingSessions.firstIndex(where: { $0.id == sessionID }) {
+            recordingSessions[index] = session
+        }
+        clipboardStatusText = "Audio kept"
+        clearClipboardStatusSoon()
+    }
+
+    func deleteVoiceNoteAudio(sessionID: UUID) {
+        guard var session = try? store.activeRecordingSession(id: sessionID),
+              session.kind != .meeting
+        else { return }
+        if let audioFileName = session.audioFileName {
+            try? store.deleteAudioFile(fileName: audioFileName)
+        }
+        session.audioFileName = nil
+        session.keepsAudioRecording = false
+        session.protectedAudioUntilTranscriptCompletes = false
+        session.lastTranscriptionFailureReason = .audioUnavailable
+        session.errorMessage = "The saved audio was deleted."
+        try? store.saveSession(session)
+        Task {
+            try? await voiceNoteCheckpointStore.delete(sessionID: sessionID)
+        }
+        if let index = recordingSessions.firstIndex(where: { $0.id == sessionID }) {
+            recordingSessions[index] = session
+        }
+        clipboardStatusText = "Audio deleted"
+        clearClipboardStatusSoon()
+    }
+
+    func retryVoiceNoteTranscription(sessionID: UUID) {
+        guard !isRecording, !hasMeetingRecordingInProgress, statusText != "Transcribing",
+              var session = try? store.activeRecordingSession(id: sessionID),
+              session.kind != .meeting,
+              session.isLongForm,
+              let requestID = session.requestID,
+              let audioFileName = session.audioFileName,
+              let audioURL = try? store.audioFileURL(fileName: audioFileName)
+        else { return }
+
+        voiceNoteLifecycleRunner?.cancelAll()
+        voiceNoteLifecycleState = VoiceNoteLifecycleState()
+        voiceNoteLifecycleRunner = VoiceNoteLifecycleRunner(sessionID: sessionID)
+        transitionVoiceNoteLifecycle(.retryRequested(sessionID))
+        session.phase = .transcriptionQueued
+        session.transcriptionRetryCount += 1
+        session.lastTranscriptionAttemptAt = .now
+        session.errorMessage = nil
+        try? store.saveSession(session)
+        activeSession = session
+        statusText = "Preparing audio"
+        AppTelemetry.contextualSignal(
+            "long_voice_note_transcription_retried",
+            parameters: voiceNoteTelemetryParameters(session: session)
+        )
+
+        let task = Task { @MainActor [weak self] in
+            guard let self else { return }
+            beginTranscriptionBackgroundTask()
+            defer { endTranscriptionBackgroundTask() }
+            var session = session
+            do {
+                var usableURL = audioURL
+                if !(await voiceNoteCheckpointStore.isReadableAudio(at: usableURL)) {
+                    usableURL = try await voiceNoteCheckpointStore.reconstructAudio(
+                        sessionID: sessionID,
+                        destinationURL: audioURL
+                    )
+                }
+
+                session.phase = .transcribing
+                try store.saveSession(session)
+                activeSession = session
+                transitionVoiceNoteLifecycle(.transcriptionStarted(sessionID))
+                statusText = "Transcribing"
+                await engine.selectModel(selectedTranscriptionModel)
+                let transcriptionURL = usableURL
+                let outcome = try await runOfflineTranscriptionJob(
+                    audioURL: transcriptionURL,
+                    onProgress: { [weak self] update in
+                        self?.statusText = self?.transcriptionStatusMessage(for: update) ?? "Transcribing"
+                    },
+                    onTimeout: {}
+                ) { [engine] progress in
+                    try await engine.transcribe(audioURL: transcriptionURL, progress: progress)
+                }
+                guard case .completed(let rawText) = outcome else {
+                    throw VoiceNoteRetryError.timeout
+                }
+                let text = postProcessTranscript(rawText)
+                let existingTranscript = try? store.transcript(for: sessionID)
+                let transcript = Transcript(
+                    id: existingTranscript?.id ?? UUID(),
+                    sessionID: sessionID,
+                    text: text,
+                    createdAt: existingTranscript?.createdAt ?? .now,
+                    engineIdentifier: engine.identifier
+                )
+                try store.saveTranscript(transcript)
+                cacheTranscript(transcript)
+
+                session.phase = .completed
+                session.endedAt = session.endedAt ?? .now
+                session.transcriptID = transcript.id
+                session.engineIdentifier = engine.identifier
+                session.errorMessage = nil
+                session.protectedAudioUntilTranscriptCompletes = false
+                session.lastTranscriptionFailureReason = nil
+                cleanupNonRetainedAudio(for: &session)
+                try store.saveSession(session)
+                try? await voiceNoteCheckpointStore.delete(sessionID: sessionID)
+
+                let existingResult = try? store.result(for: requestID)
+                let result = DictationResult(
+                    id: existingResult?.id ?? UUID(),
+                    requestID: requestID,
+                    sessionID: sessionID,
+                    text: text,
+                    createdAt: session.createdAt,
+                    engineIdentifier: engine.identifier,
+                    source: session.source
+                )
+                try store.saveResult(result)
+                scheduleICloudSyncAfterLocalChange(reason: "long_voice_note_recovered")
+                activeSession = nil
+                statusText = "Ready"
+                finishVoiceNoteLifecycle(sessionID: sessionID)
+                refreshHistory()
+            } catch {
+                session.phase = .failed
+                session.errorMessage = "Your audio is safe. We couldn't finish transcribing this note."
+                session.lastTranscriptionFailureReason = error is VoiceNoteRetryError
+                    ? .timeout
+                    : .engineFailure
+                session.protectedAudioUntilTranscriptCompletes = session.audioFileName != nil
+                try? store.saveSession(session)
+                activeSession = nil
+                statusText = session.errorMessage ?? "Transcription failed"
+                transitionVoiceNoteLifecycle(.transcriptionFailed(sessionID))
+                refreshHistory()
+                AppTelemetry.failure(
+                    "long_voice_note_transcription_failed",
+                    domain: .transcription,
+                    stage: "retry",
+                    error: error,
+                    reason: session.lastTranscriptionFailureReason?.rawValue,
+                    isTimeout: session.lastTranscriptionFailureReason == .timeout,
+                    parameters: voiceNoteTelemetryParameters(session: session)
+                )
+            }
+        }
+        voiceNoteLifecycleRunner?.transcriptionTask = task
     }
 
     @discardableResult
@@ -1710,48 +2303,67 @@ final class DictationCoordinator {
         MuesliAudioCues.modelReady()
     }
 
-    private func startRealtimeDictationRecorder(audioURL: URL, sessionID: UUID) async throws {
-        await engine.selectModel(selectedTranscriptionModel)
+    private func startCheckpointingDictationRecorder(
+        audioURL: URL,
+        sessionID: UUID,
+        enablesRealtimeTranscription: Bool,
+        usesDurableCheckpoints: Bool
+    ) async throws {
         realtimeDictationCommittedText = ""
         liveDictationTranscript = ""
         clearKeyboardLiveTranscript()
-        try await engine.startRealtimeSession(
-            partialTranscript: { [weak self] partial in
-                Task { @MainActor in
-                    self?.updateRealtimeDictationPartial(partial)
+        if enablesRealtimeTranscription {
+            await engine.selectModel(selectedTranscriptionModel)
+            try await engine.startRealtimeSession(
+                partialTranscript: { [weak self] partial in
+                    Task { @MainActor in
+                        self?.updateRealtimeDictationPartial(partial)
+                    }
+                },
+                endOfUtterance: { [weak self] utterance in
+                    Task { @MainActor in
+                        self?.commitRealtimeDictationUtterance(utterance)
+                    }
                 }
-            },
-            endOfUtterance: { [weak self] utterance in
-                Task { @MainActor in
-                    self?.commitRealtimeDictationUtterance(utterance)
-                }
-            }
-        )
-
-        let chunksDirectory = try meetingChunkDirectory(for: sessionID)
-        try? FileManager.default.removeItem(at: chunksDirectory)
-        try FileManager.default.createDirectory(at: chunksDirectory, withIntermediateDirectories: true)
-
-        let pipe = RealtimeAudioBufferPipe()
-        let streamingRecorder = StreamingMeetingRecorder()
-        streamingRecorder.onAudioBuffer = { [pipe] buffer in
-            pipe.append(buffer)
+            )
         }
 
-        realtimeDictationProcessingTask = Task { [engine, pipe] in
-            for await audioBuffer in pipe.stream {
-                do {
-                    try await engine.processRealtimeAudioBuffer(audioBuffer.buffer)
-                } catch is CancellationError {
-                    return
-                } catch {
-                    AppTelemetry.failure(
-                        "realtime_dictation_buffer_failed",
-                        domain: .transcription,
-                        stage: "streaming_buffer",
-                        error: error,
-                        parameters: ["surface": "dictation"]
-                    )
+        let chunksDirectory: URL
+        if usesDurableCheckpoints {
+            chunksDirectory = try await voiceNoteCheckpointStore.prepare(sessionID: sessionID, startedAt: .now)
+        } else {
+            chunksDirectory = try meetingChunkDirectory(for: sessionID)
+            try? FileManager.default.removeItem(at: chunksDirectory)
+            try FileManager.default.createDirectory(at: chunksDirectory, withIntermediateDirectories: true)
+        }
+
+        let streamingRecorder = StreamingMeetingRecorder()
+        streamingRecorder.onRecordingFailure = { [weak self] failure in
+            Task { @MainActor in
+                self?.handleVoiceNoteWriterFailure(failure)
+            }
+        }
+        if enablesRealtimeTranscription {
+            let pipe = RealtimeAudioBufferPipe()
+            streamingRecorder.onAudioBuffer = { [pipe] buffer in
+                pipe.append(buffer)
+            }
+            realtimeDictationBufferPipe = pipe
+            realtimeDictationProcessingTask = Task { [engine, pipe] in
+                for await audioBuffer in pipe.stream {
+                    do {
+                        try await engine.processRealtimeAudioBuffer(audioBuffer.buffer)
+                    } catch is CancellationError {
+                        return
+                    } catch {
+                        AppTelemetry.failure(
+                            "realtime_dictation_buffer_failed",
+                            domain: .transcription,
+                            stage: "streaming_buffer",
+                            error: error,
+                            parameters: ["surface": "dictation"]
+                        )
+                    }
                 }
             }
         }
@@ -1762,8 +2374,8 @@ final class DictationCoordinator {
             routeStage: "realtime dictation"
         )
         realtimeDictationRecorder = streamingRecorder
-        realtimeDictationBufferPipe = pipe
         realtimeDictationChunksDirectory = chunksDirectory
+        isRealtimeDictationSessionActive = enablesRealtimeTranscription
     }
 
     private func updateRealtimeDictationPartial(_ partial: String) {
@@ -1823,10 +2435,13 @@ final class DictationCoordinator {
         realtimeDictationCommittedText = ""
         clearKeyboardLiveTranscript()
         let kind: RecordingSessionKind = source == "keyboard" ? .keyboardDictation : .quickDictation
+        let longModeThreshold = configuredLongVoiceNoteThreshold()
         var session = RecordingSession(
             requestID: request.id,
             kind: kind,
-            keepsAudioRecording: MuesliPreferences.keepDictationAudioRecordingsEnabled
+            keepsAudioRecording: MuesliPreferences.keepDictationAudioRecordingsEnabled,
+            source: source,
+            longFormThresholdSeconds: longModeThreshold
         )
         if source == "keyboard" {
             saveKeyboardHandoff(
@@ -1859,16 +2474,34 @@ final class DictationCoordinator {
                         }
                         transitionKeyboardSession(.startSucceeded)
                     }
-                    try keyboardSessionKeeper.beginSegment(outputURL: audioURL)
+                    let checkpointDirectory: URL?
+                    if longModeThreshold != nil {
+                        checkpointDirectory = try await voiceNoteCheckpointStore.prepare(
+                            sessionID: session.id,
+                            startedAt: session.startedAt ?? session.createdAt
+                        )
+                    } else {
+                        checkpointDirectory = nil
+                    }
+                    try keyboardSessionKeeper.beginSegment(
+                        outputURL: audioURL,
+                        checkpointDirectory: checkpointDirectory
+                    )
                     transitionKeyboardSession(.recordingStarted(request.id))
-                } else if selectedTranscriptionModel.supportsRealtimeStreaming {
-                    try await startRealtimeDictationRecorder(audioURL: audioURL, sessionID: session.id)
+                } else if selectedTranscriptionModel.supportsRealtimeStreaming || longModeThreshold != nil {
+                    try await startCheckpointingDictationRecorder(
+                        audioURL: audioURL,
+                        sessionID: session.id,
+                        enablesRealtimeTranscription: selectedTranscriptionModel.supportsRealtimeStreaming,
+                        usesDurableCheckpoints: longModeThreshold != nil
+                    )
                 } else {
                     try recorder.start(outputURL: audioURL)
                 }
                 refreshAudioInputRoute()
                 activeSession = session
                 isRecording = true
+                beginVoiceNoteLifecycle(sessionID: session.id, threshold: longModeThreshold)
                 if source == "keyboard", !usesKeyboardSessionLiveActivity {
                     transitionKeyboardSession(.recordingStarted(request.id))
                 }
@@ -1922,6 +2555,11 @@ final class DictationCoordinator {
                 session.errorMessage = error.localizedDescription
                 cleanupNonRetainedAudio(for: &session)
                 try? store.saveSession(session)
+                cleanupRealtimeDictationRecorder()
+                if session.longFormThresholdSeconds != nil {
+                    try? await voiceNoteCheckpointStore.delete(sessionID: session.id)
+                }
+                finishVoiceNoteLifecycle(sessionID: session.id)
                 activeSession = nil
                 activeRequest = nil
                 stopRecordingTimer()
@@ -2117,14 +2755,50 @@ final class DictationCoordinator {
             return
         }
 
+        if var thresholdSession = session,
+           !thresholdSession.isLongForm,
+           let threshold = thresholdSession.longFormThresholdSeconds,
+           recordingElapsedTime >= Double(threshold) {
+            thresholdSession.isLongForm = true
+            thresholdSession.longFormActivatedAt = .now
+            thresholdSession.protectedAudioUntilTranscriptCompletes = true
+            session = thresholdSession
+            activeSession = thresholdSession
+            try? store.saveSession(thresholdSession)
+            transitionVoiceNoteLifecycle(.longFormActivated(thresholdSession.id))
+            if thresholdSession.kind == .quickDictation {
+                presentedLongVoiceNoteSessionID = thresholdSession.id
+            }
+            AppTelemetry.contextualSignal(
+                "long_voice_note_activated",
+                parameters: voiceNoteTelemetryParameters(
+                    session: thresholdSession,
+                    checkpointCount: longVoiceNoteCheckpointCount
+                )
+            )
+        }
+
         let usesKeyboardSessionLiveActivity = usesKeyboardSessionLiveActivity(for: request.id)
+        if let session {
+            transitionVoiceNoteLifecycle(.stopRequested(session.id))
+            stopVoiceNoteRecordingTasks(sessionID: session.id)
+            if session.isLongForm {
+                AppTelemetry.contextualSignal(
+                    "long_voice_note_stop_requested",
+                    parameters: voiceNoteTelemetryParameters(
+                        session: session,
+                        checkpointCount: longVoiceNoteCheckpointCount
+                    )
+                )
+            }
+        }
         isRecording = false
         stopMetering()
         stopRecordingTimer()
         if !usesKeyboardSessionLiveActivity {
             stopCommandPolling()
         }
-        statusText = "Transcribing"
+        statusText = "Saving audio"
         if isKeyboardHandoffActive {
             transitionKeyboardSession(.transcribing(request.id))
         }
@@ -2144,7 +2818,7 @@ final class DictationCoordinator {
             )
         }
         if var session {
-            session.phase = .transcribing
+            session.phase = .transcriptionQueued
             session.endedAt = .now
             try? store.saveSession(session)
             activeSession = session
@@ -2165,7 +2839,7 @@ final class DictationCoordinator {
         }
 
         beginTranscriptionBackgroundTask()
-        Task {
+        let transcriptionTask = Task {
             defer {
                 stopCommandPolling()
                 endTranscriptionBackgroundTask()
@@ -2173,79 +2847,99 @@ final class DictationCoordinator {
             let startedFromKeyboard = isKeyboardHandoffActive
 
             do {
-                let usesRealtimeStreaming = realtimeDictationRecorder != nil
+                let usesCheckpointingRecorder = realtimeDictationRecorder != nil
+                let usesRealtimeStreaming = usesCheckpointingRecorder && isRealtimeDictationSessionActive
                 let audioURL: URL
-                var text: String
+                var finalCheckpoint: MeetingAudioChunk?
+                var realtimeText = ""
 
                 if usesKeyboardSessionLiveActivity {
-                    audioURL = try keyboardSessionKeeper.finishSegment()
-                    if startedFromKeyboard {
-                        saveKeyboardHandoff(
-                            requestID: request.id,
-                            phase: .transcribingStarted,
-                            message: "Transcribing"
-                        )
-                    }
-                    let outcome = try await runKeyboardTranscriptionJob(
-                        audioURL: audioURL,
-                        request: request,
-                        session: session,
-                        startedFromKeyboard: startedFromKeyboard
-                    )
-                    guard case .completed(let rawText) = outcome else { return }
-                    text = postProcessTranscript(rawText)
-                } else if usesRealtimeStreaming {
+                    let segment = try keyboardSessionKeeper.finishSegment()
+                    audioURL = segment.audioURL
+                    finalCheckpoint = segment.finalCheckpoint
+                } else if usesCheckpointingRecorder {
                     let stoppedAudio = realtimeDictationRecorder?.stop()
                     realtimeDictationRecorder = nil
-                    realtimeDictationBufferPipe?.finish()
-                    await realtimeDictationProcessingTask?.value
+                    finalCheckpoint = stoppedAudio?.finalChunk
+                    if usesRealtimeStreaming {
+                        realtimeDictationBufferPipe?.finish()
+                        await realtimeDictationProcessingTask?.value
+                    }
                     realtimeDictationProcessingTask = nil
                     realtimeDictationBufferPipe = nil
-                    if let realtimeDictationChunksDirectory {
-                        try? FileManager.default.removeItem(at: realtimeDictationChunksDirectory)
-                    }
-                    realtimeDictationChunksDirectory = nil
+                    isRealtimeDictationSessionActive = false
                     guard let retainedAudioURL = stoppedAudio?.retainedAudioURL else {
                         throw AudioRecorder.RecordingError.noRecording
                     }
                     audioURL = retainedAudioURL
-                    if startedFromKeyboard {
-                        saveKeyboardHandoff(
-                            requestID: request.id,
-                            phase: .transcribingStarted,
-                            message: "Transcribing"
-                        )
+                    if usesRealtimeStreaming {
+                        realtimeText = postProcessTranscript(try await engine.finishRealtimeSession())
                     }
-                    text = postProcessTranscript(try await engine.finishRealtimeSession())
-                    if text.isEmpty {
-                        let outcome = try await runKeyboardTranscriptionJob(
-                            audioURL: audioURL,
-                            request: request,
-                            session: session,
-                            startedFromKeyboard: startedFromKeyboard
-                        )
-                        guard case .completed(let rawText) = outcome else { return }
-                        text = postProcessTranscript(rawText)
-                    }
-                    liveDictationTranscript = text
                 } else {
                     audioURL = try recorder.stop()
-                    if startedFromKeyboard {
-                        saveKeyboardHandoff(
-                            requestID: request.id,
-                            phase: .transcribingStarted,
-                            message: "Transcribing"
+                }
+
+                if let currentSession = activeSession ?? session,
+                   currentSession.longFormThresholdSeconds != nil {
+                    let manifest = try await voiceNoteCheckpointStore.finalize(
+                        sessionID: currentSession.id,
+                        finalCheckpoint: finalCheckpoint
+                    )
+                    longVoiceNoteCheckpointCount = manifest.entries.count
+                    longVoiceNoteAudioIsSecured = !manifest.entries.isEmpty
+                    transitionVoiceNoteLifecycle(.audioFinalized(currentSession.id))
+                    transitionVoiceNoteLifecycle(.transcriptionQueued(currentSession.id))
+                    if currentSession.isLongForm, !manifest.entries.isEmpty {
+                        var checkpointParameters = voiceNoteTelemetryParameters(
+                            session: currentSession,
+                            checkpointCount: manifest.entries.count
+                        )
+                        checkpointParameters["checkpoint_kind"] = "final"
+                        AppTelemetry.contextualSignal(
+                            "long_voice_note_audio_checkpoint_saved",
+                            parameters: checkpointParameters
                         )
                     }
+                    if currentSession.isLongForm {
+                        AppTelemetry.contextualSignal(
+                            "long_voice_note_transcription_queued",
+                            parameters: voiceNoteTelemetryParameters(
+                                session: currentSession,
+                                checkpointCount: manifest.entries.count
+                            )
+                        )
+                    }
+                }
+                if var currentSession = activeSession ?? session {
+                    currentSession.phase = .transcribing
+                    currentSession.lastTranscriptionAttemptAt = .now
+                    activeSession = currentSession
+                    try? store.saveSession(currentSession)
+                    transitionVoiceNoteLifecycle(.transcriptionStarted(currentSession.id))
+                }
+                statusText = "Transcribing"
+                if startedFromKeyboard {
+                    saveKeyboardHandoff(
+                        requestID: request.id,
+                        phase: .transcribingStarted,
+                        message: "Transcribing"
+                    )
+                }
+
+                let text: String
+                if realtimeText.isEmpty {
                     let outcome = try await runKeyboardTranscriptionJob(
                         audioURL: audioURL,
                         request: request,
-                        session: session,
+                        session: activeSession ?? session,
                         startedFromKeyboard: startedFromKeyboard
                     )
                     guard case .completed(let rawText) = outcome else { return }
                     text = postProcessTranscript(rawText)
+                } else {
+                    text = realtimeText
                 }
+                liveDictationTranscript = text
                 guard !isRecordingSessionCancelled(requestID: request.id) else {
                     if startedFromKeyboard {
                         saveKeyboardHandoff(requestID: request.id, phase: .cancelled, message: "Cancelled")
@@ -2282,8 +2976,14 @@ final class DictationCoordinator {
                     completedSession.transcriptID = savedTranscript.id
                     completedSession.engineIdentifier = engine.identifier
                     completedSession.errorMessage = nil
+                    completedSession.protectedAudioUntilTranscriptCompletes = false
+                    completedSession.lastTranscriptionFailureReason = nil
                     cleanupNonRetainedAudio(for: &completedSession)
                     try store.saveSession(completedSession)
+                    if completedSession.longFormThresholdSeconds != nil {
+                        try? await voiceNoteCheckpointStore.delete(sessionID: completedSession.id)
+                        realtimeDictationChunksDirectory = nil
+                    }
                     exportRetainedAudioIfNeeded(for: completedSession)
                     transcript = savedTranscript
                 } else {
@@ -2295,7 +2995,8 @@ final class DictationCoordinator {
                     sessionID: transcript?.sessionID,
                     text: text,
                     createdAt: resultCreatedAt,
-                    engineIdentifier: engine.identifier
+                    engineIdentifier: engine.identifier,
+                    source: completedSession?.source
                 )
                 try store.saveResult(result)
                 scheduleICloudSyncAfterLocalChange(reason: "dictation_completed")
@@ -2308,6 +3009,9 @@ final class DictationCoordinator {
                 lastTranscript = text
                 activeRequest = nil
                 activeSession = nil
+                if let sessionID = completedSession?.id {
+                    finishVoiceNoteLifecycle(sessionID: sessionID)
+                }
                 if usesKeyboardSessionLiveActivity {
                     keyboardSessionKeeper.cancelSegment()
                 }
@@ -2353,11 +3057,30 @@ final class DictationCoordinator {
                     ]
                 )
             } catch {
+                var failedVoiceNoteSession: RecordingSession?
                 if var session = activeSession ?? session {
                     session.phase = .failed
                     session.errorMessage = error.localizedDescription
+                    session.lastTranscriptionFailureReason = .engineFailure
                     cleanupNonRetainedAudio(for: &session)
                     try? store.saveSession(session)
+                    failedVoiceNoteSession = session
+                    if session.isLongForm {
+                        transitionVoiceNoteLifecycle(.transcriptionFailed(session.id))
+                        AppTelemetry.failure(
+                            "long_voice_note_transcription_failed",
+                            domain: .transcription,
+                            stage: "offline_transcription",
+                            error: error,
+                            parameters: voiceNoteTelemetryParameters(
+                                session: session,
+                                checkpointCount: longVoiceNoteCheckpointCount
+                            )
+                        )
+                    } else if session.longFormThresholdSeconds != nil {
+                        try? await voiceNoteCheckpointStore.delete(sessionID: session.id)
+                        finishVoiceNoteLifecycle(sessionID: session.id)
+                    }
                 }
                 activeRequest = nil
                 activeSession = nil
@@ -2389,10 +3112,11 @@ final class DictationCoordinator {
                 realtimeDictationBufferPipe = nil
                 realtimeDictationProcessingTask?.cancel()
                 realtimeDictationProcessingTask = nil
-                if let realtimeDictationChunksDirectory {
+                if failedVoiceNoteSession?.protectedAudioUntilTranscriptCompletes != true,
+                   let realtimeDictationChunksDirectory {
                     try? FileManager.default.removeItem(at: realtimeDictationChunksDirectory)
+                    self.realtimeDictationChunksDirectory = nil
                 }
-                realtimeDictationChunksDirectory = nil
                 liveDictationTranscript = ""
                 realtimeDictationCommittedText = ""
                 clearKeyboardLiveTranscript()
@@ -2414,6 +3138,9 @@ final class DictationCoordinator {
                     )
                 }
             }
+        }
+        if let sessionID = session?.id, voiceNoteLifecycleRunner?.sessionID == sessionID {
+            voiceNoteLifecycleRunner?.transcriptionTask = transcriptionTask
         }
     }
 
@@ -3356,7 +4083,22 @@ final class DictationCoordinator {
         if var failedSession = activeSession ?? session {
             failedSession.phase = .failed
             failedSession.errorMessage = message
+            failedSession.lastTranscriptionFailureReason = .timeout
             try? store.saveSession(failedSession)
+            if failedSession.isLongForm {
+                transitionVoiceNoteLifecycle(.transcriptionFailed(failedSession.id))
+                AppTelemetry.failure(
+                    "long_voice_note_transcription_failed",
+                    domain: .transcription,
+                    stage: "offline_transcription_timeout",
+                    reason: "timeout",
+                    isTimeout: true,
+                    parameters: voiceNoteTelemetryParameters(
+                        session: failedSession,
+                        checkpointCount: longVoiceNoteCheckpointCount
+                    )
+                )
+            }
         }
         activeRequest = nil
         activeSession = nil
@@ -3410,7 +4152,8 @@ final class DictationCoordinator {
     }
 
     private func cleanupNonRetainedAudio(for session: inout RecordingSession) {
-        guard !session.keepsAudioRecording,
+        guard !session.protectedAudioUntilTranscriptCompletes,
+              !session.keepsAudioRecording,
               let audioFileName = session.audioFileName
         else { return }
 
@@ -3888,10 +4631,18 @@ final class DictationCoordinator {
             cleanupRealtimeDictationRecorder()
         }
         if var session = activeSession {
+            transitionVoiceNoteLifecycle(.cancelRequested(session.id))
+            stopVoiceNoteRecordingTasks(sessionID: session.id)
             session.phase = .cancelled
             session.endedAt = .now
             discardAudio(for: &session)
             try? store.saveSession(session)
+            if session.longFormThresholdSeconds != nil {
+                Task {
+                    try? await voiceNoteCheckpointStore.delete(sessionID: session.id)
+                }
+            }
+            finishVoiceNoteLifecycle(sessionID: session.id)
             if let index = recordingSessions.firstIndex(where: { $0.id == session.id }) {
                 recordingSessions[index] = session
             }
@@ -3960,6 +4711,7 @@ final class DictationCoordinator {
         realtimeDictationBufferPipe = nil
         realtimeDictationProcessingTask?.cancel()
         realtimeDictationProcessingTask = nil
+        isRealtimeDictationSessionActive = false
         if let realtimeDictationChunksDirectory {
             try? FileManager.default.removeItem(at: realtimeDictationChunksDirectory)
         }
@@ -3989,6 +4741,10 @@ private enum OfflineTranscriptionJobOutcome<Output: Sendable>: Sendable {
 private enum KeyboardTranscriptionTimeoutSource {
     case activeDictation
     case recovery
+}
+
+private enum VoiceNoteRetryError: Error {
+    case timeout
 }
 
 private final class OfflineTranscriptionJobControl<Output: Sendable>: @unchecked Sendable {

--- a/Muesli/DictationCoordinator.swift
+++ b/Muesli/DictationCoordinator.swift
@@ -1336,7 +1336,9 @@ final class DictationCoordinator {
             detail: "UI testing"
         )
 
-        if ProcessInfo.processInfo.arguments.contains(MuesliAppConstants.longVoiceNoteUITestLaunchArgument) {
+        if ProcessInfo.processInfo.arguments.contains(MuesliAppConstants.completedLongVoiceNoteUITestLaunchArgument) {
+            configureCompletedLongVoiceNoteUITestFixture()
+        } else if ProcessInfo.processInfo.arguments.contains(MuesliAppConstants.longVoiceNoteUITestLaunchArgument) {
             configureLongVoiceNoteUITestFixture()
         }
     }
@@ -1376,6 +1378,31 @@ final class DictationCoordinator {
         )
         presentedLongVoiceNoteSessionID = session.id
         statusText = "Audio saved locally"
+    }
+
+    private func configureCompletedLongVoiceNoteUITestFixture() {
+        let request = DictationRequest()
+        let session = RecordingSession(
+            requestID: request.id,
+            kind: .quickDictation,
+            startedAt: Date.now.addingTimeInterval(-62),
+            endedAt: .now,
+            phase: .completed,
+            source: "app",
+            isLongForm: true,
+            longFormActivatedAt: Date.now.addingTimeInterval(-32),
+            longFormThresholdSeconds: 30
+        )
+        let transcript = Transcript(
+            sessionID: session.id,
+            text: "Completed long voice note transcript.",
+            engineIdentifier: selectedTranscriptionModel.engineIdentifier
+        )
+
+        recordingSessions = [session]
+        cacheTranscript(transcript)
+        presentedLongVoiceNoteSessionID = session.id
+        statusText = "Ready"
     }
     #endif
 
@@ -1630,8 +1657,7 @@ final class DictationCoordinator {
               !voiceNoteLifecycleState.isWorkActive,
               statusText != "Transcribing",
               var session = try? store.activeRecordingSession(id: sessionID),
-              session.kind != .meeting,
-              session.isLongForm,
+              session.canRetryVoiceNoteTranscription,
               let requestID = session.requestID,
               let audioFileName = session.audioFileName,
               let audioURL = try? store.audioFileURL(fileName: audioFileName)

--- a/Muesli/DictationView.swift
+++ b/Muesli/DictationView.swift
@@ -12,6 +12,8 @@ struct DictationView: View {
     @AppStorage(MuesliPreferences.iCloudSyncEnabledKey) private var iCloudSyncEnabled = false
     @AppStorage(MuesliPreferences.recordingMicrophonePreferenceKey) private var microphonePreference = RecordingMicrophonePreference.automatic.rawValue
     @AppStorage(MuesliPreferences.keyboardSessionModeKey) private var keyboardSessionMode = false
+    @AppStorage(MuesliPreferences.longVoiceNoteModeEnabledKey) private var longVoiceNoteModeEnabled = true
+    @AppStorage(MuesliPreferences.longVoiceNoteThresholdSecondsKey) private var longVoiceNoteThresholdSeconds = 60
     @State private var sourceFilter: DictationSourceFilter = .all
     @State private var isSyncSetupPromptPresented = false
     @State private var shouldShowKeyboardSetupRow = false
@@ -428,6 +430,28 @@ struct DictationView: View {
                 }
                 .padding(.top, isWaveformActive || shouldShowRealtimeTranscript ? 0 : MuesliTheme.spacing4)
 
+                if longVoiceNoteModeEnabled && !coordinator.isRecording {
+                    Button {
+                        coordinator.openLongVoiceNoteSettings()
+                    } label: {
+                        HStack(spacing: MuesliTheme.spacing8) {
+                            Image(systemName: "waveform.path.ecg")
+                                .foregroundStyle(MuesliTheme.accent)
+                            Text("Long mode after \(longModeThresholdLabel)")
+                                .font(MuesliTheme.captionMedium())
+                                .foregroundStyle(MuesliTheme.textSecondary)
+                            Spacer()
+                            Image(systemName: "chevron.right")
+                                .font(.system(size: 11, weight: .semibold))
+                                .foregroundStyle(MuesliTheme.textTertiary)
+                        }
+                        .frame(minHeight: 44)
+                        .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityHint("Opens Long Voice Note settings")
+                }
+
                 if shouldShowKeyboardSetupRow && !shouldHideKeyboardSetupRowForMockPreview && !coordinator.isRecording {
                     keyboardShortcutRow
                 }
@@ -439,6 +463,14 @@ struct DictationView: View {
             guard isActive else { return }
             await runPreviewWaveformIfNeeded()
         }
+    }
+
+    private var longModeThresholdLabel: String {
+        let seconds = MuesliPreferences.clampedLongVoiceNoteThreshold(longVoiceNoteThresholdSeconds)
+        if seconds == 60 { return "1 min" }
+        if seconds % 60 == 0 { return "\(seconds / 60) min" }
+        if seconds > 60 { return "\(seconds / 60)m \(seconds % 60)s" }
+        return "\(seconds) sec"
     }
 
     private var microphoneMenu: some View {
@@ -522,7 +554,7 @@ struct DictationView: View {
                     Text("Recent Voice Notes")
                         .font(MuesliTheme.title3())
                         .foregroundStyle(MuesliTheme.textPrimary)
-                    Text("\(displayHistory.count) saved")
+                    Text("\(voiceNoteTimeline.count) saved")
                         .font(MuesliTheme.caption())
                         .foregroundStyle(MuesliTheme.textTertiary)
                 }
@@ -543,7 +575,7 @@ struct DictationView: View {
                 }
             }
 
-            if !displayHistory.isEmpty {
+            if !voiceNoteTimeline.isEmpty {
                 DictationSourceFilterPicker(selection: $sourceFilter)
             }
         }
@@ -552,30 +584,51 @@ struct DictationView: View {
     @ViewBuilder
     private var historyRows: some View {
         Group {
-            if filteredHistory.isEmpty {
+            if voiceNoteTimeline.isEmpty {
                 emptyHistory
             } else {
                 LazyVStack(spacing: MuesliTheme.spacing12) {
-                    ForEach(filteredHistory) { result in
-                        let session = coordinator.recordingSession(for: result)
-                        let hasRetainedAudio = session?.keepsAudioRecording == true && coordinator.audioFileURL(for: result) != nil
-                        if hasRetainedAudio {
-                            NavigationLink(value: result.id) {
+                    ForEach(voiceNoteTimeline) { item in
+                        switch item {
+                        case .recoverable(let session):
+                            RecoverableVoiceNoteRow(session: session) {
+                                coordinator.openLongVoiceNote(session)
+                            }
+                        case .completed(let result, let session):
+                        let hasRetainedAudio = session?.keepsAudioRecording == true
+                            && session.flatMap { coordinator.audioFileURL(for: $0) } != nil
+                            if session?.isLongForm == true {
+                                Button {
+                                    if let session {
+                                        coordinator.openLongVoiceNote(session)
+                                    }
+                                } label: {
+                                    DictationHistoryRow(
+                                        result: result,
+                                        hasRetainedAudio: hasRetainedAudio,
+                                        onCopy: { coordinator.copyToClipboard(result) },
+                                        onDelete: { coordinator.deleteDictation(result) }
+                                    )
+                                }
+                                .buttonStyle(.plain)
+                            } else if hasRetainedAudio {
+                                NavigationLink(value: result.id) {
+                                    DictationHistoryRow(
+                                        result: result,
+                                        hasRetainedAudio: true,
+                                        onCopy: { coordinator.copyToClipboard(result) },
+                                        onDelete: { coordinator.deleteDictation(result) }
+                                    )
+                                }
+                                .buttonStyle(.plain)
+                            } else {
                                 DictationHistoryRow(
                                     result: result,
-                                    hasRetainedAudio: true,
+                                    hasRetainedAudio: false,
                                     onCopy: { coordinator.copyToClipboard(result) },
                                     onDelete: { coordinator.deleteDictation(result) }
                                 )
                             }
-                            .buttonStyle(.plain)
-                        } else {
-                            DictationHistoryRow(
-                                result: result,
-                                hasRetainedAudio: false,
-                                onCopy: { coordinator.copyToClipboard(result) },
-                                onDelete: { coordinator.deleteDictation(result) }
-                            )
                         }
                     }
                 }
@@ -585,6 +638,24 @@ struct DictationView: View {
 
     private var filteredHistory: [DictationResult] {
         displayHistory.filter { sourceFilter.includes($0.syncOrigin) }
+    }
+
+    private var filteredRecoverableVoiceNotes: [RecordingSession] {
+        coordinator.recoverableVoiceNoteSessions.filter { sourceFilter.includes($0.syncOrigin) }
+    }
+
+    private var voiceNoteTimeline: [VoiceNoteTimelineItem] {
+        let sessionsByID = Dictionary(
+            uniqueKeysWithValues: coordinator.recordingSessions.map { ($0.id, $0) }
+        )
+        let completed = filteredHistory.map { result in
+            VoiceNoteTimelineItem.completed(
+                result,
+                result.sessionID.flatMap { sessionsByID[$0] }
+            )
+        }
+        let recoverable = filteredRecoverableVoiceNotes.map(VoiceNoteTimelineItem.recoverable)
+        return VoiceNoteTimelineItem.mergeNewestFirst(completed, recoverable)
     }
 
     private var statsHistory: [DictationResult] {
@@ -876,6 +947,99 @@ private struct DictationHomeStatTile: View {
         .shadow(color: .black.opacity(0.12), radius: 6, x: 0, y: 3)
         .accessibilityElement(children: .ignore)
         .accessibilityLabel("\(value) \(label)")
+    }
+}
+
+private enum VoiceNoteTimelineItem: Identifiable {
+    case completed(DictationResult, RecordingSession?)
+    case recoverable(RecordingSession)
+
+    var id: String {
+        switch self {
+        case .completed(let result, _): "result-\(result.id.uuidString)"
+        case .recoverable(let session): "session-\(session.id.uuidString)"
+        }
+    }
+
+    var createdAt: Date {
+        switch self {
+        case .completed(let result, _): result.createdAt
+        case .recoverable(let session): session.createdAt
+        }
+    }
+
+    static func mergeNewestFirst(
+        _ completed: [VoiceNoteTimelineItem],
+        _ recoverable: [VoiceNoteTimelineItem]
+    ) -> [VoiceNoteTimelineItem] {
+        var completedIndex = 0
+        var recoverableIndex = 0
+        var merged: [VoiceNoteTimelineItem] = []
+        merged.reserveCapacity(completed.count + recoverable.count)
+
+        while completedIndex < completed.count || recoverableIndex < recoverable.count {
+            if completedIndex == completed.count {
+                merged.append(recoverable[recoverableIndex])
+                recoverableIndex += 1
+            } else if recoverableIndex == recoverable.count
+                        || completed[completedIndex].createdAt >= recoverable[recoverableIndex].createdAt {
+                merged.append(completed[completedIndex])
+                completedIndex += 1
+            } else {
+                merged.append(recoverable[recoverableIndex])
+                recoverableIndex += 1
+            }
+        }
+        return merged
+    }
+}
+
+private struct RecoverableVoiceNoteRow: View {
+    let session: RecordingSession
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: MuesliTheme.spacing12) {
+                Image(systemName: session.audioFileName == nil ? "waveform.slash" : "waveform.badge.exclamationmark")
+                    .font(.system(size: 18, weight: .medium))
+                    .foregroundStyle(session.audioFileName == nil ? MuesliTheme.destructive : MuesliTheme.accent)
+                    .frame(width: 36, height: 36)
+                    .background(MuesliTheme.accentSubtle)
+                    .clipShape(Circle())
+
+                VStack(alignment: .leading, spacing: MuesliTheme.spacing4) {
+                    Text(session.audioFileName == nil ? "Audio unavailable" : "Needs transcription")
+                        .font(MuesliTheme.headline())
+                        .foregroundStyle(MuesliTheme.textPrimary)
+                    Text(session.createdAt.formatted(date: .abbreviated, time: .shortened))
+                        .font(MuesliTheme.caption())
+                        .foregroundStyle(MuesliTheme.textTertiary)
+                    if let scratchpad = session.scratchpadText?.trimmingCharacters(in: .whitespacesAndNewlines),
+                       !scratchpad.isEmpty {
+                        Text(scratchpad)
+                            .font(MuesliTheme.callout())
+                            .foregroundStyle(MuesliTheme.textSecondary)
+                            .lineLimit(2)
+                    }
+                }
+
+                Spacer(minLength: MuesliTheme.spacing8)
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(MuesliTheme.textTertiary)
+            }
+            .padding(MuesliTheme.spacing16)
+            .background(MuesliTheme.surfacePrimary)
+            .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium, style: .continuous))
+            .overlay {
+                RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium, style: .continuous)
+                    .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
+            }
+            .contentShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium, style: .continuous))
+        }
+        .buttonStyle(.plain)
+        .accessibilityHint(session.audioFileName == nil ? "Opens recovery details" : "Opens retry actions")
     }
 }
 

--- a/Muesli/DictationView.swift
+++ b/Muesli/DictationView.swift
@@ -466,11 +466,7 @@ struct DictationView: View {
     }
 
     private var longModeThresholdLabel: String {
-        let seconds = MuesliPreferences.clampedLongVoiceNoteThreshold(longVoiceNoteThresholdSeconds)
-        if seconds == 60 { return "1 min" }
-        if seconds % 60 == 0 { return "\(seconds / 60) min" }
-        if seconds > 60 { return "\(seconds / 60)m \(seconds % 60)s" }
-        return "\(seconds) sec"
+        MuesliPreferences.longVoiceNoteThresholdLabel(longVoiceNoteThresholdSeconds)
     }
 
     private var microphoneMenu: some View {

--- a/Muesli/KeyboardSessionKeeper.swift
+++ b/Muesli/KeyboardSessionKeeper.swift
@@ -3,12 +3,19 @@ import Foundation
 import os
 
 final class KeyboardSessionKeeper: @unchecked Sendable {
+    struct SegmentResult: Sendable {
+        let audioURL: URL
+        let finalCheckpoint: MeetingAudioChunk?
+        let writerFailure: CheckpointingAudioWriterFailure?
+    }
+
     private final class ConverterInputState: @unchecked Sendable {
         var didProvideInput = false
     }
 
     private struct FileState {
         var activeFile: AVAudioFile?
+        var checkpointWriter: CheckpointingAudioWriter?
         var activeURL: URL?
         var activeSegmentID: UUID?
         var latestPowerDB: Float = -160
@@ -34,6 +41,7 @@ final class KeyboardSessionKeeper: @unchecked Sendable {
     private var isStarting = false
     private var tapInstalled = false
     private var inputActivityHandler: (@Sendable (_ powerDB: Float, _ isCapturing: Bool) -> Void)?
+    var onRecordingFailure: (@Sendable (CheckpointingAudioWriterFailure) -> Void)?
 
     private static let sampleRate: Double = 16_000
     private static let bufferSize: AVAudioFrameCount = 2_048
@@ -60,7 +68,7 @@ final class KeyboardSessionKeeper: @unchecked Sendable {
 
     var isRecordingSegment: Bool {
         lock.lock()
-        let recording = state.activeFile != nil
+        let recording = state.activeFile != nil || state.checkpointWriter != nil
         lock.unlock()
         return recording
     }
@@ -113,17 +121,31 @@ final class KeyboardSessionKeeper: @unchecked Sendable {
         lock.unlock()
     }
 
-    func beginSegment(outputURL: URL) throws {
+    func beginSegment(outputURL: URL, checkpointDirectory: URL? = nil) throws {
         guard isRunning else {
             throw AudioRecorder.RecordingError.startFailed(stage: "keyboard session inactive")
         }
 
         try FileManager.default.createDirectory(at: outputURL.deletingLastPathComponent(), withIntermediateDirectories: true)
-        let file = try AVAudioFile(forWriting: outputURL, settings: Self.makeTargetFormat().settings)
+        let format = try Self.makeTargetFormat()
+        let file = try checkpointDirectory == nil
+            ? AVAudioFile(forWriting: outputURL, settings: format.settings)
+            : nil
+        let writer = try checkpointDirectory.map {
+            try CheckpointingAudioWriter(
+                continuousAudioURL: outputURL,
+                checkpointDirectory: $0,
+                format: format
+            )
+        }
+        writer?.onFailure = { [weak self] failure in
+            self?.onRecordingFailure?(failure)
+        }
         let segmentID = UUID()
 
         lock.lock()
         state.activeFile = file
+        state.checkpointWriter = writer
         state.activeURL = outputURL
         state.activeSegmentID = segmentID
         state.segmentFrames = 0
@@ -132,30 +154,46 @@ final class KeyboardSessionKeeper: @unchecked Sendable {
     }
 
     @discardableResult
-    func finishSegment() throws -> URL {
+    func finishSegment() throws -> SegmentResult {
         lock.lock()
         state.isFinishingSegment = true
         let url = state.activeURL
         let segmentID = state.activeSegmentID
+        let writer = state.checkpointWriter
         lock.unlock()
 
-        if segmentID != nil {
+        if segmentID != nil, writer == nil {
             fileWriteQueue.sync {}
         }
+
+        let writerResult = writer?.finish()
 
         lock.lock()
         let frameCount = segmentID == state.activeSegmentID ? state.segmentFrames : 0
         state.activeFile = nil
+        state.checkpointWriter = nil
         state.activeURL = nil
         state.activeSegmentID = nil
         state.segmentFrames = 0
         state.isFinishingSegment = false
         lock.unlock()
 
-        guard let url, frameCount > 0 else {
+        let recordedFrames = writerResult?.totalFrames ?? frameCount
+        guard let url, recordedFrames > 0 else {
             throw AudioRecorder.RecordingError.noRecording
         }
-        return url
+        return SegmentResult(
+            audioURL: url,
+            finalCheckpoint: writerResult?.finalCheckpoint,
+            writerFailure: writerResult?.failure
+        )
+    }
+
+    func rotateSegmentCheckpoint() -> MeetingAudioChunk? {
+        lock.lock()
+        let writer = state.checkpointWriter
+        lock.unlock()
+        return writer?.rotateCheckpoint()
     }
 
     func cancelSegment() {
@@ -163,14 +201,17 @@ final class KeyboardSessionKeeper: @unchecked Sendable {
         state.isFinishingSegment = true
         let url = state.activeURL
         let segmentID = state.activeSegmentID
+        let writer = state.checkpointWriter
         lock.unlock()
 
-        if segmentID != nil {
+        if segmentID != nil, writer == nil {
             fileWriteQueue.sync {}
         }
+        writer?.cancel()
 
         lock.lock()
         state.activeFile = nil
+        state.checkpointWriter = nil
         state.activeURL = nil
         state.activeSegmentID = nil
         state.segmentFrames = 0
@@ -227,6 +268,7 @@ final class KeyboardSessionKeeper: @unchecked Sendable {
         let handler: (@Sendable (_ powerDB: Float, _ isCapturing: Bool) -> Void)?
         let shouldNotifyActivity: Bool
         let file: AVAudioFile?
+        let checkpointWriter: CheckpointingAudioWriter?
         let segmentID: UUID?
 
         lock.lock()
@@ -236,9 +278,17 @@ final class KeyboardSessionKeeper: @unchecked Sendable {
         {
             file = activeFile
             segmentID = activeSegmentID
+            checkpointWriter = state.checkpointWriter
+        } else if let activeSegmentID = state.activeSegmentID,
+                  let writer = state.checkpointWriter,
+                  !state.isFinishingSegment {
+            file = nil
+            segmentID = activeSegmentID
+            checkpointWriter = writer
         } else {
             file = nil
             segmentID = nil
+            checkpointWriter = nil
         }
         state.latestPowerDB = powerDB
         state.lastInputBufferAt = now
@@ -249,8 +299,7 @@ final class KeyboardSessionKeeper: @unchecked Sendable {
         handler = inputActivityHandler
         lock.unlock()
 
-        if let file,
-           let segmentID,
+        if let segmentID,
            let monoBuffer = convert(buffer: buffer, targetFormat: targetFormat)
         {
             let frameCount = Int(monoBuffer.frameLength)
@@ -260,18 +309,22 @@ final class KeyboardSessionKeeper: @unchecked Sendable {
                 lock.unlock()
 
                 if shouldWrite {
-                    enqueue(PendingFileWrite(
-                        segmentID: segmentID,
-                        file: file,
-                        buffer: monoBuffer,
-                        frameCount: frameCount
-                    ))
+                    if let checkpointWriter {
+                        checkpointWriter.append(monoBuffer)
+                    } else if let file {
+                        enqueue(PendingFileWrite(
+                            segmentID: segmentID,
+                            file: file,
+                            buffer: monoBuffer,
+                            frameCount: frameCount
+                        ))
+                    }
                 }
             }
         }
 
         if shouldNotifyActivity {
-            handler?(powerDB, file != nil)
+            handler?(powerDB, file != nil || checkpointWriter != nil)
         }
     }
 

--- a/Muesli/LongVoiceNoteView.swift
+++ b/Muesli/LongVoiceNoteView.swift
@@ -1,0 +1,422 @@
+import SwiftUI
+
+struct LongVoiceNoteView: View {
+    @Bindable var coordinator: DictationCoordinator
+    let sessionID: UUID
+
+    @Environment(\.scenePhase) private var scenePhase
+    @State private var scratchpadText = ""
+    @State private var scratchpadSaveTask: Task<Void, Never>?
+    @State private var isDiscardConfirmationPresented = false
+    @State private var isDeleteAudioConfirmationPresented = false
+
+    private var session: RecordingSession? {
+        coordinator.presentedLongVoiceNoteSession?.id == sessionID
+            ? coordinator.presentedLongVoiceNoteSession
+            : coordinator.recordingSessions.first(where: { $0.id == sessionID })
+    }
+
+    private var isActivelyRecording: Bool {
+        coordinator.isRecording && coordinator.activeLongVoiceNoteSession?.id == sessionID
+    }
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                MuesliTheme.backgroundBase.ignoresSafeArea()
+
+                ScrollView {
+                    VStack(alignment: .leading, spacing: MuesliTheme.spacing16) {
+                        recordingHeader
+                        if isActivelyRecording {
+                            activeWaveform
+                            scratchpadEditor
+                        } else {
+                            processingStatus
+                            completedTranscript
+                            scratchpadEditor
+                            recoveryAudio
+                        }
+                    }
+                    .padding(.horizontal, MuesliTheme.spacing20)
+                    .padding(.top, MuesliTheme.spacing12)
+                    .padding(.bottom, isActivelyRecording ? 112 : 40)
+                }
+                .scrollDismissesKeyboard(.interactively)
+            }
+            .safeAreaInset(edge: .bottom) {
+                if isActivelyRecording {
+                    stopBar
+                }
+            }
+            .toolbar(.hidden, for: .navigationBar)
+        }
+        .interactiveDismissDisabled(isActivelyRecording)
+        .onAppear {
+            scratchpadText = session?.scratchpadText ?? ""
+        }
+        .onChange(of: scratchpadText) { _, text in
+            scheduleScratchpadSave(text)
+        }
+        .onChange(of: scenePhase) { _, phase in
+            guard phase != .active else { return }
+            flushScratchpad()
+        }
+        .onDisappear {
+            flushScratchpad()
+        }
+        .confirmationDialog(
+            "Discard this voice note?",
+            isPresented: $isDiscardConfirmationPresented,
+            titleVisibility: .visible
+        ) {
+            Button("Discard Voice Note", role: .destructive) {
+                flushScratchpad()
+                coordinator.cancelActiveRecording()
+                coordinator.dismissLongVoiceNote()
+            }
+            Button("Keep Recording", role: .cancel) {}
+        } message: {
+            Text("The recording, saved checkpoints, and scratchpad will be deleted.")
+        }
+        .confirmationDialog(
+            "Delete saved audio?",
+            isPresented: $isDeleteAudioConfirmationPresented,
+            titleVisibility: .visible
+        ) {
+            Button("Delete Audio", role: .destructive) {
+                coordinator.deleteVoiceNoteAudio(sessionID: sessionID)
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("The transcript and scratchpad will remain, but this audio cannot be recovered.")
+        }
+    }
+
+    private var recordingHeader: some View {
+        HStack(alignment: .top, spacing: MuesliTheme.spacing12) {
+            VStack(alignment: .leading, spacing: MuesliTheme.spacing4) {
+                Text("Long Voice Note")
+                    .font(MuesliTheme.title2())
+                    .foregroundStyle(MuesliTheme.textPrimary)
+
+                HStack(spacing: 6) {
+                    Circle()
+                        .fill(statusColor)
+                        .frame(width: 7, height: 7)
+                    Text(statusCopy)
+                        .font(MuesliTheme.captionMedium())
+                        .foregroundStyle(statusColor)
+                }
+
+                Text(elapsedTimeCopy)
+                    .font(.system(.title3, design: .monospaced, weight: .medium))
+                    .monospacedDigit()
+                    .foregroundStyle(MuesliTheme.textSecondary)
+                    .padding(.top, MuesliTheme.spacing4)
+            }
+
+            Spacer()
+
+            MuesliGlassGroup(spacing: MuesliTheme.spacing8) {
+                if isActivelyRecording {
+                    Button(role: .destructive) {
+                        isDiscardConfirmationPresented = true
+                    } label: {
+                        Image(systemName: "trash")
+                            .font(.system(size: 17, weight: .semibold))
+                            .foregroundStyle(MuesliTheme.destructive)
+                            .frame(width: 44, height: 44)
+                            .muesliGlassButton(cornerRadius: 22, tint: MuesliTheme.destructive)
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("Discard voice note")
+                } else {
+                    Button("Done") {
+                        flushScratchpad()
+                        coordinator.dismissLongVoiceNote()
+                    }
+                    .font(MuesliTheme.headline())
+                    .foregroundStyle(MuesliTheme.accent)
+                    .frame(minWidth: 64, minHeight: 44)
+                    .muesliGlassButton(cornerRadius: 22, tint: MuesliTheme.accent)
+                    .buttonStyle(.plain)
+                }
+            }
+        }
+    }
+
+    private var activeWaveform: some View {
+        VStack(spacing: MuesliTheme.spacing12) {
+            MuesliInlineWaveformView(
+                mode: .level,
+                color: MuesliTheme.accent,
+                level: coordinator.inputLevel,
+                isActive: true,
+                barCount: 44
+            )
+            .frame(height: 96)
+        }
+        .padding(MuesliTheme.spacing16)
+        .background(MuesliTheme.surfacePrimary)
+        .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium, style: .continuous))
+        .overlay {
+            RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium, style: .continuous)
+                .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Live audio waveform")
+    }
+
+    private var scratchpadEditor: some View {
+        VStack(alignment: .leading, spacing: MuesliTheme.spacing12) {
+            Label("Scratchpad", systemImage: "square.and.pencil")
+                .font(MuesliTheme.headline())
+                .foregroundStyle(MuesliTheme.textPrimary)
+
+            TextEditor(text: $scratchpadText)
+                .font(MuesliTheme.body())
+                .foregroundStyle(MuesliTheme.textPrimary)
+                .scrollContentBackground(.hidden)
+                .frame(minHeight: isActivelyRecording ? 210 : 130)
+                .padding(MuesliTheme.spacing12)
+                .background(MuesliTheme.backgroundBase.opacity(0.72))
+                .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall, style: .continuous))
+                .overlay(alignment: .topLeading) {
+                    if scratchpadText.isEmpty {
+                        Text("Add notes while speaking...")
+                            .font(MuesliTheme.body())
+                            .foregroundStyle(MuesliTheme.textTertiary)
+                            .padding(.horizontal, MuesliTheme.spacing16)
+                            .padding(.vertical, MuesliTheme.spacing20)
+                            .allowsHitTesting(false)
+                    }
+                }
+                .accessibilityLabel("Voice note scratchpad")
+        }
+        .padding(MuesliTheme.spacing16)
+        .background(MuesliTheme.surfacePrimary)
+        .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium, style: .continuous))
+        .overlay {
+            RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium, style: .continuous)
+                .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
+        }
+    }
+
+    @ViewBuilder
+    private var processingStatus: some View {
+        VStack(alignment: .leading, spacing: MuesliTheme.spacing12) {
+            Text(session?.phase == .completed ? "Voice note ready" : "Processing")
+                .font(MuesliTheme.headline())
+                .foregroundStyle(MuesliTheme.textPrimary)
+
+            statusStep("Audio saved", complete: session?.audioFileName != nil, active: false)
+            statusStep(
+                "Transcribing",
+                complete: session?.phase == .completed,
+                active: session?.phase == .transcriptionQueued || session?.phase == .transcribing
+            )
+            statusStep(
+                session?.phase == .failed ? "Needs retry" : "Transcript ready",
+                complete: session?.phase == .completed,
+                active: session?.phase == .failed,
+                isFailure: session?.phase == .failed
+            )
+
+            if let error = session?.errorMessage, session?.phase == .failed {
+                Text(error)
+                    .font(MuesliTheme.callout())
+                    .foregroundStyle(MuesliTheme.textSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            if session?.phase == .failed {
+                recoveryActions
+            }
+        }
+        .padding(MuesliTheme.spacing16)
+        .background(MuesliTheme.surfacePrimary)
+        .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium, style: .continuous))
+        .overlay {
+            RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium, style: .continuous)
+                .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
+        }
+    }
+
+    @ViewBuilder
+    private var completedTranscript: some View {
+        if session?.phase == .completed,
+           let text = coordinator.transcript(for: session ?? fallbackSession)?.text
+                ?? coordinator.dictationHistory.first(where: { $0.sessionID == sessionID })?.text,
+           !text.isEmpty {
+            VStack(alignment: .leading, spacing: MuesliTheme.spacing12) {
+                Label("Transcript", systemImage: "text.alignleft")
+                    .font(MuesliTheme.headline())
+                    .foregroundStyle(MuesliTheme.textPrimary)
+                Text(text)
+                    .font(MuesliTheme.body())
+                    .foregroundStyle(MuesliTheme.textPrimary)
+                    .textSelection(.enabled)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            .padding(MuesliTheme.spacing16)
+            .background(MuesliTheme.surfacePrimary)
+            .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium, style: .continuous))
+            .overlay {
+                RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium, style: .continuous)
+                    .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var recoveryAudio: some View {
+        if let session, let audioURL = coordinator.audioFileURL(for: session) {
+            VStack(alignment: .leading, spacing: MuesliTheme.spacing12) {
+                Text("Saved Audio")
+                    .font(MuesliTheme.headline())
+                    .foregroundStyle(MuesliTheme.textPrimary)
+                SavedAudioPlayerView(audioURL: audioURL)
+            }
+            .padding(MuesliTheme.spacing16)
+            .background(MuesliTheme.surfacePrimary)
+            .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium, style: .continuous))
+            .overlay {
+                RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium, style: .continuous)
+                    .strokeBorder(MuesliTheme.surfaceBorder, lineWidth: 1)
+            }
+        }
+    }
+
+    private var recoveryActions: some View {
+        MuesliGlassGroup(spacing: MuesliTheme.spacing8) {
+            VStack(spacing: MuesliTheme.spacing8) {
+                if session?.audioFileName != nil {
+                    Button {
+                        coordinator.retryVoiceNoteTranscription(sessionID: sessionID)
+                    } label: {
+                        Label("Retry Transcript", systemImage: "arrow.clockwise")
+                            .font(MuesliTheme.headline())
+                            .foregroundStyle(.white)
+                            .frame(maxWidth: .infinity, minHeight: 48)
+                            .background(MuesliTheme.accent)
+                            .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall, style: .continuous))
+                    }
+                    .buttonStyle(.plain)
+
+                    HStack(spacing: MuesliTheme.spacing8) {
+                        Button {
+                            coordinator.keepVoiceNoteAudio(sessionID: sessionID)
+                        } label: {
+                            Label("Keep Audio", systemImage: "pin")
+                                .frame(maxWidth: .infinity, minHeight: 44)
+                                .muesliGlassButton(cornerRadius: MuesliTheme.cornerSmall, tint: MuesliTheme.accent)
+                        }
+                        .buttonStyle(.plain)
+
+                        Button(role: .destructive) {
+                            isDeleteAudioConfirmationPresented = true
+                        } label: {
+                            Label("Delete", systemImage: "trash")
+                                .foregroundStyle(MuesliTheme.destructive)
+                                .frame(maxWidth: .infinity, minHeight: 44)
+                                .muesliGlassButton(cornerRadius: MuesliTheme.cornerSmall, tint: MuesliTheme.destructive)
+                        }
+                        .buttonStyle(.plain)
+                    }
+                    .font(MuesliTheme.captionMedium())
+                } else {
+                    Label("Audio unavailable", systemImage: "waveform.slash")
+                        .font(MuesliTheme.callout())
+                        .foregroundStyle(MuesliTheme.destructive)
+                }
+            }
+        }
+    }
+
+    private var stopBar: some View {
+        Button {
+            flushScratchpad()
+            coordinator.toggleRecording()
+        } label: {
+            Label("Stop Recording", systemImage: "stop.fill")
+                .font(MuesliTheme.headline())
+                .foregroundStyle(.white)
+                .frame(maxWidth: .infinity, minHeight: 54)
+                .background(MuesliTheme.accent)
+                .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium, style: .continuous))
+                .contentShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium, style: .continuous))
+        }
+        .buttonStyle(.plain)
+        .padding(.horizontal, MuesliTheme.spacing20)
+        .padding(.vertical, MuesliTheme.spacing12)
+        .background(.ultraThinMaterial)
+        .accessibilityIdentifier("longVoiceNote.stopButton")
+    }
+
+    private func statusStep(_ title: String, complete: Bool, active: Bool, isFailure: Bool = false) -> some View {
+        HStack(spacing: MuesliTheme.spacing12) {
+            Image(systemName: complete ? "checkmark.circle.fill" : active ? (isFailure ? "exclamationmark.circle.fill" : "circle.dotted") : "circle")
+                .foregroundStyle(complete ? MuesliTheme.success : isFailure ? MuesliTheme.destructive : active ? MuesliTheme.accent : MuesliTheme.textTertiary)
+            Text(title)
+                .font(MuesliTheme.callout())
+                .foregroundStyle(active || complete ? MuesliTheme.textPrimary : MuesliTheme.textSecondary)
+            Spacer()
+        }
+    }
+
+    private var statusCopy: String {
+        if let durabilityError = coordinator.longVoiceNoteDurabilityError, isActivelyRecording {
+            return durabilityError
+        }
+        guard let session else { return "Loading voice note" }
+        if isActivelyRecording {
+            return coordinator.longVoiceNoteAudioIsSecured ? "Audio saved locally" : "Securing audio"
+        }
+        switch session.phase {
+        case .recording: return "Recovered recording"
+        case .transcriptionQueued: return "Waiting to transcribe"
+        case .transcribing: return "Transcribing"
+        case .completed: return "Transcript ready"
+        case .failed: return session.audioFileName == nil ? "Audio unavailable" : "Audio saved locally"
+        case .cancelled: return "Cancelled"
+        }
+    }
+
+    private var statusColor: Color {
+        if coordinator.longVoiceNoteDurabilityError != nil || session?.phase == .failed {
+            return MuesliTheme.destructive
+        }
+        if session?.phase == .completed || coordinator.longVoiceNoteAudioIsSecured {
+            return MuesliTheme.success
+        }
+        return MuesliTheme.accent
+    }
+
+    private var elapsedTimeCopy: String {
+        let duration = isActivelyRecording
+            ? coordinator.recordingElapsedTime
+            : session?.duration ?? 0
+        let totalSeconds = max(Int(duration.rounded(.down)), 0)
+        return String(format: "%02d:%02d", totalSeconds / 60, totalSeconds % 60)
+    }
+
+    private var fallbackSession: RecordingSession {
+        RecordingSession(id: sessionID, kind: .quickDictation, phase: .failed)
+    }
+
+    private func scheduleScratchpadSave(_ text: String) {
+        scratchpadSaveTask?.cancel()
+        scratchpadSaveTask = Task { @MainActor in
+            try? await Task.sleep(for: .milliseconds(450))
+            guard !Task.isCancelled else { return }
+            coordinator.updateVoiceNoteScratchpad(sessionID: sessionID, text: text)
+        }
+    }
+
+    private func flushScratchpad() {
+        scratchpadSaveTask?.cancel()
+        scratchpadSaveTask = nil
+        coordinator.updateVoiceNoteScratchpad(sessionID: sessionID, text: scratchpadText)
+    }
+}

--- a/Muesli/LongVoiceNoteView.swift
+++ b/Muesli/LongVoiceNoteView.swift
@@ -378,7 +378,12 @@ struct LongVoiceNoteView: View {
         case .transcriptionQueued: return "Waiting to transcribe"
         case .transcribing: return "Transcribing"
         case .completed: return "Transcript ready"
-        case .failed: return session.audioFileName == nil ? "Audio unavailable" : "Audio saved locally"
+        case .failed:
+            switch session.voiceNoteDurabilityEvidence {
+            case .durableCheckpoint: return "Audio saved locally"
+            case .audioReferenceOnly: return "Audio needs recovery"
+            case .unavailable: return "Audio unavailable"
+            }
         case .cancelled: return "Cancelled"
         }
     }

--- a/Muesli/LongVoiceNoteView.swift
+++ b/Muesli/LongVoiceNoteView.swift
@@ -32,7 +32,9 @@ struct LongVoiceNoteView: View {
                             activeWaveform
                             scratchpadEditor
                         } else {
-                            processingStatus
+                            if session?.phase == .failed {
+                                failureRecoveryPanel
+                            }
                             completedTranscript
                             scratchpadEditor
                             recoveryAudio
@@ -204,35 +206,28 @@ struct LongVoiceNoteView: View {
     }
 
     @ViewBuilder
-    private var processingStatus: some View {
+    private var failureRecoveryPanel: some View {
         VStack(alignment: .leading, spacing: MuesliTheme.spacing12) {
-            Text(session?.phase == .completed ? "Voice note ready" : "Processing")
+            Text(session?.canRetryVoiceNoteTranscription == true ? "Transcription failed" : "Recovery unavailable")
                 .font(MuesliTheme.headline())
                 .foregroundStyle(MuesliTheme.textPrimary)
 
-            statusStep("Audio saved", complete: session?.audioFileName != nil, active: false)
-            statusStep(
-                "Transcribing",
-                complete: session?.phase == .completed,
-                active: session?.phase == .transcriptionQueued || session?.phase == .transcribing
-            )
-            statusStep(
-                session?.phase == .failed ? "Needs retry" : "Transcript ready",
-                complete: session?.phase == .completed,
-                active: session?.phase == .failed,
-                isFailure: session?.phase == .failed
-            )
-
-            if let error = session?.errorMessage, session?.phase == .failed {
+            if let error = session?.errorMessage {
                 Text(error)
                     .font(MuesliTheme.callout())
                     .foregroundStyle(MuesliTheme.textSecondary)
                     .fixedSize(horizontal: false, vertical: true)
             }
 
-            if session?.phase == .failed {
-                recoveryActions
+            if session?.canRetryVoiceNoteTranscription != true,
+               session?.audioFileName != nil {
+                Text("A durable audio checkpoint is not available, so this transcription cannot be retried safely.")
+                    .font(MuesliTheme.callout())
+                    .foregroundStyle(MuesliTheme.textSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
             }
+
+            recoveryActions
         }
         .padding(MuesliTheme.spacing16)
         .background(MuesliTheme.surfacePrimary)
@@ -291,7 +286,7 @@ struct LongVoiceNoteView: View {
     private var recoveryActions: some View {
         MuesliGlassGroup(spacing: MuesliTheme.spacing8) {
             VStack(spacing: MuesliTheme.spacing8) {
-                if session?.audioFileName != nil {
+                if session?.canRetryVoiceNoteTranscription == true {
                     Button {
                         coordinator.retryVoiceNoteTranscription(sessionID: sessionID)
                     } label: {
@@ -303,7 +298,9 @@ struct LongVoiceNoteView: View {
                             .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall, style: .continuous))
                     }
                     .buttonStyle(.plain)
+                }
 
+                if session?.audioFileName != nil {
                     HStack(spacing: MuesliTheme.spacing8) {
                         Button {
                             coordinator.keepVoiceNoteAudio(sessionID: sessionID)
@@ -325,7 +322,7 @@ struct LongVoiceNoteView: View {
                         .buttonStyle(.plain)
                     }
                     .font(MuesliTheme.captionMedium())
-                } else {
+                } else if session?.canRetryVoiceNoteTranscription != true {
                     Label("Audio unavailable", systemImage: "waveform.slash")
                         .font(MuesliTheme.callout())
                         .foregroundStyle(MuesliTheme.destructive)
@@ -352,17 +349,6 @@ struct LongVoiceNoteView: View {
         .padding(.vertical, MuesliTheme.spacing12)
         .background(.ultraThinMaterial)
         .accessibilityIdentifier("longVoiceNote.stopButton")
-    }
-
-    private func statusStep(_ title: String, complete: Bool, active: Bool, isFailure: Bool = false) -> some View {
-        HStack(spacing: MuesliTheme.spacing12) {
-            Image(systemName: complete ? "checkmark.circle.fill" : active ? (isFailure ? "exclamationmark.circle.fill" : "circle.dotted") : "circle")
-                .foregroundStyle(complete ? MuesliTheme.success : isFailure ? MuesliTheme.destructive : active ? MuesliTheme.accent : MuesliTheme.textTertiary)
-            Text(title)
-                .font(MuesliTheme.callout())
-                .foregroundStyle(active || complete ? MuesliTheme.textPrimary : MuesliTheme.textSecondary)
-            Spacer()
-        }
     }
 
     private var statusCopy: String {

--- a/Muesli/MuesliApp.swift
+++ b/Muesli/MuesliApp.swift
@@ -7,7 +7,11 @@ struct MuesliApp: App {
     @Environment(\.scenePhase) private var scenePhase
 
     private var isUITesting: Bool {
+        #if DEBUG
         ProcessInfo.processInfo.arguments.contains(MuesliAppConstants.uiTestingLaunchArgument)
+        #else
+        false
+        #endif
     }
 
     init() {

--- a/Muesli/MuesliApp.swift
+++ b/Muesli/MuesliApp.swift
@@ -22,6 +22,7 @@ struct MuesliApp: App {
                     if phase == .active {
                         coordinator.prewarmModelIfNeeded(reason: "foreground")
                         coordinator.syncICloudTextIfEnabled(reason: "foreground")
+                        coordinator.recoverLongVoiceNotesIfNeeded()
                     }
                 }
         }

--- a/Muesli/MuesliApp.swift
+++ b/Muesli/MuesliApp.swift
@@ -6,6 +6,10 @@ struct MuesliApp: App {
     @State private var coordinator = DictationCoordinator()
     @Environment(\.scenePhase) private var scenePhase
 
+    private var isUITesting: Bool {
+        ProcessInfo.processInfo.arguments.contains(MuesliAppConstants.uiTestingLaunchArgument)
+    }
+
     init() {
         AppTelemetry.configure()
     }
@@ -19,7 +23,7 @@ struct MuesliApp: App {
                     coordinator.handleOpenURL(url)
                 }
                 .onChange(of: scenePhase) { _, phase in
-                    if phase == .active {
+                    if phase == .active, !isUITesting {
                         coordinator.prewarmModelIfNeeded(reason: "foreground")
                         coordinator.syncICloudTextIfEnabled(reason: "foreground")
                         coordinator.recoverLongVoiceNotesIfNeeded()

--- a/Muesli/MuesliPreferences.swift
+++ b/Muesli/MuesliPreferences.swift
@@ -10,6 +10,8 @@ enum MuesliPreferences {
     static let customDictionaryKey = "muesli.transcription.customDictionary"
     static let transcriptionModelKey = "muesli.transcription.localModel"
     static let keepDictationAudioRecordingsKey = "muesli.dictations.keepAudioRecordings"
+    static let longVoiceNoteModeEnabledKey = "muesli.dictations.longVoiceNoteMode.enabled"
+    static let longVoiceNoteThresholdSecondsKey = "muesli.dictations.longVoiceNoteMode.thresholdSeconds"
     static let keepMeetingAudioRecordingsKey = "muesli.meetings.keepAudioRecordings"
     static let recordingMicrophonePreferenceKey = "muesli.recording.microphonePreference"
     static let meetingSummariesEnabledKey = "muesli.meetings.summaries.enabled"
@@ -60,6 +62,20 @@ enum MuesliPreferences {
 
     static var keepDictationAudioRecordingsEnabled: Bool {
         bool(for: keepDictationAudioRecordingsKey, defaultValue: false)
+    }
+
+    static var longVoiceNoteModeEnabled: Bool {
+        bool(for: longVoiceNoteModeEnabledKey, defaultValue: true)
+    }
+
+    static var longVoiceNoteThresholdSeconds: Int {
+        clampedLongVoiceNoteThreshold(
+            UserDefaults.standard.object(forKey: longVoiceNoteThresholdSecondsKey) as? Int ?? 60
+        )
+    }
+
+    static func clampedLongVoiceNoteThreshold(_ value: Int) -> Int {
+        min(max(value, 30), 600)
     }
 
     static var keepMeetingAudioRecordingsEnabled: Bool {

--- a/Muesli/MuesliPreferences.swift
+++ b/Muesli/MuesliPreferences.swift
@@ -78,6 +78,14 @@ enum MuesliPreferences {
         min(max(value, 30), 600)
     }
 
+    static func longVoiceNoteThresholdLabel(_ value: Int) -> String {
+        let seconds = clampedLongVoiceNoteThreshold(value)
+        if seconds == 60 { return "1 min" }
+        if seconds % 60 == 0 { return "\(seconds / 60) min" }
+        if seconds > 60 { return "\(seconds / 60)m \(seconds % 60)s" }
+        return "\(seconds) sec"
+    }
+
     static var keepMeetingAudioRecordingsEnabled: Bool {
         bool(for: keepMeetingAudioRecordingsKey, defaultValue: false)
     }

--- a/Muesli/RootView.swift
+++ b/Muesli/RootView.swift
@@ -34,6 +34,20 @@ struct RootView: View {
         .onChange(of: pinnedSectionsStorage) { _, _ in
             clampSelectedSectionToPinnedSections()
         }
+        .fullScreenCover(
+            isPresented: Binding(
+                get: { coordinator.presentedLongVoiceNoteSessionID != nil },
+                set: { isPresented in
+                    if !isPresented {
+                        coordinator.dismissLongVoiceNote()
+                    }
+                }
+            )
+        ) {
+            if let sessionID = coordinator.presentedLongVoiceNoteSessionID {
+                LongVoiceNoteView(coordinator: coordinator, sessionID: sessionID)
+            }
+        }
     }
 
     private var currentAccent: Color {
@@ -132,6 +146,7 @@ struct RootView: View {
             SettingsView(
                 coordinator: coordinator,
                 openSyncPrivacyRequest: coordinator.syncSetupRequestID,
+                openInputRequest: coordinator.inputSettingsNavigationRequestID,
                 isActive: isActive
             ) { section in
                 selectedSection = section

--- a/Muesli/SettingsView.swift
+++ b/Muesli/SettingsView.swift
@@ -763,14 +763,14 @@ private struct LongVoiceNoteSettingsRow: View {
 
                     Menu {
                         ForEach(commonValues, id: \.self) { value in
-                            Button(thresholdLabel(value)) {
+                            Button(MuesliPreferences.longVoiceNoteThresholdLabel(value)) {
                                 thresholdSeconds = value
                                 customText = String(value)
                             }
                         }
                     } label: {
                         HStack(spacing: 6) {
-                            Text(thresholdLabel(thresholdSeconds))
+                            Text(MuesliPreferences.longVoiceNoteThresholdLabel(thresholdSeconds))
                             Image(systemName: "chevron.up.chevron.down")
                                 .font(.system(size: 11, weight: .semibold))
                         }
@@ -798,8 +798,10 @@ private struct LongVoiceNoteSettingsRow: View {
                             let clamped = MuesliPreferences.clampedLongVoiceNoteThreshold(value)
                             if thresholdSeconds != clamped {
                                 thresholdSeconds = clamped
+                                return
                             }
                             customText = String(clamped)
+                            signalThresholdChanged(clamped)
                         }
                 }
 
@@ -833,17 +835,13 @@ private struct LongVoiceNoteSettingsRow: View {
         let value = Int(customText) ?? thresholdSeconds
         thresholdSeconds = MuesliPreferences.clampedLongVoiceNoteThreshold(value)
         customText = String(thresholdSeconds)
-        AppTelemetry.signal(
-            "long_voice_note_threshold_changed",
-            parameters: ["threshold_bucket": thresholdLabel(thresholdSeconds)]
-        )
     }
 
-    private func thresholdLabel(_ seconds: Int) -> String {
-        if seconds == 60 { return "1 min" }
-        if seconds % 60 == 0 { return "\(seconds / 60) min" }
-        if seconds > 60 { return "\(seconds / 60)m \(seconds % 60)s" }
-        return "\(seconds) sec"
+    private func signalThresholdChanged(_ seconds: Int) {
+        AppTelemetry.signal(
+            "long_voice_note_threshold_changed",
+            parameters: ["threshold_bucket": MuesliPreferences.longVoiceNoteThresholdLabel(seconds)]
+        )
     }
 }
 

--- a/Muesli/SettingsView.swift
+++ b/Muesli/SettingsView.swift
@@ -794,15 +794,6 @@ private struct LongVoiceNoteSettingsRow: View {
 
                     Stepper("Threshold seconds", value: $thresholdSeconds, in: 30...600, step: 5)
                         .labelsHidden()
-                        .onChange(of: thresholdSeconds) { _, value in
-                            let clamped = MuesliPreferences.clampedLongVoiceNoteThreshold(value)
-                            if thresholdSeconds != clamped {
-                                thresholdSeconds = clamped
-                                return
-                            }
-                            customText = String(clamped)
-                            signalThresholdChanged(clamped)
-                        }
                 }
 
                 Text("30 seconds to 10 minutes")
@@ -813,6 +804,15 @@ private struct LongVoiceNoteSettingsRow: View {
         .onAppear {
             thresholdSeconds = MuesliPreferences.clampedLongVoiceNoteThreshold(thresholdSeconds)
             customText = String(thresholdSeconds)
+        }
+        .onChange(of: thresholdSeconds) { _, value in
+            let clamped = MuesliPreferences.clampedLongVoiceNoteThreshold(value)
+            if thresholdSeconds != clamped {
+                thresholdSeconds = clamped
+                return
+            }
+            customText = String(clamped)
+            signalThresholdChanged(clamped)
         }
         .onChange(of: isEnabled) { _, enabled in
             AppTelemetry.signal(

--- a/Muesli/SettingsView.swift
+++ b/Muesli/SettingsView.swift
@@ -4,6 +4,7 @@ import SwiftUI
 struct SettingsView: View {
     @Bindable var coordinator: DictationCoordinator
     var openSyncPrivacyRequest: UUID?
+    var openInputRequest: UUID?
     var isActive = true
     var onSelectSection: ((AppSection) -> Void)?
 
@@ -12,6 +13,8 @@ struct SettingsView: View {
     @AppStorage(MuesliPreferences.keyboardSessionModeKey) private var keyboardSessionMode = false
     @AppStorage(MuesliPreferences.recordingMicrophonePreferenceKey) private var microphonePreference = RecordingMicrophonePreference.automatic.rawValue
     @AppStorage(MuesliPreferences.keepDictationAudioRecordingsKey) private var keepDictationAudioRecordings = false
+    @AppStorage(MuesliPreferences.longVoiceNoteModeEnabledKey) private var longVoiceNoteModeEnabled = true
+    @AppStorage(MuesliPreferences.longVoiceNoteThresholdSecondsKey) private var longVoiceNoteThresholdSeconds = 60
     @AppStorage(MuesliPreferences.keepMeetingAudioRecordingsKey) private var keepMeetingAudioRecordings = false
     @AppStorage(MuesliPreferences.meetingSummariesEnabledKey) private var meetingSummariesEnabled = false
     @AppStorage(MuesliPreferences.meetingSummaryBackendKey) private var meetingSummaryBackend = MeetingSummaryBackend.openRouter.rawValue
@@ -37,14 +40,19 @@ struct SettingsView: View {
             .onAppear {
                 refreshVisibleSettingsIfNeeded()
                 openRequestedSyncPrivacySection()
+                openRequestedInputSection()
             }
             .onChange(of: isActive) { _, active in
                 guard active else { return }
                 refreshVisibleSettingsIfNeeded()
                 openRequestedSyncPrivacySection()
+                openRequestedInputSection()
             }
             .onChange(of: openSyncPrivacyRequest) { _, _ in
                 openRequestedSyncPrivacySection()
+            }
+            .onChange(of: openInputRequest) { _, _ in
+                openRequestedInputSection()
             }
             .sheet(isPresented: $isSyncQRCodeScannerPresented) {
                 SyncQRCodeScannerView(
@@ -249,6 +257,11 @@ struct SettingsView: View {
                         title: "Save Voice Note Audio",
                         detail: "Keep original voice note audio locally on this iPhone for playback and troubleshooting. Audio does not sync.",
                         isOn: $keepDictationAudioRecordings
+                    )
+                    Divider().overlay(MuesliTheme.surfaceBorder)
+                    LongVoiceNoteSettingsRow(
+                        isEnabled: $longVoiceNoteModeEnabled,
+                        thresholdSeconds: $longVoiceNoteThresholdSeconds
                     )
                 }
                 .padding(MuesliTheme.spacing16)
@@ -638,6 +651,12 @@ struct SettingsView: View {
         coordinator.syncSetupRequestID = nil
     }
 
+    private func openRequestedInputSection() {
+        guard openInputRequest != nil else { return }
+        selectedSettingsSection = .input
+        coordinator.inputSettingsNavigationRequestID = nil
+    }
+
 }
 
 private enum SettingsSection: String, CaseIterable, Identifiable {
@@ -713,6 +732,118 @@ private enum SettingsSection: String, CaseIterable, Identifiable {
         case .aiSummaries:
             "sparkles"
         }
+    }
+
+}
+
+private struct LongVoiceNoteSettingsRow: View {
+    @Binding var isEnabled: Bool
+    @Binding var thresholdSeconds: Int
+    @State private var customText = ""
+    @FocusState private var isCustomFieldFocused: Bool
+
+    private let commonValues = [30, 60, 90, 120]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: MuesliTheme.spacing12) {
+            SettingsToggleRow(
+                icon: "waveform.path.ecg",
+                title: "Long Voice Note Mode",
+                detail: "Switch to memo mode after longer recordings.",
+                isOn: $isEnabled
+            )
+
+            if isEnabled {
+                HStack(spacing: MuesliTheme.spacing12) {
+                    Text("Switch after")
+                        .font(MuesliTheme.captionMedium())
+                        .foregroundStyle(MuesliTheme.textSecondary)
+
+                    Spacer()
+
+                    Menu {
+                        ForEach(commonValues, id: \.self) { value in
+                            Button(thresholdLabel(value)) {
+                                thresholdSeconds = value
+                                customText = String(value)
+                            }
+                        }
+                    } label: {
+                        HStack(spacing: 6) {
+                            Text(thresholdLabel(thresholdSeconds))
+                            Image(systemName: "chevron.up.chevron.down")
+                                .font(.system(size: 11, weight: .semibold))
+                        }
+                        .font(MuesliTheme.captionMedium())
+                        .foregroundStyle(MuesliTheme.accent)
+                        .frame(minHeight: 44)
+                    }
+                }
+
+                HStack(spacing: MuesliTheme.spacing8) {
+                    TextField("Seconds", text: $customText)
+                        .keyboardType(.numberPad)
+                        .focused($isCustomFieldFocused)
+                        .font(MuesliTheme.body())
+                        .foregroundStyle(MuesliTheme.textPrimary)
+                        .padding(.horizontal, MuesliTheme.spacing12)
+                        .frame(height: 44)
+                        .background(MuesliTheme.surfacePrimary)
+                        .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall, style: .continuous))
+                        .onSubmit(commitCustomValue)
+
+                    Stepper("Threshold seconds", value: $thresholdSeconds, in: 30...600, step: 5)
+                        .labelsHidden()
+                        .onChange(of: thresholdSeconds) { _, value in
+                            let clamped = MuesliPreferences.clampedLongVoiceNoteThreshold(value)
+                            if thresholdSeconds != clamped {
+                                thresholdSeconds = clamped
+                            }
+                            customText = String(clamped)
+                        }
+                }
+
+                Text("30 seconds to 10 minutes")
+                    .font(MuesliTheme.caption())
+                    .foregroundStyle(MuesliTheme.textTertiary)
+            }
+        }
+        .onAppear {
+            thresholdSeconds = MuesliPreferences.clampedLongVoiceNoteThreshold(thresholdSeconds)
+            customText = String(thresholdSeconds)
+        }
+        .onChange(of: isEnabled) { _, enabled in
+            AppTelemetry.signal(
+                "long_voice_note_mode_toggled",
+                parameters: ["enabled": enabled ? "true" : "false"]
+            )
+        }
+        .onChange(of: customText) { _, value in
+            guard value.count > 4 else { return }
+            customText = String(value.prefix(4))
+        }
+        .onChange(of: isCustomFieldFocused) { _, focused in
+            if !focused {
+                commitCustomValue()
+            }
+        }
+    }
+
+    private func commitCustomValue() {
+        let value = Int(customText) ?? thresholdSeconds
+        thresholdSeconds = MuesliPreferences.clampedLongVoiceNoteThreshold(value)
+        customText = String(thresholdSeconds)
+        AppTelemetry.signal(
+            "long_voice_note_threshold_changed",
+            parameters: ["threshold_bucket": thresholdLabel(thresholdSeconds)]
+        )
+    }
+
+    private func thresholdLabel(_ seconds: Int) -> String {
+        if seconds == 60 { return "1 min" }
+        if seconds % 60 == 0 { return "\(seconds / 60) min" }
+        if seconds > 60 { return "\(seconds / 60)m \(seconds % 60)s" }
+        return "\(seconds) sec"
     }
 }
 

--- a/Muesli/StreamingMeetingRecorder.swift
+++ b/Muesli/StreamingMeetingRecorder.swift
@@ -65,7 +65,9 @@ final class StreamingMeetingRecorder: @unchecked Sendable {
             writer.onFailure = { [weak self] failure in
                 self?.onRecordingFailure?(failure)
             }
+            lock.lock()
             audioWriter = writer
+            lock.unlock()
 
             inputNode.installTap(onBus: 0, bufferSize: Self.bufferSize, format: nil) { [weak self] buffer, _ in
                 self?.handle(buffer: buffer, targetFormat: targetFormat)
@@ -85,7 +87,10 @@ final class StreamingMeetingRecorder: @unchecked Sendable {
 
     func rotateChunk() -> MeetingAudioChunk? {
         guard isRunning else { return nil }
-        return audioWriter?.rotateCheckpoint()
+        lock.lock()
+        let writer = audioWriter
+        lock.unlock()
+        return writer?.rotateCheckpoint()
     }
 
     func stop() -> (finalChunk: MeetingAudioChunk?, retainedAudioURL: URL?) {
@@ -97,8 +102,11 @@ final class StreamingMeetingRecorder: @unchecked Sendable {
         }
         engine.stop()
 
-        let result = audioWriter?.finish()
+        lock.lock()
+        let writer = audioWriter
         audioWriter = nil
+        lock.unlock()
+        let result = writer?.finish()
 
         try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
 
@@ -113,11 +121,12 @@ final class StreamingMeetingRecorder: @unchecked Sendable {
         engine.stop()
         isRunning = false
 
-        audioWriter?.cancel()
-        audioWriter = nil
         lock.lock()
+        let writer = audioWriter
+        audioWriter = nil
         state = FileState()
         lock.unlock()
+        writer?.cancel()
         try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
     }
 
@@ -167,8 +176,8 @@ final class StreamingMeetingRecorder: @unchecked Sendable {
         let rms = sqrt(sumSquares / Float(frameCount))
         let powerDB = rms > 0.000_001 ? max(-160, min(0, 20 * log10(rms))) : -160
 
-        audioWriter?.append(monoBuffer)
         lock.lock()
+        audioWriter?.append(monoBuffer)
         state.latestPowerDB = powerDB
         lock.unlock()
 
@@ -207,11 +216,12 @@ final class StreamingMeetingRecorder: @unchecked Sendable {
             tapInstalled = false
         }
         engine.stop()
-        audioWriter?.cancel()
-        audioWriter = nil
         lock.lock()
+        let writer = audioWriter
+        audioWriter = nil
         state = FileState()
         lock.unlock()
+        writer?.cancel()
         isRunning = false
         try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
     }

--- a/Muesli/StreamingMeetingRecorder.swift
+++ b/Muesli/StreamingMeetingRecorder.swift
@@ -12,16 +12,9 @@ struct MeetingAudioChunk: Sendable, Equatable {
 final class StreamingMeetingRecorder: @unchecked Sendable {
     var onAudioSamples: (([Float]) -> Void)?
     var onAudioBuffer: ((AVAudioPCMBuffer) -> Void)?
+    var onRecordingFailure: (@Sendable (CheckpointingAudioWriterFailure) -> Void)?
 
     private struct FileState {
-        var chunkFile: AVAudioFile?
-        var chunkURL: URL?
-        var chunkIndex = 0
-        var chunkStartFrame: AVAudioFramePosition = 0
-        var chunkFrames: AVAudioFramePosition = 0
-        var retainedFile: AVAudioFile?
-        var retainedURL: URL?
-        var totalFrames: AVAudioFramePosition = 0
         var latestPowerDB: Float = -160
     }
 
@@ -29,6 +22,7 @@ final class StreamingMeetingRecorder: @unchecked Sendable {
     private let lock = NSLock()
     private var state = FileState()
     private var converter: AVAudioConverter?
+    private var audioWriter: CheckpointingAudioWriter?
     private var isRunning = false
     private var tapInstalled = false
     private var chunksDirectory: URL?
@@ -63,21 +57,15 @@ final class StreamingMeetingRecorder: @unchecked Sendable {
                 ? AVAudioConverter(from: inputFormat, to: targetFormat)
                 : nil
 
-            let firstChunkURL = chunkURL(directory: chunksDirectory, index: 0)
-            let firstChunkFile = try AVAudioFile(forWriting: firstChunkURL, settings: targetFormat.settings)
-            let retainedFile = try retainedAudioURL.map { url in
-                try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
-                return try AVAudioFile(forWriting: url, settings: targetFormat.settings)
-            }
-
-            lock.lock()
-            state = FileState(
-                chunkFile: firstChunkFile,
-                chunkURL: firstChunkURL,
-                retainedFile: retainedFile,
-                retainedURL: retainedAudioURL
+            let writer = try CheckpointingAudioWriter(
+                continuousAudioURL: retainedAudioURL,
+                checkpointDirectory: chunksDirectory,
+                format: targetFormat
             )
-            lock.unlock()
+            writer.onFailure = { [weak self] failure in
+                self?.onRecordingFailure?(failure)
+            }
+            audioWriter = writer
 
             inputNode.installTap(onBus: 0, bufferSize: Self.bufferSize, format: nil) { [weak self] buffer, _ in
                 self?.handle(buffer: buffer, targetFormat: targetFormat)
@@ -96,49 +84,8 @@ final class StreamingMeetingRecorder: @unchecked Sendable {
     }
 
     func rotateChunk() -> MeetingAudioChunk? {
-        guard isRunning, let chunksDirectory else { return nil }
-
-        lock.lock()
-        guard let completedURL = state.chunkURL, state.chunkFrames > 0 else {
-            lock.unlock()
-            return nil
-        }
-
-        state.chunkFile = nil
-        let completedIndex = state.chunkIndex
-        let completedStartFrame = state.chunkStartFrame
-        let completedFrames = state.chunkFrames
-        let nextIndex = completedIndex + 1
-        let nextURL = chunkURL(directory: chunksDirectory, index: nextIndex)
-
-        do {
-            guard let format = AVAudioFormat(
-                commonFormat: .pcmFormatFloat32,
-                sampleRate: Self.sampleRate,
-                channels: 1,
-                interleaved: false
-            ) else {
-                lock.unlock()
-                return nil
-            }
-            let nextFile = try AVAudioFile(forWriting: nextURL, settings: format.settings)
-            state.chunkFile = nextFile
-            state.chunkURL = nextURL
-            state.chunkIndex = nextIndex
-            state.chunkStartFrame = state.totalFrames
-            state.chunkFrames = 0
-        } catch {
-            lock.unlock()
-            return nil
-        }
-        lock.unlock()
-
-        return MeetingAudioChunk(
-            index: completedIndex,
-            url: completedURL,
-            startTime: Double(completedStartFrame) / Self.sampleRate,
-            duration: Double(completedFrames) / Self.sampleRate
-        )
+        guard isRunning else { return nil }
+        return audioWriter?.rotateCheckpoint()
     }
 
     func stop() -> (finalChunk: MeetingAudioChunk?, retainedAudioURL: URL?) {
@@ -150,32 +97,12 @@ final class StreamingMeetingRecorder: @unchecked Sendable {
         }
         engine.stop()
 
-        lock.lock()
-        let finalURL = state.chunkURL
-        let finalIndex = state.chunkIndex
-        let finalStartFrame = state.chunkStartFrame
-        let finalFrames = state.chunkFrames
-        let retainedURL = state.retainedURL
-        state.chunkFile = nil
-        state.retainedFile = nil
-        state.chunkURL = nil
-        state.retainedURL = nil
-        lock.unlock()
+        let result = audioWriter?.finish()
+        audioWriter = nil
 
         try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
 
-        let finalChunk: MeetingAudioChunk?
-        if let finalURL, finalFrames > 0 {
-            finalChunk = MeetingAudioChunk(
-                index: finalIndex,
-                url: finalURL,
-                startTime: Double(finalStartFrame) / Self.sampleRate,
-                duration: Double(finalFrames) / Self.sampleRate
-            )
-        } else {
-            finalChunk = nil
-        }
-        return (finalChunk, retainedURL)
+        return (result?.finalCheckpoint, result?.continuousAudioURL)
     }
 
     func cancel() {
@@ -186,18 +113,11 @@ final class StreamingMeetingRecorder: @unchecked Sendable {
         engine.stop()
         isRunning = false
 
+        audioWriter?.cancel()
+        audioWriter = nil
         lock.lock()
-        let chunkURL = state.chunkURL
-        let retainedURL = state.retainedURL
         state = FileState()
         lock.unlock()
-
-        if let chunkURL {
-            try? FileManager.default.removeItem(at: chunkURL)
-        }
-        if let retainedURL {
-            try? FileManager.default.removeItem(at: retainedURL)
-        }
         try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
     }
 
@@ -247,16 +167,9 @@ final class StreamingMeetingRecorder: @unchecked Sendable {
         let rms = sqrt(sumSquares / Float(frameCount))
         let powerDB = rms > 0.000_001 ? max(-160, min(0, 20 * log10(rms))) : -160
 
+        audioWriter?.append(monoBuffer)
         lock.lock()
-        do {
-            try state.chunkFile?.write(from: monoBuffer)
-            try state.retainedFile?.write(from: monoBuffer)
-            state.chunkFrames += AVAudioFramePosition(frameCount)
-            state.totalFrames += AVAudioFramePosition(frameCount)
-            state.latestPowerDB = powerDB
-        } catch {
-            // Keep recording best-effort; UI will surface failure on stop if no chunks exist.
-        }
+        state.latestPowerDB = powerDB
         lock.unlock()
 
         if let audioBuffer = Self.copyBuffer(monoBuffer) {
@@ -294,6 +207,8 @@ final class StreamingMeetingRecorder: @unchecked Sendable {
             tapInstalled = false
         }
         engine.stop()
+        audioWriter?.cancel()
+        audioWriter = nil
         lock.lock()
         state = FileState()
         lock.unlock()
@@ -301,9 +216,4 @@ final class StreamingMeetingRecorder: @unchecked Sendable {
         try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
     }
 
-    private func chunkURL(directory: URL, index: Int) -> URL {
-        directory
-            .appendingPathComponent("chunk-\(String(format: "%04d", index))")
-            .appendingPathExtension("wav")
-    }
 }

--- a/Muesli/StreamingMeetingRecorder.swift
+++ b/Muesli/StreamingMeetingRecorder.swift
@@ -10,6 +10,12 @@ struct MeetingAudioChunk: Sendable, Equatable {
 }
 
 final class StreamingMeetingRecorder: @unchecked Sendable {
+    struct StopResult: Sendable {
+        let finalChunk: MeetingAudioChunk?
+        let retainedAudioURL: URL?
+        let writerFailure: CheckpointingAudioWriterFailure?
+    }
+
     var onAudioSamples: (([Float]) -> Void)?
     var onAudioBuffer: ((AVAudioPCMBuffer) -> Void)?
     var onRecordingFailure: (@Sendable (CheckpointingAudioWriterFailure) -> Void)?
@@ -93,8 +99,14 @@ final class StreamingMeetingRecorder: @unchecked Sendable {
         return writer?.rotateCheckpoint()
     }
 
-    func stop() -> (finalChunk: MeetingAudioChunk?, retainedAudioURL: URL?) {
-        guard isRunning else { return (nil, nil) }
+    func stop() -> StopResult {
+        guard isRunning else {
+            return StopResult(
+                finalChunk: nil,
+                retainedAudioURL: nil,
+                writerFailure: nil
+            )
+        }
         isRunning = false
         if tapInstalled {
             engine.inputNode.removeTap(onBus: 0)
@@ -110,7 +122,11 @@ final class StreamingMeetingRecorder: @unchecked Sendable {
 
         try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
 
-        return (result?.finalCheckpoint, result?.continuousAudioURL)
+        return StopResult(
+            finalChunk: result?.finalCheckpoint,
+            retainedAudioURL: result?.continuousAudioURL,
+            writerFailure: result?.failure
+        )
     }
 
     func cancel() {

--- a/Muesli/VoiceNoteCheckpointStore.swift
+++ b/Muesli/VoiceNoteCheckpointStore.swift
@@ -1,0 +1,214 @@
+import AVFoundation
+import Foundation
+
+struct VoiceNoteCheckpointManifest: Codable, Sendable, Equatable {
+    struct Entry: Codable, Sendable, Equatable {
+        let index: Int
+        let fileName: String
+        let frameCount: Int64
+        let startTime: TimeInterval
+        let duration: TimeInterval
+        let finalizedAt: Date
+    }
+
+    let schemaVersion: Int
+    let sessionID: UUID
+    let startedAt: Date
+    var finalizedAt: Date?
+    var entries: [Entry]
+
+    init(sessionID: UUID, startedAt: Date) {
+        schemaVersion = 1
+        self.sessionID = sessionID
+        self.startedAt = startedAt
+        finalizedAt = nil
+        entries = []
+    }
+}
+
+actor VoiceNoteCheckpointStore {
+    enum StoreError: Error {
+        case missingManifest
+        case noRecoverableAudio
+        case incompatibleAudioFormat
+    }
+
+    private let store: SharedStore
+    private let encoder: JSONEncoder
+    private let decoder: JSONDecoder
+
+    init(store: SharedStore) {
+        self.store = store
+        encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        decoder = JSONDecoder()
+    }
+
+    func prepare(sessionID: UUID, startedAt: Date) throws -> URL {
+        let directory = try store.voiceNoteCheckpointDirectoryURL(sessionID: sessionID)
+        try write(VoiceNoteCheckpointManifest(sessionID: sessionID, startedAt: startedAt), to: directory)
+        return directory
+    }
+
+    func record(_ checkpoint: MeetingAudioChunk, sessionID: UUID) throws -> VoiceNoteCheckpointManifest {
+        let directory = try store.voiceNoteCheckpointDirectoryURL(sessionID: sessionID)
+        var manifest = try load(from: directory)
+        guard !manifest.entries.contains(where: { $0.index == checkpoint.index }) else { return manifest }
+        let frameCount = (try? AVAudioFile(forReading: checkpoint.url).length) ?? 0
+        manifest.entries.append(.init(
+            index: checkpoint.index,
+            fileName: checkpoint.url.lastPathComponent,
+            frameCount: frameCount,
+            startTime: checkpoint.startTime,
+            duration: checkpoint.duration,
+            finalizedAt: .now
+        ))
+        manifest.entries.sort { $0.index < $1.index }
+        try write(manifest, to: directory)
+        return manifest
+    }
+
+    func finalize(sessionID: UUID, finalCheckpoint: MeetingAudioChunk?) throws -> VoiceNoteCheckpointManifest {
+        if let finalCheckpoint {
+            _ = try record(finalCheckpoint, sessionID: sessionID)
+        }
+        let directory = try store.voiceNoteCheckpointDirectoryURL(sessionID: sessionID)
+        var manifest = try load(from: directory)
+        manifest.finalizedAt = .now
+        try write(manifest, to: directory)
+        return manifest
+    }
+
+    func manifest(sessionID: UUID) throws -> VoiceNoteCheckpointManifest {
+        try load(from: store.voiceNoteCheckpointDirectoryURL(sessionID: sessionID))
+    }
+
+    func salvageTrailingCheckpoint(sessionID: UUID) throws -> VoiceNoteCheckpointManifest {
+        let directory = try store.voiceNoteCheckpointDirectoryURL(sessionID: sessionID)
+        var manifest = try load(from: directory)
+        var expectedIndex = (manifest.entries.map(\.index).max() ?? -1) + 1
+        var startTime = manifest.entries
+            .sorted(by: { $0.index < $1.index })
+            .last
+            .map { $0.startTime + $0.duration } ?? 0
+
+        while true {
+            let url = directory
+                .appendingPathComponent("chunk-\(String(format: "%04d", expectedIndex))")
+                .appendingPathExtension("wav")
+            guard FileManager.default.fileExists(atPath: url.path),
+                  let file = try? AVAudioFile(forReading: url),
+                  file.length > 0,
+                  file.processingFormat.sampleRate > 0
+            else { break }
+
+            let duration = Double(file.length) / file.processingFormat.sampleRate
+            manifest.entries.append(.init(
+                index: expectedIndex,
+                fileName: url.lastPathComponent,
+                frameCount: file.length,
+                startTime: startTime,
+                duration: duration,
+                finalizedAt: fileModificationDate(at: url) ?? .now
+            ))
+            expectedIndex += 1
+            startTime += duration
+        }
+
+        manifest.entries.sort { $0.index < $1.index }
+        try write(manifest, to: directory)
+        return manifest
+    }
+
+    func delete(sessionID: UUID) throws {
+        try store.deleteVoiceNoteCheckpoints(sessionID: sessionID)
+    }
+
+    func checkpointSessionIDs() throws -> [UUID] {
+        try store.voiceNoteCheckpointSessionIDs()
+    }
+
+    func isReadableAudio(at url: URL) -> Bool {
+        guard FileManager.default.fileExists(atPath: url.path),
+              let file = try? AVAudioFile(forReading: url)
+        else { return false }
+        return file.length > 0
+    }
+
+    func reconstructAudio(sessionID: UUID, destinationURL: URL) throws -> URL {
+        let directory = try store.voiceNoteCheckpointDirectoryURL(sessionID: sessionID)
+        let manifest = try salvageTrailingCheckpoint(sessionID: sessionID)
+        let entries = recoverableContiguousEntries(manifest.entries, directory: directory)
+        guard !entries.isEmpty else { throw StoreError.noRecoverableAudio }
+
+        if FileManager.default.fileExists(atPath: destinationURL.path) {
+            try FileManager.default.removeItem(at: destinationURL)
+        }
+
+        var output: AVAudioFile?
+        for entry in entries {
+            let input = try AVAudioFile(forReading: directory.appendingPathComponent(entry.fileName))
+            if output == nil {
+                output = try AVAudioFile(forWriting: destinationURL, settings: input.processingFormat.settings)
+            } else if output?.processingFormat.sampleRate != input.processingFormat.sampleRate
+                        || output?.processingFormat.channelCount != input.processingFormat.channelCount {
+                throw StoreError.incompatibleAudioFormat
+            }
+            while input.framePosition < input.length {
+                let remaining = input.length - input.framePosition
+                let capacity = AVAudioFrameCount(min(remaining, 8_192))
+                guard let buffer = AVAudioPCMBuffer(
+                    pcmFormat: input.processingFormat,
+                    frameCapacity: capacity
+                ) else { throw StoreError.noRecoverableAudio }
+                try input.read(into: buffer, frameCount: capacity)
+                guard buffer.frameLength > 0 else { break }
+                try output?.write(from: buffer)
+            }
+        }
+        output = nil
+        guard isReadableAudio(at: destinationURL) else { throw StoreError.noRecoverableAudio }
+        return destinationURL
+    }
+
+    private func contiguousEntries(
+        _ entries: [VoiceNoteCheckpointManifest.Entry]
+    ) -> [VoiceNoteCheckpointManifest.Entry] {
+        var expected = 0
+        var contiguous: [VoiceNoteCheckpointManifest.Entry] = []
+        for entry in entries.sorted(by: { $0.index < $1.index }) {
+            guard entry.index == expected else { break }
+            contiguous.append(entry)
+            expected += 1
+        }
+        return contiguous
+    }
+
+    private func recoverableContiguousEntries(
+        _ entries: [VoiceNoteCheckpointManifest.Entry],
+        directory: URL
+    ) -> [VoiceNoteCheckpointManifest.Entry] {
+        var recoverable: [VoiceNoteCheckpointManifest.Entry] = []
+        for entry in contiguousEntries(entries) {
+            let url = directory.appendingPathComponent(entry.fileName)
+            guard isReadableAudio(at: url) else { break }
+            recoverable.append(entry)
+        }
+        return recoverable
+    }
+
+    private func load(from directory: URL) throws -> VoiceNoteCheckpointManifest {
+        let url = directory.appendingPathComponent("manifest.json")
+        guard FileManager.default.fileExists(atPath: url.path) else { throw StoreError.missingManifest }
+        return try decoder.decode(VoiceNoteCheckpointManifest.self, from: Data(contentsOf: url))
+    }
+
+    private func write(_ manifest: VoiceNoteCheckpointManifest, to directory: URL) throws {
+        let url = directory.appendingPathComponent("manifest.json")
+        try encoder.encode(manifest).write(to: url, options: .atomic)
+    }
+
+    private func fileModificationDate(at url: URL) -> Date? {
+        try? url.resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate
+    }
+}

--- a/Muesli/VoiceNoteCheckpointStore.swift
+++ b/Muesli/VoiceNoteCheckpointStore.swift
@@ -31,6 +31,7 @@ actor VoiceNoteCheckpointStore {
         case missingManifest
         case noRecoverableAudio
         case incompatibleAudioFormat
+        case invalidCheckpoint
     }
 
     private let store: SharedStore
@@ -54,7 +55,18 @@ actor VoiceNoteCheckpointStore {
         let directory = try store.voiceNoteCheckpointDirectoryURL(sessionID: sessionID)
         var manifest = try load(from: directory)
         guard !manifest.entries.contains(where: { $0.index == checkpoint.index }) else { return manifest }
-        let frameCount = (try? AVAudioFile(forReading: checkpoint.url).length) ?? 0
+        let checkpointFile: AVAudioFile
+        do {
+            checkpointFile = try AVAudioFile(forReading: checkpoint.url)
+        } catch {
+            throw StoreError.invalidCheckpoint
+        }
+        guard checkpointFile.length > 0,
+              checkpointFile.processingFormat.sampleRate > 0
+        else {
+            throw StoreError.invalidCheckpoint
+        }
+        let frameCount = checkpointFile.length
         manifest.entries.append(.init(
             index: checkpoint.index,
             fileName: checkpoint.url.lastPathComponent,

--- a/Muesli/VoiceNoteLifecycle.swift
+++ b/Muesli/VoiceNoteLifecycle.swift
@@ -44,6 +44,16 @@ struct VoiceNoteLifecycleState: Equatable {
             false
         }
     }
+
+    var isWorkActive: Bool {
+        switch phase {
+        case .recordingShort, .recordingLongProtected, .stopping, .audioSaved,
+             .transcriptionQueued, .transcribing, .cancelling:
+            true
+        case .idle, .failedRetryable:
+            false
+        }
+    }
 }
 
 enum VoiceNoteLifecycleEvent {
@@ -96,11 +106,30 @@ enum VoiceNoteLifecycleReducer {
     }
 }
 
+struct VoiceNoteRequestOwnership: Equatable {
+    let requestID: UUID?
+    let isWorkActive: Bool
+
+    func accepts(requestID incomingRequestID: UUID) -> Bool {
+        guard isWorkActive else { return true }
+        guard let requestID else { return false }
+        return requestID == incomingRequestID
+    }
+}
+
 struct VoiceNoteLifecycleRunner {
+    let id: UUID
     let sessionID: UUID
+    let requestID: UUID
     var checkpointTask: Task<Void, Never>?
     var thresholdTask: Task<Void, Never>?
     var transcriptionTask: Task<Void, Never>?
+
+    init(id: UUID = UUID(), sessionID: UUID, requestID: UUID) {
+        self.id = id
+        self.sessionID = sessionID
+        self.requestID = requestID
+    }
 
     mutating func cancelAll() {
         checkpointTask?.cancel()
@@ -119,5 +148,24 @@ enum VoiceNoteAudioRetentionPolicy {
 
     static func shouldDeleteAudioAfterSuccess(_ session: RecordingSession) -> Bool {
         !session.keepsAudioRecording
+    }
+}
+
+enum VoiceNoteCheckpointRetentionPolicy {
+    static func shouldDeleteCheckpoints(for session: RecordingSession?) -> Bool {
+        guard let session else { return true }
+        guard session.kind != .meeting else { return false }
+        if session.phase == .completed || session.phase == .cancelled {
+            return true
+        }
+        if session.protectedAudioUntilTranscriptCompletes,
+           session.audioFileName != nil {
+            return false
+        }
+        if !session.isLongForm {
+            return ![.recording, .transcriptionQueued, .transcribing].contains(session.phase)
+        }
+        return session.audioFileName == nil
+            && !session.protectedAudioUntilTranscriptCompletes
     }
 }

--- a/Muesli/VoiceNoteLifecycle.swift
+++ b/Muesli/VoiceNoteLifecycle.swift
@@ -187,6 +187,20 @@ struct VoiceNoteRequestOwnership: Equatable {
     }
 }
 
+enum KeyboardCommandArbitration {
+    static func shouldDeferUntilRecorderStarts(
+        action: DictationCommandAction,
+        activeRequestMatches: Bool,
+        hasActiveSession: Bool,
+        isRecording: Bool
+    ) -> Bool {
+        action != .start
+            && activeRequestMatches
+            && !hasActiveSession
+            && !isRecording
+    }
+}
+
 struct VoiceNoteLifecycleRunner {
     let id: UUID
     let sessionID: UUID

--- a/Muesli/VoiceNoteLifecycle.swift
+++ b/Muesli/VoiceNoteLifecycle.swift
@@ -11,6 +11,20 @@ struct VoiceNoteLifecycleState: Equatable {
         case transcribing(UUID)
         case failedRetryable(UUID)
         case cancelling(UUID)
+
+        var telemetryName: String {
+            switch self {
+            case .idle: "idle"
+            case .recordingShort: "recording_short"
+            case .recordingLongProtected: "recording_long_protected"
+            case .stopping: "stopping"
+            case .audioSaved: "audio_saved"
+            case .transcriptionQueued: "transcription_queued"
+            case .transcribing: "transcribing"
+            case .failedRetryable: "failed_retryable"
+            case .cancelling: "cancelling"
+            }
+        }
     }
 
     var phase: Phase = .idle
@@ -67,42 +81,92 @@ enum VoiceNoteLifecycleEvent {
     case retryRequested(UUID)
     case cancelRequested(UUID)
     case finished(UUID)
+
+    var telemetryName: String {
+        switch self {
+        case .recordingStarted: "recording_started"
+        case .longFormActivated: "long_form_activated"
+        case .stopRequested: "stop_requested"
+        case .audioFinalized: "audio_finalized"
+        case .transcriptionQueued: "transcription_queued"
+        case .transcriptionStarted: "transcription_started"
+        case .transcriptionFailed: "transcription_failed"
+        case .retryRequested: "retry_requested"
+        case .cancelRequested: "cancel_requested"
+        case .finished: "finished"
+        }
+    }
+}
+
+struct VoiceNoteLifecycleTransition: Equatable {
+    let state: VoiceNoteLifecycleState
+    let accepted: Bool
 }
 
 enum VoiceNoteLifecycleReducer {
-    static func reduce(_ state: VoiceNoteLifecycleState, event: VoiceNoteLifecycleEvent) -> VoiceNoteLifecycleState {
-        switch event {
-        case .recordingStarted(let id):
-            guard state.activeSessionID == nil || state.activeSessionID == id else { return state }
-            return VoiceNoteLifecycleState(phase: .recordingShort(id))
-        case .longFormActivated(let id):
-            guard state.activeSessionID == id else { return state }
-            return VoiceNoteLifecycleState(phase: .recordingLongProtected(id))
-        case .stopRequested(let id):
-            guard state.activeSessionID == id else { return state }
-            return VoiceNoteLifecycleState(phase: .stopping(id))
-        case .audioFinalized(let id):
-            guard state.activeSessionID == id else { return state }
-            return VoiceNoteLifecycleState(phase: .audioSaved(id))
-        case .transcriptionQueued(let id):
-            guard state.activeSessionID == id else { return state }
-            return VoiceNoteLifecycleState(phase: .transcriptionQueued(id))
-        case .transcriptionStarted(let id):
-            guard state.activeSessionID == id else { return state }
-            return VoiceNoteLifecycleState(phase: .transcribing(id))
-        case .transcriptionFailed(let id):
-            guard state.activeSessionID == id else { return state }
-            return VoiceNoteLifecycleState(phase: .failedRetryable(id))
-        case .retryRequested(let id):
-            guard state.activeSessionID == nil || state.activeSessionID == id else { return state }
-            return VoiceNoteLifecycleState(phase: .transcriptionQueued(id))
-        case .cancelRequested(let id):
-            guard state.activeSessionID == id else { return state }
-            return VoiceNoteLifecycleState(phase: .cancelling(id))
-        case .finished(let id):
-            guard state.activeSessionID == id else { return state }
-            return VoiceNoteLifecycleState()
+    static func transition(
+        _ state: VoiceNoteLifecycleState,
+        event: VoiceNoteLifecycleEvent
+    ) -> VoiceNoteLifecycleTransition {
+        let nextState: VoiceNoteLifecycleState?
+        switch (state.phase, event) {
+        case (.idle, .recordingStarted(let id)):
+            nextState = VoiceNoteLifecycleState(phase: .recordingShort(id))
+        case (.failedRetryable, .recordingStarted(let id)):
+            nextState = VoiceNoteLifecycleState(phase: .recordingShort(id))
+        case (.recordingShort(let activeID), .recordingStarted(let id)) where activeID == id:
+            nextState = state
+        case (.recordingShort(let activeID), .longFormActivated(let id)) where activeID == id:
+            nextState = VoiceNoteLifecycleState(phase: .recordingLongProtected(id))
+        case (.recordingShort(let activeID), .stopRequested(let id)) where activeID == id:
+            nextState = VoiceNoteLifecycleState(phase: .stopping(id))
+        case (.recordingLongProtected(let activeID), .stopRequested(let id)) where activeID == id:
+            nextState = VoiceNoteLifecycleState(phase: .stopping(id))
+        case (.stopping(let activeID), .audioFinalized(let id)) where activeID == id:
+            nextState = VoiceNoteLifecycleState(phase: .audioSaved(id))
+        case (.audioSaved(let activeID), .transcriptionQueued(let id)) where activeID == id:
+            nextState = VoiceNoteLifecycleState(phase: .transcriptionQueued(id))
+        case (.stopping(let activeID), .transcriptionStarted(let id)) where activeID == id:
+            nextState = VoiceNoteLifecycleState(phase: .transcribing(id))
+        case (.audioSaved(let activeID), .transcriptionStarted(let id)) where activeID == id:
+            nextState = VoiceNoteLifecycleState(phase: .transcribing(id))
+        case (.transcriptionQueued(let activeID), .transcriptionStarted(let id)) where activeID == id:
+            nextState = VoiceNoteLifecycleState(phase: .transcribing(id))
+        case (.stopping(let activeID), .transcriptionFailed(let id)) where activeID == id:
+            nextState = VoiceNoteLifecycleState(phase: .failedRetryable(id))
+        case (.audioSaved(let activeID), .transcriptionFailed(let id)) where activeID == id:
+            nextState = VoiceNoteLifecycleState(phase: .failedRetryable(id))
+        case (.transcriptionQueued(let activeID), .transcriptionFailed(let id)) where activeID == id:
+            nextState = VoiceNoteLifecycleState(phase: .failedRetryable(id))
+        case (.transcribing(let activeID), .transcriptionFailed(let id)) where activeID == id:
+            nextState = VoiceNoteLifecycleState(phase: .failedRetryable(id))
+        case (.idle, .retryRequested(let id)):
+            nextState = VoiceNoteLifecycleState(phase: .transcriptionQueued(id))
+        case (.failedRetryable(let activeID), .retryRequested(let id)) where activeID == id:
+            nextState = VoiceNoteLifecycleState(phase: .transcriptionQueued(id))
+        case (.recordingShort(let activeID), .cancelRequested(let id)) where activeID == id:
+            nextState = VoiceNoteLifecycleState(phase: .cancelling(id))
+        case (.recordingLongProtected(let activeID), .cancelRequested(let id)) where activeID == id:
+            nextState = VoiceNoteLifecycleState(phase: .cancelling(id))
+        case (.stopping(let activeID), .cancelRequested(let id)) where activeID == id:
+            nextState = VoiceNoteLifecycleState(phase: .cancelling(id))
+        case (_, .finished(let id)) where state.activeSessionID == id:
+            nextState = VoiceNoteLifecycleState()
+        default:
+            nextState = nil
         }
+
+        guard let nextState else {
+            return VoiceNoteLifecycleTransition(state: state, accepted: false)
+        }
+        return VoiceNoteLifecycleTransition(state: nextState, accepted: true)
+    }
+
+    static func reduce(
+        _ state: VoiceNoteLifecycleState,
+        event: VoiceNoteLifecycleEvent
+    ) -> VoiceNoteLifecycleState {
+        transition(state, event: event).state
     }
 }
 
@@ -148,6 +212,15 @@ enum VoiceNoteAudioRetentionPolicy {
 
     static func shouldDeleteAudioAfterSuccess(_ session: RecordingSession) -> Bool {
         !session.keepsAudioRecording
+    }
+}
+
+enum VoiceNoteFailureLifecycleDisposition: Equatable {
+    case retryable
+    case finished
+
+    static func resolve(for session: RecordingSession) -> VoiceNoteFailureLifecycleDisposition {
+        session.isLongForm ? .retryable : .finished
     }
 }
 

--- a/Muesli/VoiceNoteLifecycle.swift
+++ b/Muesli/VoiceNoteLifecycle.swift
@@ -185,8 +185,7 @@ struct VoiceNoteLifecycleRunner {
     let id: UUID
     let sessionID: UUID
     let requestID: UUID
-    var checkpointTask: Task<Void, Never>?
-    var thresholdTask: Task<Void, Never>?
+    var recordingScheduleTask: Task<Void, Never>?
     var transcriptionTask: Task<Void, Never>?
 
     init(id: UUID = UUID(), sessionID: UUID, requestID: UUID) {
@@ -196,12 +195,44 @@ struct VoiceNoteLifecycleRunner {
     }
 
     mutating func cancelAll() {
-        checkpointTask?.cancel()
-        thresholdTask?.cancel()
+        recordingScheduleTask?.cancel()
         transcriptionTask?.cancel()
-        checkpointTask = nil
-        thresholdTask = nil
+        recordingScheduleTask = nil
         transcriptionTask = nil
+    }
+}
+
+struct VoiceNoteRecordingSchedule: Equatable {
+    enum Event: Equatable {
+        case checkpoint
+        case activateLongForm
+    }
+
+    static let checkpointIntervalSeconds = 30
+
+    let thresholdSeconds: Int
+    private(set) var nextCheckpointSeconds = checkpointIntervalSeconds
+    private(set) var didActivateLongForm = false
+
+    var nextDeadlineSeconds: Int {
+        if didActivateLongForm {
+            return nextCheckpointSeconds
+        }
+        return min(nextCheckpointSeconds, thresholdSeconds)
+    }
+
+    mutating func consumeNextDeadline() -> [Event] {
+        let deadline = nextDeadlineSeconds
+        var events: [Event] = []
+        if deadline == nextCheckpointSeconds {
+            events.append(.checkpoint)
+            nextCheckpointSeconds += Self.checkpointIntervalSeconds
+        }
+        if !didActivateLongForm, deadline == thresholdSeconds {
+            events.append(.activateLongForm)
+            didActivateLongForm = true
+        }
+        return events
     }
 }
 

--- a/Muesli/VoiceNoteLifecycle.swift
+++ b/Muesli/VoiceNoteLifecycle.swift
@@ -253,6 +253,19 @@ enum VoiceNoteFailureSessionPolicy {
     }
 }
 
+enum VoiceNoteFailureTelemetryPolicy {
+    static func stage(
+        for reason: VoiceNoteTranscriptionFailureReason,
+        standard: String,
+        timeout: String
+    ) -> String {
+        switch reason {
+        case .timeout: timeout
+        default: standard
+        }
+    }
+}
+
 enum VoiceNoteCheckpointRetentionPolicy {
     static func shouldDeleteCheckpoints(for session: RecordingSession?) -> Bool {
         guard let session else { return true }

--- a/Muesli/VoiceNoteLifecycle.swift
+++ b/Muesli/VoiceNoteLifecycle.swift
@@ -150,6 +150,12 @@ enum VoiceNoteLifecycleReducer {
             nextState = VoiceNoteLifecycleState(phase: .cancelling(id))
         case (.stopping(let activeID), .cancelRequested(let id)) where activeID == id:
             nextState = VoiceNoteLifecycleState(phase: .cancelling(id))
+        case (.audioSaved(let activeID), .cancelRequested(let id)) where activeID == id:
+            nextState = VoiceNoteLifecycleState(phase: .cancelling(id))
+        case (.transcriptionQueued(let activeID), .cancelRequested(let id)) where activeID == id:
+            nextState = VoiceNoteLifecycleState(phase: .cancelling(id))
+        case (.transcribing(let activeID), .cancelRequested(let id)) where activeID == id:
+            nextState = VoiceNoteLifecycleState(phase: .cancelling(id))
         case (_, .finished(let id)) where state.activeSessionID == id:
             nextState = VoiceNoteLifecycleState()
         default:

--- a/Muesli/VoiceNoteLifecycle.swift
+++ b/Muesli/VoiceNoteLifecycle.swift
@@ -75,10 +75,10 @@ enum VoiceNoteLifecycleReducer {
             guard state.activeSessionID == id else { return state }
             return VoiceNoteLifecycleState(phase: .audioSaved(id))
         case .transcriptionQueued(let id):
-            guard state.activeSessionID == nil || state.activeSessionID == id else { return state }
+            guard state.activeSessionID == id else { return state }
             return VoiceNoteLifecycleState(phase: .transcriptionQueued(id))
         case .transcriptionStarted(let id):
-            guard state.activeSessionID == nil || state.activeSessionID == id else { return state }
+            guard state.activeSessionID == id else { return state }
             return VoiceNoteLifecycleState(phase: .transcribing(id))
         case .transcriptionFailed(let id):
             guard state.activeSessionID == id else { return state }
@@ -87,7 +87,7 @@ enum VoiceNoteLifecycleReducer {
             guard state.activeSessionID == nil || state.activeSessionID == id else { return state }
             return VoiceNoteLifecycleState(phase: .transcriptionQueued(id))
         case .cancelRequested(let id):
-            guard state.activeSessionID == nil || state.activeSessionID == id else { return state }
+            guard state.activeSessionID == id else { return state }
             return VoiceNoteLifecycleState(phase: .cancelling(id))
         case .finished(let id):
             guard state.activeSessionID == id else { return state }

--- a/Muesli/VoiceNoteLifecycle.swift
+++ b/Muesli/VoiceNoteLifecycle.swift
@@ -224,6 +224,35 @@ enum VoiceNoteFailureLifecycleDisposition: Equatable {
     }
 }
 
+enum VoiceNoteRecordingTerminationCause: Equatable {
+    case interrupted
+    case checkpointFailure
+
+    var failureReason: VoiceNoteTranscriptionFailureReason {
+        switch self {
+        case .interrupted: .interrupted
+        case .checkpointFailure: .checkpointFailure
+        }
+    }
+}
+
+enum VoiceNoteFailureSessionPolicy {
+    static func prepare(
+        _ session: RecordingSession,
+        reason: VoiceNoteTranscriptionFailureReason,
+        message: String,
+        hasRecoverableAudio: Bool
+    ) -> RecordingSession {
+        var failedSession = session
+        failedSession.phase = .failed
+        failedSession.errorMessage = message
+        failedSession.lastTranscriptionFailureReason = reason
+        failedSession.protectedAudioUntilTranscriptCompletes = session.isLongForm
+            && hasRecoverableAudio
+        return failedSession
+    }
+}
+
 enum VoiceNoteCheckpointRetentionPolicy {
     static func shouldDeleteCheckpoints(for session: RecordingSession?) -> Bool {
         guard let session else { return true }

--- a/Muesli/VoiceNoteLifecycle.swift
+++ b/Muesli/VoiceNoteLifecycle.swift
@@ -1,0 +1,123 @@
+import Foundation
+
+struct VoiceNoteLifecycleState: Equatable {
+    enum Phase: Equatable {
+        case idle
+        case recordingShort(UUID)
+        case recordingLongProtected(UUID)
+        case stopping(UUID)
+        case audioSaved(UUID)
+        case transcriptionQueued(UUID)
+        case transcribing(UUID)
+        case failedRetryable(UUID)
+        case cancelling(UUID)
+    }
+
+    var phase: Phase = .idle
+
+    var activeSessionID: UUID? {
+        switch phase {
+        case .idle:
+            nil
+        case .recordingShort(let id), .recordingLongProtected(let id), .stopping(let id),
+             .audioSaved(let id), .transcriptionQueued(let id), .transcribing(let id),
+             .failedRetryable(let id), .cancelling(let id):
+            id
+        }
+    }
+
+    var isRecording: Bool {
+        switch phase {
+        case .recordingShort, .recordingLongProtected, .stopping:
+            true
+        case .idle, .audioSaved, .transcriptionQueued, .transcribing, .failedRetryable, .cancelling:
+            false
+        }
+    }
+
+    var isLongFormVisible: Bool {
+        switch phase {
+        case .recordingLongProtected, .stopping, .audioSaved, .transcriptionQueued,
+             .transcribing, .failedRetryable:
+            true
+        case .idle, .recordingShort, .cancelling:
+            false
+        }
+    }
+}
+
+enum VoiceNoteLifecycleEvent {
+    case recordingStarted(UUID)
+    case longFormActivated(UUID)
+    case stopRequested(UUID)
+    case audioFinalized(UUID)
+    case transcriptionQueued(UUID)
+    case transcriptionStarted(UUID)
+    case transcriptionFailed(UUID)
+    case retryRequested(UUID)
+    case cancelRequested(UUID)
+    case finished(UUID)
+}
+
+enum VoiceNoteLifecycleReducer {
+    static func reduce(_ state: VoiceNoteLifecycleState, event: VoiceNoteLifecycleEvent) -> VoiceNoteLifecycleState {
+        switch event {
+        case .recordingStarted(let id):
+            guard state.activeSessionID == nil || state.activeSessionID == id else { return state }
+            return VoiceNoteLifecycleState(phase: .recordingShort(id))
+        case .longFormActivated(let id):
+            guard state.activeSessionID == id else { return state }
+            return VoiceNoteLifecycleState(phase: .recordingLongProtected(id))
+        case .stopRequested(let id):
+            guard state.activeSessionID == id else { return state }
+            return VoiceNoteLifecycleState(phase: .stopping(id))
+        case .audioFinalized(let id):
+            guard state.activeSessionID == id else { return state }
+            return VoiceNoteLifecycleState(phase: .audioSaved(id))
+        case .transcriptionQueued(let id):
+            guard state.activeSessionID == nil || state.activeSessionID == id else { return state }
+            return VoiceNoteLifecycleState(phase: .transcriptionQueued(id))
+        case .transcriptionStarted(let id):
+            guard state.activeSessionID == nil || state.activeSessionID == id else { return state }
+            return VoiceNoteLifecycleState(phase: .transcribing(id))
+        case .transcriptionFailed(let id):
+            guard state.activeSessionID == id else { return state }
+            return VoiceNoteLifecycleState(phase: .failedRetryable(id))
+        case .retryRequested(let id):
+            guard state.activeSessionID == nil || state.activeSessionID == id else { return state }
+            return VoiceNoteLifecycleState(phase: .transcriptionQueued(id))
+        case .cancelRequested(let id):
+            guard state.activeSessionID == nil || state.activeSessionID == id else { return state }
+            return VoiceNoteLifecycleState(phase: .cancelling(id))
+        case .finished(let id):
+            guard state.activeSessionID == id else { return state }
+            return VoiceNoteLifecycleState()
+        }
+    }
+}
+
+struct VoiceNoteLifecycleRunner {
+    let sessionID: UUID
+    var checkpointTask: Task<Void, Never>?
+    var thresholdTask: Task<Void, Never>?
+    var transcriptionTask: Task<Void, Never>?
+
+    mutating func cancelAll() {
+        checkpointTask?.cancel()
+        thresholdTask?.cancel()
+        transcriptionTask?.cancel()
+        checkpointTask = nil
+        thresholdTask = nil
+        transcriptionTask = nil
+    }
+}
+
+enum VoiceNoteAudioRetentionPolicy {
+    static func shouldDeleteAudioAfterFailure(_ session: RecordingSession) -> Bool {
+        !session.protectedAudioUntilTranscriptCompletes && !session.keepsAudioRecording
+    }
+
+    static func shouldDeleteAudioAfterSuccess(_ session: RecordingSession) -> Bool {
+        !session.keepsAudioRecording
+    }
+}

--- a/Muesli/VoiceNoteLifecycle.swift
+++ b/Muesli/VoiceNoteLifecycle.swift
@@ -266,6 +266,18 @@ enum VoiceNoteAudioRetentionPolicy {
     }
 }
 
+struct VoiceNoteRecoveryInventory {
+    let sessions: [RecordingSession]
+
+    static func load(
+        _ loader: () throws -> [RecordingSession]
+    ) -> Result<VoiceNoteRecoveryInventory, Error> {
+        Result {
+            VoiceNoteRecoveryInventory(sessions: try loader())
+        }
+    }
+}
+
 enum VoiceNoteFailureLifecycleDisposition: Equatable {
     case retryable
     case finished

--- a/MuesliKeyboard/KeyboardController.swift
+++ b/MuesliKeyboard/KeyboardController.swift
@@ -381,11 +381,12 @@ final class KeyboardController {
 
     func startObservingSharedState() {
         markKeyboardVisible()
+        eventObservationTask?.cancel()
+        let events = eventBus.events()
         refreshLatestDictation()
         prepareLaunchRequestIfNeeded()
-        eventObservationTask?.cancel()
-        eventObservationTask = Task { @MainActor [weak self, eventBus] in
-            for await event in eventBus.events() {
+        eventObservationTask = Task { @MainActor [weak self] in
+            for await event in events {
                 guard !Task.isCancelled, let self else { return }
                 switch event {
                 case .runtimeStatusChanged:

--- a/MuesliKeyboard/KeyboardController.swift
+++ b/MuesliKeyboard/KeyboardController.swift
@@ -7,12 +7,11 @@ final class KeyboardController {
     private static let staleRecordingInterval: TimeInterval = 45
     private static let staleStoppingInterval: TimeInterval = 10
     private static let staleTranscribingInterval: TimeInterval = 120
-    private static let runtimeLevelMinUpdateInterval: TimeInterval = 0.16
-    private static let runtimeLevelMinDelta = 0.02
-
-    private let store = SharedStore()
+    private let store: SharedStore
+    private let eventBus: any CrossProcessEventStreaming
     private let handoffRecoveryPolicy = KeyboardHandoffRecoveryPolicy.keyboardDefaults
-    private var pollingTask: Task<Void, Never>?
+    private var eventObservationTask: Task<Void, Never>?
+    private var commandAcknowledgementTask: Task<Void, Never>?
     private var latestResultID: UUID?
     private var preparedRequest: DictationRequest?
     private var activeRequestID: UUID?
@@ -21,7 +20,6 @@ final class KeyboardController {
     private var latestRuntimeStatus: KeyboardRuntimeStatus?
     private var insertedRequestIDs = Set<UUID>()
     private var cancelledRequestIDs = Set<UUID>()
-    private var lastRuntimeLevelUpdateAt = Date.distantPast
     private var isBlockedByAppVoiceNote = false
 
     var statusText = "Record a voice note first"
@@ -36,6 +34,14 @@ final class KeyboardController {
     var inputLevel = 0.0
     private var lastInsertedCharacterCount = 0
     private var canUseRuntimeStart = false
+
+    init(
+        store: SharedStore? = nil,
+        eventBus: any CrossProcessEventStreaming = DarwinCrossProcessEventBus.shared
+    ) {
+        self.eventBus = eventBus
+        self.store = store ?? SharedStore(eventPoster: eventBus)
+    }
 
     var showsLiveTranscript: Bool {
         activeRequestID != nil
@@ -97,7 +103,7 @@ final class KeyboardController {
             return .openMuesliRecovery
         }
 
-        if latestHandoffState?.phase == .stopRequested {
+        if latestHandoffState.map({ [.stopRequested, .cancelRequested].contains($0.phase) }) == true {
             return .waitingForMuesli
         }
 
@@ -118,7 +124,7 @@ final class KeyboardController {
     var isPrimaryButtonDisabled: Bool {
         isBlockedByAppVoiceNote || recoveryRequestID == nil && (
             dictationPhase == .transcribing
-            || latestHandoffState?.phase == .stopRequested
+            || latestHandoffState.map({ [.stopRequested, .cancelRequested].contains($0.phase) }) == true
         )
     }
 
@@ -131,11 +137,11 @@ final class KeyboardController {
     }
 
     var waveformMode: MuesliFloatingWaveformMode {
-        dictationPhase == .recording ? .level : .waiting
+        .waiting
     }
 
     var waveformLevel: Double? {
-        dictationPhase == .recording ? inputLevel : nil
+        nil
     }
 
     var canCancelActiveDictation: Bool {
@@ -162,6 +168,7 @@ final class KeyboardController {
     }
 
     func primaryLaunchAction() {
+        refreshLatestDictation()
         guard !isBlockedByAppVoiceNote else { return }
         if recoveryRequestID != nil {
             statusText = "Opening Muesli"
@@ -172,6 +179,7 @@ final class KeyboardController {
     }
 
     func primaryAction() {
+        refreshLatestDictation()
         guard !isBlockedByAppVoiceNote else { return }
         switch dictationPhase {
         case .requested, .recording:
@@ -225,6 +233,7 @@ final class KeyboardController {
     }
 
     func startDictation() {
+        refreshLatestDictation()
         guard !isBlockedByAppVoiceNote else { return }
         if hasPendingCancelCommand() {
             try? store.clearPendingCommand()
@@ -239,7 +248,7 @@ final class KeyboardController {
         liveTranscript = ""
         insertedRequestIDs.remove(request.id)
         cancelledRequestIDs.remove(request.id)
-        dictationPhase = .recording
+        dictationPhase = .requested
         statusText = "Opening Muesli"
 
         do {
@@ -253,9 +262,11 @@ final class KeyboardController {
             ))
             if canUseRuntimeStart {
                 try store.saveCommand(.init(requestID: request.id, action: .start))
-                try store.saveStatus(.init(requestID: request.id, phase: .requested, message: "Starting"))
-            } else {
-                try store.saveStatus(.init(requestID: request.id, phase: .requested, message: "Opening Muesli"))
+                awaitCommandAcknowledgement(
+                    requestID: request.id,
+                    action: .start,
+                    requestedPhase: .startRequested
+                )
             }
         } catch {
             statusText = "Enable Full Access"
@@ -277,15 +288,19 @@ final class KeyboardController {
 
         MuesliHaptics.dictationStop()
         do {
-            try store.saveCommand(.init(requestID: activeRequestID, action: .stop))
             try store.saveKeyboardHandoffState(.init(
                 requestID: activeRequestID,
                 phase: .stopRequested,
                 message: "Stopping"
             ))
-            try store.saveStatus(.init(requestID: activeRequestID, phase: .recording, message: "Stopping"))
+            try store.saveCommand(.init(requestID: activeRequestID, action: .stop))
             dictationPhase = .recording
             statusText = "Stopping"
+            awaitCommandAcknowledgement(
+                requestID: activeRequestID,
+                action: .stop,
+                requestedPhase: .stopRequested
+            )
         } catch {
             statusText = "Enable Full Access"
         }
@@ -325,6 +340,7 @@ final class KeyboardController {
     }
 
     func cancelActiveDictation() {
+        refreshLatestDictation()
         guard canCancelActiveDictation else {
             statusText = dictationPhase == .transcribing ? "Transcribing" : statusText
             return
@@ -340,22 +356,19 @@ final class KeyboardController {
 
         MuesliHaptics.dictationStop()
         do {
-            try store.saveCommand(.init(requestID: activeRequestID, action: .cancel))
             try store.saveKeyboardHandoffState(.init(
                 requestID: activeRequestID,
-                phase: .cancelled,
-                message: "Cancelled"
+                phase: .cancelRequested,
+                message: "Cancelling"
             ))
-            try store.saveStatus(.idle)
-            try store.clearPendingRequest()
-            try store.clearKeyboardLiveTranscript()
-            cancelledRequestIDs.insert(activeRequestID)
-            self.activeRequestID = nil
-            recoveryRequestID = nil
-            liveTranscript = ""
-            dictationPhase = .idle
-            statusText = hasLatestDictation ? "Latest ready" : "Ready"
-            prepareLaunchRequestIfNeeded(clearsPendingCommand: false)
+            try store.saveCommand(.init(requestID: activeRequestID, action: .cancel))
+            dictationPhase = .recording
+            statusText = "Cancelling"
+            awaitCommandAcknowledgement(
+                requestID: activeRequestID,
+                action: .cancel,
+                requestedPhase: .cancelRequested
+            )
         } catch {
             statusText = "Enable Full Access"
         }
@@ -366,25 +379,23 @@ final class KeyboardController {
         return cancelledRequestIDs.contains(command.requestID)
     }
 
-    func startPolling() {
+    func startObservingSharedState() {
         markKeyboardVisible()
         refreshLatestDictation()
         prepareLaunchRequestIfNeeded()
-        pollingTask?.cancel()
-        pollingTask = Task { @MainActor [weak self] in
-            var lastFullRefresh = Date.distantPast
-            while !Task.isCancelled {
-                guard let self else { return }
-
-                if self.dictationPhase == .recording,
-                   Date().timeIntervalSince(lastFullRefresh) < 0.45
-                {
-                    self.refreshRuntimeLevelOnly()
-                    try? await Task.sleep(for: .milliseconds(125))
-                } else {
+        eventObservationTask?.cancel()
+        eventObservationTask = Task { @MainActor [weak self, eventBus] in
+            for await event in eventBus.events() {
+                guard !Task.isCancelled, let self else { return }
+                switch event {
+                case .runtimeStatusChanged:
+                    self.refreshRuntimeStatus()
+                case .liveTranscriptChanged:
+                    self.refreshLiveTranscript()
+                case .handoffStatusChanged, .resultChanged, .ownershipChanged:
                     self.refreshLatestDictation()
-                    lastFullRefresh = Date()
-                    try? await Task.sleep(for: self.dictationPhase == .recording ? .milliseconds(125) : .milliseconds(500))
+                case .commandChanged:
+                    break
                 }
             }
         }
@@ -398,20 +409,11 @@ final class KeyboardController {
         }
     }
 
-    func stopPolling() {
-        pollingTask?.cancel()
-        pollingTask = nil
-    }
-
-    private func refreshRuntimeLevelOnly() {
-        do {
-            let runtimeStatus = try store.keyboardRuntimeStatus()
-            latestRuntimeStatus = runtimeStatus
-            apply(runtimeStatus: runtimeStatus)
-        } catch {
-            apply(runtimeStatus: latestRuntimeStatus)
-            inputLevel = 0
-        }
+    func stopObservingSharedState() {
+        eventObservationTask?.cancel()
+        eventObservationTask = nil
+        commandAcknowledgementTask?.cancel()
+        commandAcknowledgementTask = nil
     }
 
     private func refreshLatestDictation() {
@@ -419,16 +421,21 @@ final class KeyboardController {
             let runtimeStatus = try store.keyboardRuntimeStatus()
             latestRuntimeStatus = runtimeStatus
             apply(runtimeStatus: runtimeStatus)
+            let status = try store.status()
 
             let handoffState = try store.keyboardHandoffState()
             latestHandoffState = handoffState
             apply(handoffState: handoffState)
             apply(liveTranscript: try store.keyboardLiveTranscript())
 
-            if handoffState.requestID == nil
-                || [.idle, .failed, .cancelled, .inserted].contains(handoffState.phase) {
-                let status = try store.status()
+            let statusBelongsToAppVoiceNote = applyAppVoiceNoteOwnership(status: status)
+            if !statusBelongsToAppVoiceNote,
+               (handoffState.requestID == nil
+                || [.idle, .failed, .cancelled, .inserted].contains(handoffState.phase)) {
                 apply(status: status)
+            }
+            if isBlockedByAppVoiceNote {
+                return
             }
 
             guard let result = try store.resultsHistory().first else {
@@ -462,8 +469,31 @@ final class KeyboardController {
         }
     }
 
+    private func refreshRuntimeStatus() {
+        do {
+            let runtimeStatus = try store.keyboardRuntimeStatus()
+            latestRuntimeStatus = runtimeStatus
+            apply(runtimeStatus: runtimeStatus)
+        } catch {
+            statusText = "Waiting for Full Access"
+        }
+    }
+
+    private func refreshLiveTranscript() {
+        do {
+            apply(liveTranscript: try store.keyboardLiveTranscript())
+        } catch {
+            statusText = "Waiting for Full Access"
+        }
+    }
+
     private func apply(handoffState: KeyboardHandoffState) {
         guard let requestID = handoffState.requestID else { return }
+
+        if ![.startRequested, .stopRequested, .cancelRequested].contains(handoffState.phase) {
+            commandAcknowledgementTask?.cancel()
+            commandAcknowledgementTask = nil
+        }
 
         if cancelledRequestIDs.contains(requestID) {
             if [.cancelled, .idle, .failed].contains(handoffState.phase),
@@ -484,6 +514,7 @@ final class KeyboardController {
             .startAcknowledged,
             .recordingStarted,
             .stopRequested,
+            .cancelRequested,
             .stopAcknowledged,
             .audioSaved,
             .transcribingStarted,
@@ -521,6 +552,9 @@ final class KeyboardController {
         case .stopRequested:
             dictationPhase = .recording
             statusText = handoffState.message ?? "Stopping"
+        case .cancelRequested:
+            dictationPhase = .recording
+            statusText = handoffState.message ?? "Cancelling"
         case .stopAcknowledged:
             dictationPhase = .transcribing
             inputLevel = 0
@@ -546,7 +580,10 @@ final class KeyboardController {
         case .recoveryRequested:
             dictationPhase = .failed
             recoveryRequestID = requestID
-            launchURL = makeLaunchURL(for: requestID, action: MuesliAppConstants.startAction)
+            launchURL = makeLaunchURL(
+                for: requestID,
+                action: urlAction(for: handoffState.recoveryAction ?? .start)
+            )
             statusText = handoffState.message ?? "Open Muesli to finish"
         case .failed:
             dictationPhase = .failed
@@ -556,6 +593,7 @@ final class KeyboardController {
             inputLevel = 0
             statusText = handoffState.message ?? "Voice note failed"
         case .cancelled:
+            cancelledRequestIDs.insert(requestID)
             dictationPhase = .idle
             activeRequestID = nil
             recoveryRequestID = nil
@@ -566,10 +604,8 @@ final class KeyboardController {
     }
 
     private func apply(runtimeStatus: KeyboardRuntimeStatus?) {
-        let now = Date()
-        let isRecent = runtimeStatus.map { now.timeIntervalSince($0.updatedAt) < 8 } ?? false
-        applyRuntimeInputLevel(isRecent ? (runtimeStatus?.inputLevel ?? 0) : 0, now: now)
-        canUseRuntimeStart = runtimeStatus?.canAcceptStartCommand == true && isRecent
+        inputLevel = 0
+        canUseRuntimeStart = runtimeStatus?.canAcceptStartCommand == true
 
         guard activeRequestID == nil, canUseRuntimeStart else { return }
         guard let runtimeRequestID = runtimeStatus?.activeRequestID,
@@ -584,31 +620,9 @@ final class KeyboardController {
         }
     }
 
-    private func applyRuntimeInputLevel(_ rawLevel: Double, now: Date) {
-        let level = min(max(rawLevel, 0), 1)
-
-        guard level > 0 else {
-            if inputLevel != 0 {
-                inputLevel = 0
-            }
-            lastRuntimeLevelUpdateAt = now
-            return
-        }
-
-        let hasMeaningfulDelta = abs(inputLevel - level) >= Self.runtimeLevelMinDelta
-        let hasReachedCadence = now.timeIntervalSince(lastRuntimeLevelUpdateAt) >= Self.runtimeLevelMinUpdateInterval
-
-        guard hasMeaningfulDelta || hasReachedCadence else {
-            return
-        }
-
-        inputLevel = level
-        lastRuntimeLevelUpdateAt = now
-    }
-
     private func apply(status: DictationStatus) {
+        guard !applyAppVoiceNoteOwnership(status: status) else { return }
         guard let requestID = status.requestID else {
-            isBlockedByAppVoiceNote = false
             if activeRequestID != nil {
                 activeRequestID = nil
                 dictationPhase = .idle
@@ -616,21 +630,6 @@ final class KeyboardController {
             }
             return
         }
-
-        if let session = try? store.recordingSession(requestID: requestID),
-           !session.isKeyboardOwnedVoiceNote {
-            isBlockedByAppVoiceNote = session.hasActiveVoiceNoteWork
-            if isBlockedByAppVoiceNote {
-                activeRequestID = nil
-                recoveryRequestID = nil
-                dictationPhase = .idle
-                liveTranscript = ""
-                inputLevel = 0
-                statusText = "Finish the voice note in Muesli"
-            }
-            return
-        }
-        isBlockedByAppVoiceNote = false
 
         if activeRequestID == nil, preparedRequest?.id == requestID, status.phase == .requested {
             return
@@ -689,6 +688,28 @@ final class KeyboardController {
         }
     }
 
+    @discardableResult
+    private func applyAppVoiceNoteOwnership(status: DictationStatus) -> Bool {
+        guard let requestID = status.requestID,
+              let session = try? store.recordingSession(requestID: requestID),
+              !session.isKeyboardOwnedVoiceNote
+        else {
+            isBlockedByAppVoiceNote = false
+            return false
+        }
+
+        isBlockedByAppVoiceNote = session.hasActiveVoiceNoteWork
+        if isBlockedByAppVoiceNote {
+            activeRequestID = nil
+            recoveryRequestID = nil
+            dictationPhase = .idle
+            liveTranscript = ""
+            inputLevel = 0
+            statusText = "Finish the voice note in Muesli"
+        }
+        return true
+    }
+
     private func apply(liveTranscript transcript: KeyboardLiveTranscript?) {
         guard let activeRequestID else {
             liveTranscript = ""
@@ -708,7 +729,7 @@ final class KeyboardController {
     private func markForRecoveryIfStale(_ status: DictationStatus, requestID: UUID) -> Bool {
         if let latestRuntimeStatus,
            latestRuntimeStatus.activeRequestID == requestID,
-           Date().timeIntervalSince(latestRuntimeStatus.updatedAt) < 8,
+           Date().timeIntervalSince(latestRuntimeStatus.updatedAt) < handoffRecoveryPolicy.runtimeFreshnessInterval,
            [.recording, .transcribing].contains(latestRuntimeStatus.phase)
         {
             recoveryRequestID = nil
@@ -804,8 +825,73 @@ final class KeyboardController {
 
     }
 
+    private func awaitCommandAcknowledgement(
+        requestID: UUID,
+        action: DictationCommandAction,
+        requestedPhase: KeyboardHandoffPhase
+    ) {
+        commandAcknowledgementTask?.cancel()
+        commandAcknowledgementTask = Task { @MainActor [weak self, eventBus] in
+            try? await Task.sleep(for: .milliseconds(750))
+            guard !Task.isCancelled, let self else { return }
+            self.refreshLatestDictation()
+            guard self.isAwaitingAcknowledgement(requestID: requestID, phase: requestedPhase) else { return }
+            eventBus.post(.commandChanged)
+
+            try? await Task.sleep(for: .milliseconds(1_250))
+            guard !Task.isCancelled else { return }
+            self.refreshLatestDictation()
+            guard self.isAwaitingAcknowledgement(requestID: requestID, phase: requestedPhase) else { return }
+
+            let urlAction: String
+            let message: String
+            switch action {
+            case .start:
+                urlAction = MuesliAppConstants.startAction
+                message = "Open Muesli to start"
+            case .stop:
+                urlAction = MuesliAppConstants.stopAction
+                message = "Open Muesli to finish"
+            case .cancel:
+                urlAction = MuesliAppConstants.cancelAction
+                message = "Open Muesli to cancel"
+            }
+            let recovery = KeyboardHandoffState(
+                requestID: requestID,
+                phase: .recoveryRequested,
+                message: message,
+                recoveryAttemptCount: 1,
+                recoveryAction: action
+            )
+            try? self.store.saveKeyboardHandoffState(recovery)
+            self.latestHandoffState = recovery
+            self.canUseRuntimeStart = false
+            self.recoveryRequestID = requestID
+            self.activeRequestID = nil
+            self.dictationPhase = .failed
+            self.launchURL = self.makeLaunchURL(for: requestID, action: urlAction)
+            self.statusText = message
+        }
+    }
+
+    private func isAwaitingAcknowledgement(
+        requestID: UUID,
+        phase: KeyboardHandoffPhase
+    ) -> Bool {
+        guard let state = try? store.keyboardHandoffState() else { return false }
+        return state.requestID == requestID && state.phase == phase
+    }
+
     private func makeLaunchURL(for request: DictationRequest) -> URL? {
         makeLaunchURL(for: request.id, action: MuesliAppConstants.startAction)
+    }
+
+    private func urlAction(for action: DictationCommandAction) -> String {
+        switch action {
+        case .start: MuesliAppConstants.startAction
+        case .stop: MuesliAppConstants.stopAction
+        case .cancel: MuesliAppConstants.cancelAction
+        }
     }
 
     private func makeLaunchURL(for requestID: UUID, action: String) -> URL? {

--- a/MuesliKeyboard/KeyboardController.swift
+++ b/MuesliKeyboard/KeyboardController.swift
@@ -22,6 +22,7 @@ final class KeyboardController {
     private var insertedRequestIDs = Set<UUID>()
     private var cancelledRequestIDs = Set<UUID>()
     private var lastRuntimeLevelUpdateAt = Date.distantPast
+    private var isBlockedByAppVoiceNote = false
 
     var statusText = "Record a voice note first"
     var hasLatestDictation = false
@@ -44,6 +45,8 @@ final class KeyboardController {
 
     var primaryButtonTitle: String {
         return switch primaryButtonRole {
+        case .blocked:
+            "Voice Note Active"
         case .openMuesliRecovery:
             "Open Muesli"
         case .waitingForMuesli:
@@ -63,6 +66,8 @@ final class KeyboardController {
 
     var primaryButtonIcon: String {
         return switch primaryButtonRole {
+        case .blocked:
+            "waveform"
         case .openMuesliRecovery:
             "arrow.up.forward.app"
         case .waitingForMuesli:
@@ -85,6 +90,9 @@ final class KeyboardController {
     }
 
     var primaryButtonRole: KeyboardPrimaryButtonRole {
+        if isBlockedByAppVoiceNote {
+            return .blocked
+        }
         if recoveryRequestID != nil {
             return .openMuesliRecovery
         }
@@ -108,7 +116,7 @@ final class KeyboardController {
     }
 
     var isPrimaryButtonDisabled: Bool {
-        recoveryRequestID == nil && (
+        isBlockedByAppVoiceNote || recoveryRequestID == nil && (
             dictationPhase == .transcribing
             || latestHandoffState?.phase == .stopRequested
         )
@@ -142,17 +150,19 @@ final class KeyboardController {
     }
 
     var opensMuesliFromPrimaryButton: Bool {
-        recoveryRequestID != nil
-            || !canUseRuntimeStart
-            && (
-                dictationPhase == .idle
-                    || dictationPhase == .finished
-                    || dictationPhase == .failed
-                    || (dictationPhase == .requested && activeRequestID == nil)
-            )
+        !isBlockedByAppVoiceNote
+            && (recoveryRequestID != nil
+                || !canUseRuntimeStart
+                && (
+                    dictationPhase == .idle
+                        || dictationPhase == .finished
+                        || dictationPhase == .failed
+                        || (dictationPhase == .requested && activeRequestID == nil)
+                ))
     }
 
     func primaryLaunchAction() {
+        guard !isBlockedByAppVoiceNote else { return }
         if recoveryRequestID != nil {
             statusText = "Opening Muesli"
             return
@@ -162,6 +172,7 @@ final class KeyboardController {
     }
 
     func primaryAction() {
+        guard !isBlockedByAppVoiceNote else { return }
         switch dictationPhase {
         case .requested, .recording:
             stopActiveDictation()
@@ -214,6 +225,7 @@ final class KeyboardController {
     }
 
     func startDictation() {
+        guard !isBlockedByAppVoiceNote else { return }
         if hasPendingCancelCommand() {
             try? store.clearPendingCommand()
         }
@@ -413,10 +425,16 @@ final class KeyboardController {
             apply(handoffState: handoffState)
             apply(liveTranscript: try store.keyboardLiveTranscript())
 
+            if handoffState.requestID == nil
+                || [.idle, .failed, .cancelled, .inserted].contains(handoffState.phase) {
+                let status = try store.status()
+                apply(status: status)
+            }
+
             guard let result = try store.resultsHistory().first else {
                 latestResultID = nil
                 hasLatestDictation = false
-                if activeRequestID == nil {
+                if activeRequestID == nil, !isBlockedByAppVoiceNote {
                     statusText = "Ready"
                 }
                 return
@@ -428,17 +446,14 @@ final class KeyboardController {
                 return
             }
 
-            if handoffState.requestID == nil || handoffState.phase == .idle {
-                let status = try store.status()
-                apply(status: status)
-            }
-
             if latestResultID != result.id {
                 latestResultID = result.id
-                if activeRequestID == nil {
+                if activeRequestID == nil, !isBlockedByAppVoiceNote {
                     statusText = "Latest ready"
                 }
-            } else if activeRequestID == nil && statusText != "Inserted" {
+            } else if activeRequestID == nil,
+                      !isBlockedByAppVoiceNote,
+                      statusText != "Inserted" {
                 statusText = "Latest ready"
             }
         } catch {
@@ -593,6 +608,7 @@ final class KeyboardController {
 
     private func apply(status: DictationStatus) {
         guard let requestID = status.requestID else {
+            isBlockedByAppVoiceNote = false
             if activeRequestID != nil {
                 activeRequestID = nil
                 dictationPhase = .idle
@@ -600,6 +616,21 @@ final class KeyboardController {
             }
             return
         }
+
+        if let session = try? store.recordingSession(requestID: requestID),
+           !session.isKeyboardOwnedVoiceNote {
+            isBlockedByAppVoiceNote = session.hasActiveVoiceNoteWork
+            if isBlockedByAppVoiceNote {
+                activeRequestID = nil
+                recoveryRequestID = nil
+                dictationPhase = .idle
+                liveTranscript = ""
+                inputLevel = 0
+                statusText = "Finish the voice note in Muesli"
+            }
+            return
+        }
+        isBlockedByAppVoiceNote = false
 
         if activeRequestID == nil, preparedRequest?.id == requestID, status.phase == .requested {
             return
@@ -796,6 +827,7 @@ final class KeyboardController {
 }
 
 enum KeyboardPrimaryButtonRole {
+    case blocked
     case openMuesliRecovery
     case waitingForMuesli
     case openMuesliRequested

--- a/MuesliKeyboard/KeyboardViewController.swift
+++ b/MuesliKeyboard/KeyboardViewController.swift
@@ -43,16 +43,16 @@ final class KeyboardViewController: UIInputViewController {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         controller.markKeyboardVisible()
-        controller.startPolling()
+        controller.startObservingSharedState()
     }
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        controller.startPolling()
+        controller.startObservingSharedState()
     }
 
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
-        controller.stopPolling()
+        controller.stopObservingSharedState()
     }
 }

--- a/Shared/AppConstants.swift
+++ b/Shared/AppConstants.swift
@@ -10,6 +10,7 @@ enum MuesliAppConstants {
     static let resetOnboardingPath = "/reset-onboarding"
     static let resetOnboardingLaunchArgument = "--muesli-reset-onboarding"
     static let uiTestingLaunchArgument = "--muesli-ui-testing"
+    static let longVoiceNoteUITestLaunchArgument = "--muesli-ui-testing-long-voice-note"
     static let requestQueryItem = "request"
     static let actionQueryItem = "action"
     static let sourceQueryItem = "source"

--- a/Shared/AppConstants.swift
+++ b/Shared/AppConstants.swift
@@ -11,6 +11,7 @@ enum MuesliAppConstants {
     static let resetOnboardingLaunchArgument = "--muesli-reset-onboarding"
     static let uiTestingLaunchArgument = "--muesli-ui-testing"
     static let longVoiceNoteUITestLaunchArgument = "--muesli-ui-testing-long-voice-note"
+    static let completedLongVoiceNoteUITestLaunchArgument = "--muesli-ui-testing-completed-long-voice-note"
     static let requestQueryItem = "request"
     static let actionQueryItem = "action"
     static let sourceQueryItem = "source"

--- a/Shared/AppConstants.swift
+++ b/Shared/AppConstants.swift
@@ -17,4 +17,5 @@ enum MuesliAppConstants {
     static let sourceQueryItem = "source"
     static let startAction = "start"
     static let stopAction = "stop"
+    static let cancelAction = "cancel"
 }

--- a/Shared/CrossProcessEventBus.swift
+++ b/Shared/CrossProcessEventBus.swift
@@ -1,0 +1,104 @@
+import CoreFoundation
+import Foundation
+
+enum CrossProcessEvent: String, CaseIterable, Sendable {
+    case commandChanged = "command.changed"
+    case handoffStatusChanged = "handoff-status.changed"
+    case runtimeStatusChanged = "runtime-status.changed"
+    case liveTranscriptChanged = "live-transcript.changed"
+    case resultChanged = "result.changed"
+    case ownershipChanged = "ownership.changed"
+
+    var notificationName: String {
+        "com.phequals7.muesli.\(rawValue).v1"
+    }
+
+    init?(notificationName: String) {
+        guard let event = Self.allCases.first(where: { $0.notificationName == notificationName }) else {
+            return nil
+        }
+        self = event
+    }
+}
+
+protocol CrossProcessEventPosting: Sendable {
+    func post(_ event: CrossProcessEvent)
+}
+
+protocol CrossProcessEventStreaming: CrossProcessEventPosting {
+    func events() -> AsyncStream<CrossProcessEvent>
+}
+
+final class DarwinCrossProcessEventBus: CrossProcessEventStreaming, @unchecked Sendable {
+    static let shared = DarwinCrossProcessEventBus()
+
+    private let lock = NSLock()
+    private var continuations: [UUID: AsyncStream<CrossProcessEvent>.Continuation] = [:]
+    private let center = CFNotificationCenterGetDarwinNotifyCenter()
+
+    private init() {
+        for event in CrossProcessEvent.allCases {
+            CFNotificationCenterAddObserver(
+                center,
+                Unmanaged.passUnretained(self).toOpaque(),
+                crossProcessEventCallback,
+                event.notificationName as CFString,
+                nil,
+                .deliverImmediately
+            )
+        }
+    }
+
+    deinit {
+        CFNotificationCenterRemoveEveryObserver(
+            center,
+            Unmanaged.passUnretained(self).toOpaque()
+        )
+    }
+
+    func post(_ event: CrossProcessEvent) {
+        CFNotificationCenterPostNotification(
+            center,
+            CFNotificationName(event.notificationName as CFString),
+            nil,
+            nil,
+            true
+        )
+    }
+
+    func events() -> AsyncStream<CrossProcessEvent> {
+        let id = UUID()
+        return AsyncStream(bufferingPolicy: .bufferingNewest(32)) { continuation in
+            lock.lock()
+            continuations[id] = continuation
+            lock.unlock()
+            continuation.onTermination = { [weak self] _ in
+                self?.removeContinuation(id: id)
+            }
+        }
+    }
+
+    fileprivate func receive(notificationName: String) {
+        guard let event = CrossProcessEvent(notificationName: notificationName) else { return }
+        lock.lock()
+        let currentContinuations = Array(continuations.values)
+        lock.unlock()
+        for continuation in currentContinuations {
+            continuation.yield(event)
+        }
+    }
+
+    private func removeContinuation(id: UUID) {
+        lock.lock()
+        continuations[id] = nil
+        lock.unlock()
+    }
+}
+
+private let crossProcessEventCallback: CFNotificationCallback = { _, observer, name, _, _ in
+    guard let observer,
+          let name
+    else { return }
+    let bus = Unmanaged<DarwinCrossProcessEventBus>.fromOpaque(observer).takeUnretainedValue()
+    bus.receive(notificationName: name.rawValue as String)
+}

--- a/Shared/DictationModels.swift
+++ b/Shared/DictationModels.swift
@@ -440,6 +440,16 @@ struct RecordingSession: Codable, Sendable, Equatable, Identifiable {
         return (endedAt ?? .now).timeIntervalSince(startedAt)
     }
 
+    var isKeyboardOwnedVoiceNote: Bool {
+        kind == .keyboardDictation
+            || source?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "keyboard"
+    }
+
+    var hasActiveVoiceNoteWork: Bool {
+        kind != .meeting
+            && [.recording, .transcriptionQueued, .transcribing].contains(phase)
+    }
+
     var syncOrigin: SyncOrigin {
         SyncOrigin.classify(
             source: source,

--- a/Shared/DictationModels.swift
+++ b/Shared/DictationModels.swift
@@ -72,6 +72,15 @@ enum RecordingSessionPhase: String, Codable, Sendable, Equatable {
     case cancelled
 }
 
+enum VoiceNoteTranscriptionFailureReason: String, Codable, Sendable, Equatable {
+    case timeout
+    case interrupted
+    case engineFailure
+    case audioUnavailable
+    case checkpointFailure
+    case unknown
+}
+
 enum MeetingProcessingState: String, Codable, Sendable, Equatable {
     case notStarted
     case processing
@@ -365,6 +374,14 @@ struct RecordingSession: Codable, Sendable, Equatable, Identifiable {
     var cloudRecordName: String?
     var manualNotes: String?
     var errorMessage: String?
+    var isLongForm: Bool
+    var longFormActivatedAt: Date?
+    var longFormThresholdSeconds: Int?
+    var protectedAudioUntilTranscriptCompletes: Bool
+    var transcriptionRetryCount: Int
+    var lastTranscriptionAttemptAt: Date?
+    var lastTranscriptionFailureReason: VoiceNoteTranscriptionFailureReason?
+    var scratchpadText: String?
 
     init(
         id: UUID = UUID(),
@@ -382,7 +399,15 @@ struct RecordingSession: Codable, Sendable, Equatable, Identifiable {
         source: String? = nil,
         cloudRecordName: String? = nil,
         manualNotes: String? = nil,
-        errorMessage: String? = nil
+        errorMessage: String? = nil,
+        isLongForm: Bool = false,
+        longFormActivatedAt: Date? = nil,
+        longFormThresholdSeconds: Int? = nil,
+        protectedAudioUntilTranscriptCompletes: Bool = false,
+        transcriptionRetryCount: Int = 0,
+        lastTranscriptionAttemptAt: Date? = nil,
+        lastTranscriptionFailureReason: VoiceNoteTranscriptionFailureReason? = nil,
+        scratchpadText: String? = nil
     ) {
         self.id = id
         self.requestID = requestID
@@ -400,6 +425,14 @@ struct RecordingSession: Codable, Sendable, Equatable, Identifiable {
         self.cloudRecordName = cloudRecordName
         self.manualNotes = manualNotes
         self.errorMessage = errorMessage
+        self.isLongForm = isLongForm
+        self.longFormActivatedAt = longFormActivatedAt
+        self.longFormThresholdSeconds = longFormThresholdSeconds
+        self.protectedAudioUntilTranscriptCompletes = protectedAudioUntilTranscriptCompletes
+        self.transcriptionRetryCount = transcriptionRetryCount
+        self.lastTranscriptionAttemptAt = lastTranscriptionAttemptAt
+        self.lastTranscriptionFailureReason = lastTranscriptionFailureReason
+        self.scratchpadText = scratchpadText
     }
 
     var duration: TimeInterval? {
@@ -432,6 +465,14 @@ struct RecordingSession: Codable, Sendable, Equatable, Identifiable {
         case cloudRecordName
         case manualNotes
         case errorMessage
+        case isLongForm
+        case longFormActivatedAt
+        case longFormThresholdSeconds
+        case protectedAudioUntilTranscriptCompletes
+        case transcriptionRetryCount
+        case lastTranscriptionAttemptAt
+        case lastTranscriptionFailureReason
+        case scratchpadText
     }
 
     init(from decoder: Decoder) throws {
@@ -452,6 +493,20 @@ struct RecordingSession: Codable, Sendable, Equatable, Identifiable {
         cloudRecordName = try container.decodeIfPresent(String.self, forKey: .cloudRecordName)
         manualNotes = try container.decodeIfPresent(String.self, forKey: .manualNotes)
         errorMessage = try container.decodeIfPresent(String.self, forKey: .errorMessage)
+        isLongForm = try container.decodeIfPresent(Bool.self, forKey: .isLongForm) ?? false
+        longFormActivatedAt = try container.decodeIfPresent(Date.self, forKey: .longFormActivatedAt)
+        longFormThresholdSeconds = try container.decodeIfPresent(Int.self, forKey: .longFormThresholdSeconds)
+        protectedAudioUntilTranscriptCompletes = try container.decodeIfPresent(
+            Bool.self,
+            forKey: .protectedAudioUntilTranscriptCompletes
+        ) ?? false
+        transcriptionRetryCount = try container.decodeIfPresent(Int.self, forKey: .transcriptionRetryCount) ?? 0
+        lastTranscriptionAttemptAt = try container.decodeIfPresent(Date.self, forKey: .lastTranscriptionAttemptAt)
+        lastTranscriptionFailureReason = try container.decodeIfPresent(
+            VoiceNoteTranscriptionFailureReason.self,
+            forKey: .lastTranscriptionFailureReason
+        )
+        scratchpadText = try container.decodeIfPresent(String.self, forKey: .scratchpadText)
     }
 }
 

--- a/Shared/DictationModels.swift
+++ b/Shared/DictationModels.swift
@@ -466,6 +466,14 @@ struct RecordingSession: Codable, Sendable, Equatable, Identifiable {
         return audioFileName == nil ? .unavailable : .audioReferenceOnly
     }
 
+    var canRetryVoiceNoteTranscription: Bool {
+        kind != .meeting
+            && isLongForm
+            && phase == .failed
+            && voiceNoteDurabilityEvidence == .durableCheckpoint
+            && audioFileName != nil
+    }
+
     var syncOrigin: SyncOrigin {
         SyncOrigin.classify(
             source: source,

--- a/Shared/DictationModels.swift
+++ b/Shared/DictationModels.swift
@@ -21,6 +21,7 @@ enum KeyboardHandoffPhase: String, Codable, Sendable, Equatable {
     case startAcknowledged
     case recordingStarted
     case stopRequested
+    case cancelRequested
     case stopAcknowledged
     case audioSaved
     case transcribingStarted
@@ -36,7 +37,7 @@ enum KeyboardHandoffPhase: String, Codable, Sendable, Equatable {
             .idle
         case .startRequested, .startAcknowledged:
             .requested
-        case .recordingStarted, .stopRequested:
+        case .recordingStarted, .stopRequested, .cancelRequested:
             .recording
         case .stopAcknowledged, .audioSaved, .transcribingStarted, .resultReady:
             .transcribing
@@ -204,6 +205,7 @@ struct KeyboardHandoffState: Codable, Sendable, Equatable {
     let phase: KeyboardHandoffPhase
     let message: String?
     let recoveryAttemptCount: Int
+    let recoveryAction: DictationCommandAction?
     let createdAt: Date
     let updatedAt: Date
 
@@ -212,6 +214,7 @@ struct KeyboardHandoffState: Codable, Sendable, Equatable {
         phase: KeyboardHandoffPhase,
         message: String? = nil,
         recoveryAttemptCount: Int = 0,
+        recoveryAction: DictationCommandAction? = nil,
         createdAt: Date = .now,
         updatedAt: Date = .now
     ) {
@@ -219,6 +222,7 @@ struct KeyboardHandoffState: Codable, Sendable, Equatable {
         self.phase = phase
         self.message = message
         self.recoveryAttemptCount = recoveryAttemptCount
+        self.recoveryAction = recoveryAction
         self.createdAt = createdAt
         self.updatedAt = updatedAt
     }
@@ -227,6 +231,7 @@ struct KeyboardHandoffState: Codable, Sendable, Equatable {
         to phase: KeyboardHandoffPhase,
         message: String? = nil,
         recoveryAttemptCount: Int? = nil,
+        recoveryAction: DictationCommandAction? = nil,
         updatedAt: Date = .now
     ) -> KeyboardHandoffState {
         KeyboardHandoffState(
@@ -234,6 +239,7 @@ struct KeyboardHandoffState: Codable, Sendable, Equatable {
             phase: phase,
             message: message,
             recoveryAttemptCount: recoveryAttemptCount ?? self.recoveryAttemptCount,
+            recoveryAction: recoveryAction ?? self.recoveryAction,
             createdAt: createdAt,
             updatedAt: updatedAt
         )
@@ -260,7 +266,7 @@ struct KeyboardHandoffRecoveryPolicy: Sendable, Equatable {
         staleRecordingInterval: 45,
         staleStopRequestInterval: 8,
         staleTranscribingInterval: 120,
-        runtimeFreshnessInterval: 8
+        runtimeFreshnessInterval: 15
     )
 
     func action(
@@ -297,6 +303,10 @@ struct KeyboardHandoffRecoveryPolicy: Sendable, Equatable {
             threshold = staleStopRequestInterval
             retryAction = .stop
             recoveryMessage = "Open Muesli to finish"
+        case .cancelRequested:
+            threshold = staleStopRequestInterval
+            retryAction = .cancel
+            recoveryMessage = "Open Muesli to cancel"
         case .stopAcknowledged, .audioSaved, .transcribingStarted:
             threshold = staleTranscribingInterval
             retryAction = nil
@@ -312,9 +322,14 @@ struct KeyboardHandoffRecoveryPolicy: Sendable, Equatable {
         }
 
         if let retryAction, state.recoveryAttemptCount == 0, canUseRuntimeStart {
+            let retryMessage = switch retryAction {
+            case .start: "Retrying start"
+            case .stop: "Retrying stop"
+            case .cancel: "Retrying cancellation"
+            }
             let retrying = state.advanced(
                 to: state.phase,
-                message: retryAction == .start ? "Retrying start" : "Retrying stop",
+                message: retryMessage,
                 recoveryAttemptCount: 1,
                 updatedAt: now
             )
@@ -325,6 +340,7 @@ struct KeyboardHandoffRecoveryPolicy: Sendable, Equatable {
             to: .recoveryRequested,
             message: recoveryMessage,
             recoveryAttemptCount: max(state.recoveryAttemptCount, 1),
+            recoveryAction: retryAction,
             updatedAt: now
         )
         return .recover(recovery)
@@ -389,6 +405,7 @@ struct RecordingSession: Codable, Sendable, Equatable, Identifiable {
     var lastTranscriptionAttemptAt: Date?
     var lastTranscriptionFailureReason: VoiceNoteTranscriptionFailureReason?
     var scratchpadText: String?
+    var longFormRecoveryValidatedAt: Date?
 
     init(
         id: UUID = UUID(),
@@ -415,7 +432,8 @@ struct RecordingSession: Codable, Sendable, Equatable, Identifiable {
         transcriptionRetryCount: Int = 0,
         lastTranscriptionAttemptAt: Date? = nil,
         lastTranscriptionFailureReason: VoiceNoteTranscriptionFailureReason? = nil,
-        scratchpadText: String? = nil
+        scratchpadText: String? = nil,
+        longFormRecoveryValidatedAt: Date? = nil
     ) {
         self.id = id
         self.requestID = requestID
@@ -442,6 +460,7 @@ struct RecordingSession: Codable, Sendable, Equatable, Identifiable {
         self.lastTranscriptionAttemptAt = lastTranscriptionAttemptAt
         self.lastTranscriptionFailureReason = lastTranscriptionFailureReason
         self.scratchpadText = scratchpadText
+        self.longFormRecoveryValidatedAt = longFormRecoveryValidatedAt
     }
 
     var duration: TimeInterval? {
@@ -508,6 +527,7 @@ struct RecordingSession: Codable, Sendable, Equatable, Identifiable {
         case lastTranscriptionAttemptAt
         case lastTranscriptionFailureReason
         case scratchpadText
+        case longFormRecoveryValidatedAt
     }
 
     init(from decoder: Decoder) throws {
@@ -546,6 +566,10 @@ struct RecordingSession: Codable, Sendable, Equatable, Identifiable {
             forKey: .lastTranscriptionFailureReason
         )
         scratchpadText = try container.decodeIfPresent(String.self, forKey: .scratchpadText)
+        longFormRecoveryValidatedAt = try container.decodeIfPresent(
+            Date.self,
+            forKey: .longFormRecoveryValidatedAt
+        )
     }
 }
 

--- a/Shared/DictationModels.swift
+++ b/Shared/DictationModels.swift
@@ -81,6 +81,12 @@ enum VoiceNoteTranscriptionFailureReason: String, Codable, Sendable, Equatable {
     case unknown
 }
 
+enum VoiceNoteDurabilityEvidence: Sendable, Equatable {
+    case durableCheckpoint
+    case audioReferenceOnly
+    case unavailable
+}
+
 enum MeetingProcessingState: String, Codable, Sendable, Equatable {
     case notStarted
     case processing
@@ -377,6 +383,7 @@ struct RecordingSession: Codable, Sendable, Equatable, Identifiable {
     var isLongForm: Bool
     var longFormActivatedAt: Date?
     var longFormThresholdSeconds: Int?
+    var hasDurableAudioCheckpoint: Bool
     var protectedAudioUntilTranscriptCompletes: Bool
     var transcriptionRetryCount: Int
     var lastTranscriptionAttemptAt: Date?
@@ -403,6 +410,7 @@ struct RecordingSession: Codable, Sendable, Equatable, Identifiable {
         isLongForm: Bool = false,
         longFormActivatedAt: Date? = nil,
         longFormThresholdSeconds: Int? = nil,
+        hasDurableAudioCheckpoint: Bool = false,
         protectedAudioUntilTranscriptCompletes: Bool = false,
         transcriptionRetryCount: Int = 0,
         lastTranscriptionAttemptAt: Date? = nil,
@@ -428,6 +436,7 @@ struct RecordingSession: Codable, Sendable, Equatable, Identifiable {
         self.isLongForm = isLongForm
         self.longFormActivatedAt = longFormActivatedAt
         self.longFormThresholdSeconds = longFormThresholdSeconds
+        self.hasDurableAudioCheckpoint = hasDurableAudioCheckpoint
         self.protectedAudioUntilTranscriptCompletes = protectedAudioUntilTranscriptCompletes
         self.transcriptionRetryCount = transcriptionRetryCount
         self.lastTranscriptionAttemptAt = lastTranscriptionAttemptAt
@@ -448,6 +457,13 @@ struct RecordingSession: Codable, Sendable, Equatable, Identifiable {
     var hasActiveVoiceNoteWork: Bool {
         kind != .meeting
             && [.recording, .transcriptionQueued, .transcribing].contains(phase)
+    }
+
+    var voiceNoteDurabilityEvidence: VoiceNoteDurabilityEvidence {
+        if hasDurableAudioCheckpoint {
+            return .durableCheckpoint
+        }
+        return audioFileName == nil ? .unavailable : .audioReferenceOnly
     }
 
     var syncOrigin: SyncOrigin {
@@ -478,6 +494,7 @@ struct RecordingSession: Codable, Sendable, Equatable, Identifiable {
         case isLongForm
         case longFormActivatedAt
         case longFormThresholdSeconds
+        case hasDurableAudioCheckpoint
         case protectedAudioUntilTranscriptCompletes
         case transcriptionRetryCount
         case lastTranscriptionAttemptAt
@@ -506,6 +523,10 @@ struct RecordingSession: Codable, Sendable, Equatable, Identifiable {
         isLongForm = try container.decodeIfPresent(Bool.self, forKey: .isLongForm) ?? false
         longFormActivatedAt = try container.decodeIfPresent(Date.self, forKey: .longFormActivatedAt)
         longFormThresholdSeconds = try container.decodeIfPresent(Int.self, forKey: .longFormThresholdSeconds)
+        hasDurableAudioCheckpoint = try container.decodeIfPresent(
+            Bool.self,
+            forKey: .hasDurableAudioCheckpoint
+        ) ?? false
         protectedAudioUntilTranscriptCompletes = try container.decodeIfPresent(
             Bool.self,
             forKey: .protectedAudioUntilTranscriptCompletes

--- a/Shared/SharedStore.swift
+++ b/Shared/SharedStore.swift
@@ -15,15 +15,18 @@ enum SharedStoreError: Error, LocalizedError {
 struct SharedStore: Sendable {
     private let appGroupIdentifier: String
     private let overrideContainerURL: URL?
+    private let eventPoster: any CrossProcessEventPosting
     private let encoder: JSONEncoder
     private let decoder: JSONDecoder
 
     init(
         appGroupIdentifier: String = MuesliAppConstants.appGroupIdentifier,
-        containerURL: URL? = nil
+        containerURL: URL? = nil,
+        eventPoster: any CrossProcessEventPosting = DarwinCrossProcessEventBus.shared
     ) {
         self.appGroupIdentifier = appGroupIdentifier
         self.overrideContainerURL = containerURL
+        self.eventPoster = eventPoster
         self.encoder = JSONEncoder()
         self.decoder = JSONDecoder()
     }
@@ -42,6 +45,7 @@ struct SharedStore: Sendable {
 
     func saveCommand(_ command: DictationCommand) throws {
         try database().saveValue(command, key: .pendingCommand)
+        eventPoster.post(.commandChanged)
     }
 
     func pendingCommand() throws -> DictationCommand? {
@@ -54,6 +58,7 @@ struct SharedStore: Sendable {
 
     func saveKeyboardHandoffState(_ state: KeyboardHandoffState) throws {
         try database().saveValue(state, key: .keyboardHandoffState)
+        eventPoster.post(.handoffStatusChanged)
     }
 
     func keyboardHandoffState() throws -> KeyboardHandoffState {
@@ -62,10 +67,12 @@ struct SharedStore: Sendable {
 
     func clearKeyboardHandoffState() throws {
         try database().clearValue(key: .keyboardHandoffState)
+        eventPoster.post(.handoffStatusChanged)
     }
 
     func saveStatus(_ status: DictationStatus) throws {
         try database().saveValue(status, key: .dictationStatus)
+        eventPoster.post(.ownershipChanged)
     }
 
     func status() throws -> DictationStatus {
@@ -74,6 +81,7 @@ struct SharedStore: Sendable {
 
     func saveResult(_ result: DictationResult) throws {
         try database().saveResult(result)
+        eventPoster.post(.resultChanged)
     }
 
     func result(for requestID: UUID) throws -> DictationResult? {
@@ -86,10 +94,12 @@ struct SharedStore: Sendable {
 
     func deleteResult(_ result: DictationResult) throws {
         try database().deleteResult(id: result.id, requestID: result.requestID)
+        eventPoster.post(.resultChanged)
     }
 
     func clearResult(for requestID: UUID) throws {
         try database().clearResult(for: requestID)
+        eventPoster.post(.resultChanged)
     }
 
     func saveKeyboardExtensionStatus(_ status: KeyboardExtensionStatus) throws {
@@ -102,6 +112,7 @@ struct SharedStore: Sendable {
 
     func saveKeyboardRuntimeStatus(_ status: KeyboardRuntimeStatus) throws {
         try database().saveValue(status, key: .keyboardRuntimeStatus)
+        eventPoster.post(.runtimeStatusChanged)
     }
 
     func keyboardRuntimeStatus() throws -> KeyboardRuntimeStatus? {
@@ -110,10 +121,12 @@ struct SharedStore: Sendable {
 
     func clearKeyboardRuntimeStatus() throws {
         try database().clearValue(key: .keyboardRuntimeStatus)
+        eventPoster.post(.runtimeStatusChanged)
     }
 
     func saveKeyboardLiveTranscript(_ transcript: KeyboardLiveTranscript) throws {
         try database().saveValue(transcript, key: .keyboardLiveTranscript)
+        eventPoster.post(.liveTranscriptChanged)
     }
 
     func keyboardLiveTranscript() throws -> KeyboardLiveTranscript? {
@@ -122,6 +135,7 @@ struct SharedStore: Sendable {
 
     func clearKeyboardLiveTranscript() throws {
         try database().clearValue(key: .keyboardLiveTranscript)
+        eventPoster.post(.liveTranscriptChanged)
     }
 
     func saveSession(_ session: RecordingSession) throws {
@@ -146,6 +160,7 @@ struct SharedStore: Sendable {
 
     func deleteRecordingSession(id: UUID) throws {
         try database().deleteRecordingSession(id: id)
+        eventPoster.post(.ownershipChanged)
     }
 
     @discardableResult

--- a/Shared/SharedStore.swift
+++ b/Shared/SharedStore.swift
@@ -228,6 +228,39 @@ struct SharedStore: Sendable {
         try? deleteExportedAudioFile(fileName: fileName)
     }
 
+    func voiceNoteCheckpointDirectoryURL(sessionID: UUID) throws -> URL {
+        let root = try recordingsDirectoryURL()
+            .appendingPathComponent("VoiceNoteCheckpoints", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        var values = URLResourceValues()
+        values.isExcludedFromBackup = true
+        var mutableRoot = root
+        try? mutableRoot.setResourceValues(values)
+
+        let directory = root.appendingPathComponent(sessionID.uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        return directory
+    }
+
+    func deleteVoiceNoteCheckpoints(sessionID: UUID) throws {
+        let directory = try recordingsDirectoryURL()
+            .appendingPathComponent("VoiceNoteCheckpoints", isDirectory: true)
+            .appendingPathComponent(sessionID.uuidString, isDirectory: true)
+        guard FileManager.default.fileExists(atPath: directory.path) else { return }
+        try FileManager.default.removeItem(at: directory)
+    }
+
+    func voiceNoteCheckpointSessionIDs() throws -> [UUID] {
+        let root = try recordingsDirectoryURL()
+            .appendingPathComponent("VoiceNoteCheckpoints", isDirectory: true)
+        guard FileManager.default.fileExists(atPath: root.path) else { return [] }
+        return try FileManager.default.contentsOfDirectory(
+            at: root,
+            includingPropertiesForKeys: [.isDirectoryKey],
+            options: [.skipsHiddenFiles]
+        ).compactMap { UUID(uuidString: $0.lastPathComponent) }
+    }
+
     @discardableResult
     func exportAudioFileToDocuments(fileName: String) throws -> URL {
         let sourceURL = try audioFileURL(fileName: fileName)

--- a/Tests/MuesliTests/LongVoiceNotePersistenceTests.swift
+++ b/Tests/MuesliTests/LongVoiceNotePersistenceTests.swift
@@ -77,6 +77,29 @@ final class LongVoiceNotePersistenceTests: XCTestCase {
         XCTAssertEqual(referencedOnly.voiceNoteDurabilityEvidence, .audioReferenceOnly)
     }
 
+    func testTranscriptionRetryRequiresAFailedSessionWithDurableCheckpoint() {
+        let retryable = RecordingSession(
+            kind: .quickDictation,
+            phase: .failed,
+            audioFileName: "voice-note.wav",
+            isLongForm: true,
+            hasDurableAudioCheckpoint: true
+        )
+        XCTAssertTrue(retryable.canRetryVoiceNoteTranscription)
+
+        var referenceOnly = retryable
+        referenceOnly.hasDurableAudioCheckpoint = false
+        XCTAssertFalse(referenceOnly.canRetryVoiceNoteTranscription)
+
+        var missingAudio = retryable
+        missingAudio.audioFileName = nil
+        XCTAssertFalse(missingAudio.canRetryVoiceNoteTranscription)
+
+        var completed = retryable
+        completed.phase = .completed
+        XCTAssertFalse(completed.canRetryVoiceNoteTranscription)
+    }
+
     func testVoiceNoteWorkOwnershipDistinguishesAppAndKeyboardSessions() {
         let appSession = RecordingSession(
             kind: .quickDictation,

--- a/Tests/MuesliTests/LongVoiceNotePersistenceTests.swift
+++ b/Tests/MuesliTests/LongVoiceNotePersistenceTests.swift
@@ -61,4 +61,29 @@ final class LongVoiceNotePersistenceTests: XCTestCase {
         XCTAssertNil(decoded.lastTranscriptionFailureReason)
         XCTAssertNil(decoded.scratchpadText)
     }
+
+    func testVoiceNoteWorkOwnershipDistinguishesAppAndKeyboardSessions() {
+        let appSession = RecordingSession(
+            kind: .quickDictation,
+            phase: .recording,
+            source: "app"
+        )
+        XCTAssertTrue(appSession.hasActiveVoiceNoteWork)
+        XCTAssertFalse(appSession.isKeyboardOwnedVoiceNote)
+
+        let keyboardSession = RecordingSession(
+            kind: .keyboardDictation,
+            phase: .transcribing,
+            source: "keyboard"
+        )
+        XCTAssertTrue(keyboardSession.hasActiveVoiceNoteWork)
+        XCTAssertTrue(keyboardSession.isKeyboardOwnedVoiceNote)
+
+        let completedAppSession = RecordingSession(
+            kind: .quickDictation,
+            phase: .completed,
+            source: "app"
+        )
+        XCTAssertFalse(completedAppSession.hasActiveVoiceNoteWork)
+    }
 }

--- a/Tests/MuesliTests/LongVoiceNotePersistenceTests.swift
+++ b/Tests/MuesliTests/LongVoiceNotePersistenceTests.swift
@@ -16,6 +16,7 @@ final class LongVoiceNotePersistenceTests: XCTestCase {
             isLongForm: true,
             longFormActivatedAt: activatedAt,
             longFormThresholdSeconds: 60,
+            hasDurableAudioCheckpoint: true,
             protectedAudioUntilTranscriptCompletes: true,
             transcriptionRetryCount: 2,
             lastTranscriptionAttemptAt: attemptedAt,
@@ -29,11 +30,13 @@ final class LongVoiceNotePersistenceTests: XCTestCase {
         XCTAssertTrue(recovered.isLongForm)
         XCTAssertEqual(recovered.longFormActivatedAt, activatedAt)
         XCTAssertEqual(recovered.longFormThresholdSeconds, 60)
+        XCTAssertTrue(recovered.hasDurableAudioCheckpoint)
         XCTAssertTrue(recovered.protectedAudioUntilTranscriptCompletes)
         XCTAssertEqual(recovered.transcriptionRetryCount, 2)
         XCTAssertEqual(recovered.lastTranscriptionAttemptAt, attemptedAt)
         XCTAssertEqual(recovered.lastTranscriptionFailureReason, .timeout)
         XCTAssertEqual(recovered.scratchpadText, "Remember the second point")
+        XCTAssertEqual(recovered.voiceNoteDurabilityEvidence, .durableCheckpoint)
     }
 
     func testLegacySessionDecodesLongVoiceNoteDefaults() throws {
@@ -42,7 +45,7 @@ final class LongVoiceNotePersistenceTests: XCTestCase {
         var payload = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
         for key in [
             "isLongForm", "longFormActivatedAt", "longFormThresholdSeconds",
-            "protectedAudioUntilTranscriptCompletes", "transcriptionRetryCount",
+            "hasDurableAudioCheckpoint", "protectedAudioUntilTranscriptCompletes", "transcriptionRetryCount",
             "lastTranscriptionAttemptAt", "lastTranscriptionFailureReason", "scratchpadText"
         ] {
             payload.removeValue(forKey: key)
@@ -56,10 +59,22 @@ final class LongVoiceNotePersistenceTests: XCTestCase {
         XCTAssertFalse(decoded.isLongForm)
         XCTAssertNil(decoded.longFormActivatedAt)
         XCTAssertNil(decoded.longFormThresholdSeconds)
+        XCTAssertFalse(decoded.hasDurableAudioCheckpoint)
         XCTAssertFalse(decoded.protectedAudioUntilTranscriptCompletes)
         XCTAssertEqual(decoded.transcriptionRetryCount, 0)
         XCTAssertNil(decoded.lastTranscriptionFailureReason)
         XCTAssertNil(decoded.scratchpadText)
+        XCTAssertEqual(decoded.voiceNoteDurabilityEvidence, .unavailable)
+    }
+
+    func testDurabilityEvidenceDoesNotTreatAFileNameAsACheckpoint() {
+        let referencedOnly = RecordingSession(
+            kind: .quickDictation,
+            phase: .failed,
+            audioFileName: "unverified.wav"
+        )
+
+        XCTAssertEqual(referencedOnly.voiceNoteDurabilityEvidence, .audioReferenceOnly)
     }
 
     func testVoiceNoteWorkOwnershipDistinguishesAppAndKeyboardSessions() {

--- a/Tests/MuesliTests/LongVoiceNotePersistenceTests.swift
+++ b/Tests/MuesliTests/LongVoiceNotePersistenceTests.swift
@@ -1,0 +1,64 @@
+import XCTest
+@testable import Muesli
+
+final class LongVoiceNotePersistenceTests: XCTestCase {
+    func testLongVoiceNoteMetadataAndScratchpadPersist() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("muesli-long-note-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = SharedStore(containerURL: directory)
+        let activatedAt = Date(timeIntervalSince1970: 200)
+        let attemptedAt = Date(timeIntervalSince1970: 300)
+        let session = RecordingSession(
+            kind: .quickDictation,
+            phase: .failed,
+            audioFileName: "protected.wav",
+            isLongForm: true,
+            longFormActivatedAt: activatedAt,
+            longFormThresholdSeconds: 60,
+            protectedAudioUntilTranscriptCompletes: true,
+            transcriptionRetryCount: 2,
+            lastTranscriptionAttemptAt: attemptedAt,
+            lastTranscriptionFailureReason: .timeout,
+            scratchpadText: "Remember the second point"
+        )
+
+        try store.saveSession(session)
+        let recovered = try XCTUnwrap(try store.recordingSession(id: session.id))
+
+        XCTAssertTrue(recovered.isLongForm)
+        XCTAssertEqual(recovered.longFormActivatedAt, activatedAt)
+        XCTAssertEqual(recovered.longFormThresholdSeconds, 60)
+        XCTAssertTrue(recovered.protectedAudioUntilTranscriptCompletes)
+        XCTAssertEqual(recovered.transcriptionRetryCount, 2)
+        XCTAssertEqual(recovered.lastTranscriptionAttemptAt, attemptedAt)
+        XCTAssertEqual(recovered.lastTranscriptionFailureReason, .timeout)
+        XCTAssertEqual(recovered.scratchpadText, "Remember the second point")
+    }
+
+    func testLegacySessionDecodesLongVoiceNoteDefaults() throws {
+        let session = RecordingSession(kind: .quickDictation, phase: .completed)
+        let data = try JSONEncoder().encode(session)
+        var payload = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        for key in [
+            "isLongForm", "longFormActivatedAt", "longFormThresholdSeconds",
+            "protectedAudioUntilTranscriptCompletes", "transcriptionRetryCount",
+            "lastTranscriptionAttemptAt", "lastTranscriptionFailureReason", "scratchpadText"
+        ] {
+            payload.removeValue(forKey: key)
+        }
+
+        let decoded = try JSONDecoder().decode(
+            RecordingSession.self,
+            from: JSONSerialization.data(withJSONObject: payload)
+        )
+
+        XCTAssertFalse(decoded.isLongForm)
+        XCTAssertNil(decoded.longFormActivatedAt)
+        XCTAssertNil(decoded.longFormThresholdSeconds)
+        XCTAssertFalse(decoded.protectedAudioUntilTranscriptCompletes)
+        XCTAssertEqual(decoded.transcriptionRetryCount, 0)
+        XCTAssertNil(decoded.lastTranscriptionFailureReason)
+        XCTAssertNil(decoded.scratchpadText)
+    }
+}

--- a/Tests/MuesliTests/LongVoiceNotePersistenceTests.swift
+++ b/Tests/MuesliTests/LongVoiceNotePersistenceTests.swift
@@ -9,6 +9,7 @@ final class LongVoiceNotePersistenceTests: XCTestCase {
         let store = SharedStore(containerURL: directory)
         let activatedAt = Date(timeIntervalSince1970: 200)
         let attemptedAt = Date(timeIntervalSince1970: 300)
+        let recoveryValidatedAt = Date(timeIntervalSince1970: 400)
         let session = RecordingSession(
             kind: .quickDictation,
             phase: .failed,
@@ -21,7 +22,8 @@ final class LongVoiceNotePersistenceTests: XCTestCase {
             transcriptionRetryCount: 2,
             lastTranscriptionAttemptAt: attemptedAt,
             lastTranscriptionFailureReason: .timeout,
-            scratchpadText: "Remember the second point"
+            scratchpadText: "Remember the second point",
+            longFormRecoveryValidatedAt: recoveryValidatedAt
         )
 
         try store.saveSession(session)
@@ -36,6 +38,7 @@ final class LongVoiceNotePersistenceTests: XCTestCase {
         XCTAssertEqual(recovered.lastTranscriptionAttemptAt, attemptedAt)
         XCTAssertEqual(recovered.lastTranscriptionFailureReason, .timeout)
         XCTAssertEqual(recovered.scratchpadText, "Remember the second point")
+        XCTAssertEqual(recovered.longFormRecoveryValidatedAt, recoveryValidatedAt)
         XCTAssertEqual(recovered.voiceNoteDurabilityEvidence, .durableCheckpoint)
     }
 
@@ -46,7 +49,8 @@ final class LongVoiceNotePersistenceTests: XCTestCase {
         for key in [
             "isLongForm", "longFormActivatedAt", "longFormThresholdSeconds",
             "hasDurableAudioCheckpoint", "protectedAudioUntilTranscriptCompletes", "transcriptionRetryCount",
-            "lastTranscriptionAttemptAt", "lastTranscriptionFailureReason", "scratchpadText"
+            "lastTranscriptionAttemptAt", "lastTranscriptionFailureReason", "scratchpadText",
+            "longFormRecoveryValidatedAt"
         ] {
             payload.removeValue(forKey: key)
         }
@@ -64,6 +68,7 @@ final class LongVoiceNotePersistenceTests: XCTestCase {
         XCTAssertEqual(decoded.transcriptionRetryCount, 0)
         XCTAssertNil(decoded.lastTranscriptionFailureReason)
         XCTAssertNil(decoded.scratchpadText)
+        XCTAssertNil(decoded.longFormRecoveryValidatedAt)
         XCTAssertEqual(decoded.voiceNoteDurabilityEvidence, .unavailable)
     }
 

--- a/Tests/MuesliTests/MuesliPreferencesTests.swift
+++ b/Tests/MuesliTests/MuesliPreferencesTests.swift
@@ -2,6 +2,29 @@ import XCTest
 @testable import Muesli
 
 final class MuesliPreferencesTests: XCTestCase {
+    func testLongVoiceNoteThresholdClampsToSupportedRange() {
+        XCTAssertEqual(MuesliPreferences.clampedLongVoiceNoteThreshold(5), 30)
+        XCTAssertEqual(MuesliPreferences.clampedLongVoiceNoteThreshold(60), 60)
+        XCTAssertEqual(MuesliPreferences.clampedLongVoiceNoteThreshold(9_999), 600)
+    }
+
+    func testLongVoiceNotePreferencesDefaultEnabledAtSixtySeconds() {
+        let defaults = UserDefaults.standard
+        let enabled = defaults.object(forKey: MuesliPreferences.longVoiceNoteModeEnabledKey)
+        let threshold = defaults.object(forKey: MuesliPreferences.longVoiceNoteThresholdSecondsKey)
+        defer {
+            if let enabled { defaults.set(enabled, forKey: MuesliPreferences.longVoiceNoteModeEnabledKey) }
+            else { defaults.removeObject(forKey: MuesliPreferences.longVoiceNoteModeEnabledKey) }
+            if let threshold { defaults.set(threshold, forKey: MuesliPreferences.longVoiceNoteThresholdSecondsKey) }
+            else { defaults.removeObject(forKey: MuesliPreferences.longVoiceNoteThresholdSecondsKey) }
+        }
+        defaults.removeObject(forKey: MuesliPreferences.longVoiceNoteModeEnabledKey)
+        defaults.removeObject(forKey: MuesliPreferences.longVoiceNoteThresholdSecondsKey)
+
+        XCTAssertTrue(MuesliPreferences.longVoiceNoteModeEnabled)
+        XCTAssertEqual(MuesliPreferences.longVoiceNoteThresholdSeconds, 60)
+    }
+
     func testOpenRouterModelReturnsCustomStoredValue() {
         let defaults = UserDefaults.standard
         let originalValue = defaults.object(forKey: MuesliPreferences.openRouterModelKey)

--- a/Tests/MuesliTests/MuesliPreferencesTests.swift
+++ b/Tests/MuesliTests/MuesliPreferencesTests.swift
@@ -8,6 +8,13 @@ final class MuesliPreferencesTests: XCTestCase {
         XCTAssertEqual(MuesliPreferences.clampedLongVoiceNoteThreshold(9_999), 600)
     }
 
+    func testLongVoiceNoteThresholdLabelsUseSharedFormatting() {
+        XCTAssertEqual(MuesliPreferences.longVoiceNoteThresholdLabel(30), "30 sec")
+        XCTAssertEqual(MuesliPreferences.longVoiceNoteThresholdLabel(60), "1 min")
+        XCTAssertEqual(MuesliPreferences.longVoiceNoteThresholdLabel(90), "1m 30s")
+        XCTAssertEqual(MuesliPreferences.longVoiceNoteThresholdLabel(120), "2 min")
+    }
+
     func testLongVoiceNotePreferencesDefaultEnabledAtSixtySeconds() {
         let defaults = UserDefaults.standard
         let enabled = defaults.object(forKey: MuesliPreferences.longVoiceNoteModeEnabledKey)

--- a/Tests/MuesliTests/SharedStoreTests.swift
+++ b/Tests/MuesliTests/SharedStoreTests.swift
@@ -3,6 +3,82 @@ import SQLite3
 @testable import Muesli
 
 final class SharedStoreTests: XCTestCase {
+    func testDarwinEventBusDeliversPayloadFreeInvalidation() async {
+        let bus = DarwinCrossProcessEventBus.shared
+        let delivered = expectation(description: "Darwin event delivered")
+        let observation = Task {
+            for await event in bus.events() where event == .ownershipChanged {
+                delivered.fulfill()
+                return
+            }
+        }
+        await Task.yield()
+
+        bus.post(.ownershipChanged)
+
+        await fulfillment(of: [delivered], timeout: 1)
+        observation.cancel()
+    }
+
+    func testSharedStorePostsCommandEventAfterCommandIsReadableBySecondStore() async throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let bus = TestCrossProcessEventBus()
+        let writer = SharedStore(containerURL: directory, eventPoster: bus)
+        let reader = SharedStore(containerURL: directory, eventPoster: bus)
+        let requestID = UUID()
+
+        let observedCommand = Task { () throws -> DictationCommand? in
+            for await event in bus.events() where event == .commandChanged {
+                return try reader.pendingCommand()
+            }
+            return nil
+        }
+        await Task.yield()
+        try writer.saveCommand(.init(requestID: requestID, action: .start))
+
+        let command = try await observedCommand.value
+        XCTAssertEqual(command?.requestID, requestID)
+        XCTAssertEqual(command?.action, .start)
+    }
+
+    func testSharedStoreDoesNotPostWhenDatabaseMutationFails() throws {
+        let root = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let invalidContainer = root.appendingPathComponent("not-a-directory")
+        try Data("file".utf8).write(to: invalidContainer)
+        let bus = TestCrossProcessEventBus()
+        let store = SharedStore(containerURL: invalidContainer, eventPoster: bus)
+
+        XCTAssertThrowsError(try store.saveCommand(.init(requestID: UUID(), action: .start)))
+        XCTAssertTrue(bus.postedEvents.isEmpty)
+    }
+
+    func testDuplicateCommandEventsDoNotDuplicatePersistedCommand() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let bus = TestCrossProcessEventBus()
+        let store = SharedStore(containerURL: directory, eventPoster: bus)
+        let command = DictationCommand(requestID: UUID(), action: .stop)
+
+        try store.saveCommand(command)
+        bus.post(.commandChanged)
+        bus.post(.commandChanged)
+
+        XCTAssertEqual(try store.pendingCommand(), command)
+    }
+
+    func testPreparingRequestDoesNotSignalCommandBeforeCommandIsPersisted() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let bus = TestCrossProcessEventBus()
+        let store = SharedStore(containerURL: directory, eventPoster: bus)
+
+        try store.saveRequest(DictationRequest())
+
+        XCTAssertFalse(bus.postedEvents.contains(.commandChanged))
+    }
+
     func testFreshSQLiteStoreCreatesV4Schema() throws {
         let directory = try makeTemporaryDirectory()
         defer { try? FileManager.default.removeItem(at: directory) }
@@ -221,6 +297,32 @@ final class SharedStoreTests: XCTestCase {
         XCTAssertEqual(recoveryState.phase, .recoveryRequested)
         XCTAssertEqual(recoveryState.message, "Open Muesli to continue")
         XCTAssertEqual(recoveryState.recoveryAttemptCount, 1)
+    }
+
+    func testKeyboardHandoffRecoveryPolicyRetriesCancellationIntent() throws {
+        let requestID = UUID()
+        let now = Date(timeIntervalSince1970: 1_000)
+        let staleCancellation = KeyboardHandoffState(
+            requestID: requestID,
+            phase: .cancelRequested,
+            message: "Cancelling",
+            createdAt: now.addingTimeInterval(-9),
+            updatedAt: now.addingTimeInterval(-9)
+        )
+
+        let action = KeyboardHandoffRecoveryPolicy.keyboardDefaults.action(
+            for: staleCancellation,
+            latestRuntimeStatus: nil,
+            canUseRuntimeStart: true,
+            now: now
+        )
+
+        guard case let .retry(retryAction, retryingState) = action else {
+            return XCTFail("Expected stale cancellation to retry once")
+        }
+        XCTAssertEqual(retryAction, .cancel)
+        XCTAssertEqual(retryingState.phase, .cancelRequested)
+        XCTAssertEqual(retryingState.recoveryAttemptCount, 1)
     }
 
     func testKeyboardHandoffRecoveryPolicyIgnoresFreshActiveRuntimeStatus() throws {
@@ -1325,3 +1427,40 @@ private enum SQLiteTestError: Error {
 }
 
 private let sqliteTransient = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
+
+private final class TestCrossProcessEventBus: CrossProcessEventStreaming, @unchecked Sendable {
+    private let lock = NSLock()
+    private var continuations: [UUID: AsyncStream<CrossProcessEvent>.Continuation] = [:]
+    private var eventsStorage: [CrossProcessEvent] = []
+
+    var postedEvents: [CrossProcessEvent] {
+        lock.lock()
+        defer { lock.unlock() }
+        return eventsStorage
+    }
+
+    func post(_ event: CrossProcessEvent) {
+        lock.lock()
+        eventsStorage.append(event)
+        let currentContinuations = Array(continuations.values)
+        lock.unlock()
+        for continuation in currentContinuations {
+            continuation.yield(event)
+        }
+    }
+
+    func events() -> AsyncStream<CrossProcessEvent> {
+        let id = UUID()
+        return AsyncStream { continuation in
+            lock.lock()
+            continuations[id] = continuation
+            lock.unlock()
+            continuation.onTermination = { [weak self] _ in
+                guard let self else { return }
+                self.lock.lock()
+                self.continuations[id] = nil
+                self.lock.unlock()
+            }
+        }
+    }
+}

--- a/Tests/MuesliTests/SharedStoreTests.swift
+++ b/Tests/MuesliTests/SharedStoreTests.swift
@@ -3,6 +3,17 @@ import SQLite3
 @testable import Muesli
 
 final class SharedStoreTests: XCTestCase {
+    func testEventStreamBuffersEventPostedAfterSubscriptionBeforeConsumption() async {
+        let bus = TestCrossProcessEventBus()
+        let stream = bus.events()
+
+        bus.post(.ownershipChanged)
+
+        var iterator = stream.makeAsyncIterator()
+        let event = await iterator.next()
+        XCTAssertEqual(event, .ownershipChanged)
+    }
+
     func testDarwinEventBusDeliversPayloadFreeInvalidation() async {
         let bus = DarwinCrossProcessEventBus.shared
         let delivered = expectation(description: "Darwin event delivered")

--- a/Tests/MuesliTests/VoiceNoteCheckpointStoreTests.swift
+++ b/Tests/MuesliTests/VoiceNoteCheckpointStoreTests.swift
@@ -1,0 +1,135 @@
+import AVFoundation
+import XCTest
+@testable import Muesli
+
+final class VoiceNoteCheckpointStoreTests: XCTestCase {
+    func testManifestSortsChunksAndPersistsFrameCounts() async throws {
+        let fixture = try await makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        let first = try writeChunk(index: 0, duration: 0.1, directory: fixture.directory)
+        let second = try writeChunk(index: 1, duration: 0.1, directory: fixture.directory)
+        _ = try await fixture.checkpoints.record(second, sessionID: fixture.sessionID)
+        let manifest = try await fixture.checkpoints.record(first, sessionID: fixture.sessionID)
+
+        XCTAssertEqual(manifest.entries.map(\.index), [0, 1])
+        XCTAssertTrue(manifest.entries.allSatisfy { $0.frameCount > 0 })
+        let persistedManifest = try await fixture.checkpoints.manifest(sessionID: fixture.sessionID)
+        XCTAssertEqual(persistedManifest, manifest)
+    }
+
+    func testReconstructsContinuousAudioFromOrderedChunks() async throws {
+        let fixture = try await makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        for index in 0..<2 {
+            let chunk = try writeChunk(index: index, duration: 0.1, directory: fixture.directory)
+            _ = try await fixture.checkpoints.record(chunk, sessionID: fixture.sessionID)
+        }
+        let output = fixture.root.appendingPathComponent("reconstructed.wav")
+
+        _ = try await fixture.checkpoints.reconstructAudio(
+            sessionID: fixture.sessionID,
+            destinationURL: output
+        )
+
+        let file = try AVAudioFile(forReading: output)
+        XCTAssertEqual(file.length, 3_200, accuracy: 2)
+    }
+
+    func testRecoveryStopsAtMissingChunkInsteadOfAppendingLaterAudio() async throws {
+        let fixture = try await makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        for index in [0, 2] {
+            let chunk = try writeChunk(index: index, duration: 0.1, directory: fixture.directory)
+            _ = try await fixture.checkpoints.record(chunk, sessionID: fixture.sessionID)
+        }
+        let output = fixture.root.appendingPathComponent("contiguous.wav")
+
+        _ = try await fixture.checkpoints.reconstructAudio(
+            sessionID: fixture.sessionID,
+            destinationURL: output
+        )
+
+        XCTAssertEqual(try AVAudioFile(forReading: output).length, 1_600, accuracy: 2)
+    }
+
+    func testRecoveryIgnoresCorruptTrailingChunk() async throws {
+        let fixture = try await makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        let first = try writeChunk(index: 0, duration: 0.1, directory: fixture.directory)
+        _ = try await fixture.checkpoints.record(first, sessionID: fixture.sessionID)
+        let corruptURL = fixture.directory.appendingPathComponent("chunk-0001.wav")
+        try Data("not audio".utf8).write(to: corruptURL)
+        let corrupt = Muesli.MeetingAudioChunk(index: 1, url: corruptURL, startTime: 0.1, duration: 0.1)
+        _ = try await fixture.checkpoints.record(corrupt, sessionID: fixture.sessionID)
+        let output = fixture.root.appendingPathComponent("salvaged.wav")
+
+        _ = try await fixture.checkpoints.reconstructAudio(
+            sessionID: fixture.sessionID,
+            destinationURL: output
+        )
+
+        XCTAssertEqual(try AVAudioFile(forReading: output).length, 1_600, accuracy: 2)
+    }
+
+    func testRecoveryAddsValidUnmanifestedTrailingChunkAfterProcessDeath() async throws {
+        let fixture = try await makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        let first = try writeChunk(index: 0, duration: 0.1, directory: fixture.directory)
+        _ = try await fixture.checkpoints.record(first, sessionID: fixture.sessionID)
+        _ = try writeChunk(index: 1, duration: 0.1, directory: fixture.directory)
+
+        let salvaged = try await fixture.checkpoints.salvageTrailingCheckpoint(
+            sessionID: fixture.sessionID
+        )
+
+        XCTAssertEqual(salvaged.entries.map(\.index), [0, 1])
+        XCTAssertTrue(salvaged.entries.allSatisfy { $0.frameCount > 0 })
+    }
+
+    private func makeFixture() async throws -> (
+        root: URL,
+        directory: URL,
+        sessionID: UUID,
+        checkpoints: Muesli.VoiceNoteCheckpointStore
+    ) {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("muesli-checkpoints-\(UUID().uuidString)", isDirectory: true)
+        let store = Muesli.SharedStore(containerURL: root)
+        let sessionID = UUID()
+        let checkpoints = Muesli.VoiceNoteCheckpointStore(store: store)
+        let directory = try await checkpoints.prepare(sessionID: sessionID, startedAt: .now)
+        return (root, directory, sessionID, checkpoints)
+    }
+
+    private func writeChunk(index: Int, duration: TimeInterval, directory: URL) throws -> Muesli.MeetingAudioChunk {
+        let sampleRate = 16_000.0
+        let frameCount = AVAudioFrameCount(sampleRate * duration)
+        let format = try XCTUnwrap(AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: sampleRate,
+            channels: 1,
+            interleaved: false
+        ))
+        let buffer = try XCTUnwrap(AVAudioPCMBuffer(pcmFormat: format, frameCapacity: frameCount))
+        buffer.frameLength = frameCount
+        if let samples = buffer.floatChannelData?[0] {
+            for frame in 0..<Int(frameCount) {
+                samples[frame] = sin(Float(frame) * 0.03) * 0.1
+            }
+        }
+        let url = directory.appendingPathComponent(String(format: "chunk-%04d.wav", index))
+        let file = try AVAudioFile(forWriting: url, settings: format.settings)
+        try file.write(from: buffer)
+        return Muesli.MeetingAudioChunk(
+            index: index,
+            url: url,
+            startTime: Double(index) * duration,
+            duration: duration
+        )
+    }
+}

--- a/Tests/MuesliTests/VoiceNoteCheckpointStoreTests.swift
+++ b/Tests/MuesliTests/VoiceNoteCheckpointStoreTests.swift
@@ -106,6 +106,49 @@ final class VoiceNoteCheckpointStoreTests: XCTestCase {
         XCTAssertTrue(salvaged.entries.allSatisfy { $0.frameCount > 0 })
     }
 
+    func testConcurrentRecordAndSalvageRemainOrderedAndDeduplicated() async throws {
+        let fixture = try await makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        let first = try writeChunk(index: 0, duration: 0.1, directory: fixture.directory)
+        _ = try writeChunk(index: 1, duration: 0.1, directory: fixture.directory)
+        async let recorded = fixture.checkpoints.record(first, sessionID: fixture.sessionID)
+        async let salvaged = fixture.checkpoints.salvageTrailingCheckpoint(sessionID: fixture.sessionID)
+        _ = try await (recorded, salvaged)
+
+        let manifest = try await fixture.checkpoints.manifest(sessionID: fixture.sessionID)
+        XCTAssertEqual(manifest.entries.map(\.index), [0, 1])
+        XCTAssertEqual(Set(manifest.entries.map(\.index)).count, manifest.entries.count)
+    }
+
+    func testCheckpointWriterCancellationRemovesRotatedChunksAndContinuousAudio() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("muesli-writer-cancel-\(UUID().uuidString)", isDirectory: true)
+        let checkpointDirectory = root.appendingPathComponent("checkpoints", isDirectory: true)
+        let continuousURL = root.appendingPathComponent("continuous.wav")
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let format = try XCTUnwrap(AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: 16_000,
+            channels: 1,
+            interleaved: false
+        ))
+        let writer = try Muesli.CheckpointingAudioWriter(
+            continuousAudioURL: continuousURL,
+            checkpointDirectory: checkpointDirectory,
+            format: format
+        )
+        writer.append(try makeBuffer(format: format, frameCount: 1_600))
+        let rotated = try XCTUnwrap(writer.rotateCheckpoint())
+        XCTAssertTrue(FileManager.default.fileExists(atPath: rotated.url.path))
+
+        writer.cancel()
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: checkpointDirectory.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: continuousURL.path))
+    }
+
     private func makeFixture() async throws -> (
         root: URL,
         directory: URL,
@@ -146,5 +189,16 @@ final class VoiceNoteCheckpointStoreTests: XCTestCase {
             startTime: Double(index) * duration,
             duration: duration
         )
+    }
+
+    private func makeBuffer(format: AVAudioFormat, frameCount: AVAudioFrameCount) throws -> AVAudioPCMBuffer {
+        let buffer = try XCTUnwrap(AVAudioPCMBuffer(pcmFormat: format, frameCapacity: frameCount))
+        buffer.frameLength = frameCount
+        if let samples = buffer.floatChannelData?[0] {
+            for frame in 0..<Int(frameCount) {
+                samples[frame] = sin(Float(frame) * 0.03) * 0.1
+            }
+        }
+        return buffer
     }
 }

--- a/Tests/MuesliTests/VoiceNoteCheckpointStoreTests.swift
+++ b/Tests/MuesliTests/VoiceNoteCheckpointStoreTests.swift
@@ -55,7 +55,24 @@ final class VoiceNoteCheckpointStoreTests: XCTestCase {
         XCTAssertEqual(try AVAudioFile(forReading: output).length, 1_600, accuracy: 2)
     }
 
-    func testRecoveryIgnoresCorruptTrailingChunk() async throws {
+    func testRecordRejectsCorruptCheckpoint() async throws {
+        let fixture = try await makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        let corruptURL = fixture.directory.appendingPathComponent("chunk-0000.wav")
+        try Data("not audio".utf8).write(to: corruptURL)
+        let corrupt = Muesli.MeetingAudioChunk(index: 0, url: corruptURL, startTime: 0, duration: 0.1)
+
+        do {
+            _ = try await fixture.checkpoints.record(corrupt, sessionID: fixture.sessionID)
+            XCTFail("Corrupt checkpoint should not be added to the manifest")
+        } catch Muesli.VoiceNoteCheckpointStore.StoreError.invalidCheckpoint {
+            let manifest = try await fixture.checkpoints.manifest(sessionID: fixture.sessionID)
+            XCTAssertTrue(manifest.entries.isEmpty)
+        }
+    }
+
+    func testRecoveryIgnoresCorruptUnmanifestedTrailingChunk() async throws {
         let fixture = try await makeFixture()
         defer { try? FileManager.default.removeItem(at: fixture.root) }
 
@@ -63,8 +80,6 @@ final class VoiceNoteCheckpointStoreTests: XCTestCase {
         _ = try await fixture.checkpoints.record(first, sessionID: fixture.sessionID)
         let corruptURL = fixture.directory.appendingPathComponent("chunk-0001.wav")
         try Data("not audio".utf8).write(to: corruptURL)
-        let corrupt = Muesli.MeetingAudioChunk(index: 1, url: corruptURL, startTime: 0.1, duration: 0.1)
-        _ = try await fixture.checkpoints.record(corrupt, sessionID: fixture.sessionID)
         let output = fixture.root.appendingPathComponent("salvaged.wav")
 
         _ = try await fixture.checkpoints.reconstructAudio(

--- a/Tests/MuesliTests/VoiceNoteLifecycleTests.swift
+++ b/Tests/MuesliTests/VoiceNoteLifecycleTests.swift
@@ -2,6 +2,29 @@ import XCTest
 @testable import Muesli
 
 final class VoiceNoteLifecycleTests: XCTestCase {
+    func testStopAndCancelRemainDeferredWhileRecorderStartupIsInFlight() {
+        for action in [Muesli.DictationCommandAction.stop, .cancel] {
+            XCTAssertTrue(KeyboardCommandArbitration.shouldDeferUntilRecorderStarts(
+                action: action,
+                activeRequestMatches: true,
+                hasActiveSession: false,
+                isRecording: false
+            ))
+        }
+        XCTAssertFalse(KeyboardCommandArbitration.shouldDeferUntilRecorderStarts(
+            action: Muesli.DictationCommandAction.start,
+            activeRequestMatches: true,
+            hasActiveSession: false,
+            isRecording: false
+        ))
+        XCTAssertFalse(KeyboardCommandArbitration.shouldDeferUntilRecorderStarts(
+            action: Muesli.DictationCommandAction.cancel,
+            activeRequestMatches: true,
+            hasActiveSession: true,
+            isRecording: false
+        ))
+    }
+
     func testLifecycleMovesThroughProtectedRecordingAndCompletion() {
         let id = UUID()
         var state = VoiceNoteLifecycleReducer.reduce(.init(), event: .recordingStarted(id))

--- a/Tests/MuesliTests/VoiceNoteLifecycleTests.swift
+++ b/Tests/MuesliTests/VoiceNoteLifecycleTests.swift
@@ -367,4 +367,23 @@ final class VoiceNoteLifecycleTests: XCTestCase {
         XCTAssertTrue(recoverableLongSession.protectedAudioUntilTranscriptCompletes)
         XCTAssertFalse(unavailableLongSession.protectedAudioUntilTranscriptCompletes)
     }
+
+    func testFailureTelemetryPolicyPreservesTimeoutStageNames() {
+        XCTAssertEqual(
+            VoiceNoteFailureTelemetryPolicy.stage(
+                for: .timeout,
+                standard: "transcription",
+                timeout: "transcription_timeout"
+            ),
+            "transcription_timeout"
+        )
+        XCTAssertEqual(
+            VoiceNoteFailureTelemetryPolicy.stage(
+                for: .engineFailure,
+                standard: "transcription",
+                timeout: "transcription_timeout"
+            ),
+            "transcription"
+        )
+    }
 }

--- a/Tests/MuesliTests/VoiceNoteLifecycleTests.swift
+++ b/Tests/MuesliTests/VoiceNoteLifecycleTests.swift
@@ -1,0 +1,55 @@
+import XCTest
+@testable import Muesli
+
+final class VoiceNoteLifecycleTests: XCTestCase {
+    func testLifecycleMovesThroughProtectedRecordingAndCompletion() {
+        let id = UUID()
+        var state = VoiceNoteLifecycleReducer.reduce(.init(), event: .recordingStarted(id))
+        XCTAssertEqual(state.phase, .recordingShort(id))
+
+        state = VoiceNoteLifecycleReducer.reduce(state, event: .longFormActivated(id))
+        XCTAssertEqual(state.phase, .recordingLongProtected(id))
+        XCTAssertTrue(state.isLongFormVisible)
+
+        state = VoiceNoteLifecycleReducer.reduce(state, event: .stopRequested(id))
+        state = VoiceNoteLifecycleReducer.reduce(state, event: .audioFinalized(id))
+        state = VoiceNoteLifecycleReducer.reduce(state, event: .transcriptionQueued(id))
+        state = VoiceNoteLifecycleReducer.reduce(state, event: .transcriptionStarted(id))
+        state = VoiceNoteLifecycleReducer.reduce(state, event: .finished(id))
+        XCTAssertEqual(state.phase, .idle)
+    }
+
+    func testLifecycleRejectsStaleSessionEvents() {
+        let active = UUID()
+        let stale = UUID()
+        let state = VoiceNoteLifecycleReducer.reduce(.init(), event: .recordingStarted(active))
+        XCTAssertEqual(
+            VoiceNoteLifecycleReducer.reduce(state, event: .longFormActivated(stale)),
+            state
+        )
+    }
+
+    func testFailureCanRetry() {
+        let id = UUID()
+        var state = VoiceNoteLifecycleReducer.reduce(.init(), event: .transcriptionStarted(id))
+        state = VoiceNoteLifecycleReducer.reduce(state, event: .transcriptionFailed(id))
+        XCTAssertEqual(state.phase, .failedRetryable(id))
+
+        state = VoiceNoteLifecycleReducer.reduce(state, event: .retryRequested(id))
+        XCTAssertEqual(state.phase, .transcriptionQueued(id))
+    }
+
+    func testProtectedAudioSurvivesFailureUntilExplicitlyRetainedOrCompleted() {
+        let protected = Muesli.RecordingSession(
+            kind: .quickDictation,
+            protectedAudioUntilTranscriptCompletes: true
+        )
+        XCTAssertFalse(VoiceNoteAudioRetentionPolicy.shouldDeleteAudioAfterFailure(protected))
+
+        let short = Muesli.RecordingSession(kind: .quickDictation)
+        XCTAssertTrue(VoiceNoteAudioRetentionPolicy.shouldDeleteAudioAfterFailure(short))
+
+        let retained = Muesli.RecordingSession(kind: .quickDictation, keepsAudioRecording: true)
+        XCTAssertFalse(VoiceNoteAudioRetentionPolicy.shouldDeleteAudioAfterSuccess(retained))
+    }
+}

--- a/Tests/MuesliTests/VoiceNoteLifecycleTests.swift
+++ b/Tests/MuesliTests/VoiceNoteLifecycleTests.swift
@@ -29,9 +29,28 @@ final class VoiceNoteLifecycleTests: XCTestCase {
         )
     }
 
+    func testLifecycleRejectsLateEventsAfterFinishing() {
+        let id = UUID()
+        let idle = VoiceNoteLifecycleState()
+
+        XCTAssertEqual(
+            VoiceNoteLifecycleReducer.reduce(idle, event: .transcriptionQueued(id)),
+            idle
+        )
+        XCTAssertEqual(
+            VoiceNoteLifecycleReducer.reduce(idle, event: .transcriptionStarted(id)),
+            idle
+        )
+        XCTAssertEqual(
+            VoiceNoteLifecycleReducer.reduce(idle, event: .cancelRequested(id)),
+            idle
+        )
+    }
+
     func testFailureCanRetry() {
         let id = UUID()
-        var state = VoiceNoteLifecycleReducer.reduce(.init(), event: .transcriptionStarted(id))
+        var state = VoiceNoteLifecycleReducer.reduce(.init(), event: .retryRequested(id))
+        state = VoiceNoteLifecycleReducer.reduce(state, event: .transcriptionStarted(id))
         state = VoiceNoteLifecycleReducer.reduce(state, event: .transcriptionFailed(id))
         XCTAssertEqual(state.phase, .failedRetryable(id))
 

--- a/Tests/MuesliTests/VoiceNoteLifecycleTests.swift
+++ b/Tests/MuesliTests/VoiceNoteLifecycleTests.swift
@@ -43,6 +43,102 @@ final class VoiceNoteLifecycleTests: XCTestCase {
         XCTAssertEqual(transition.state.phase, .stopping(id))
     }
 
+    func testDuplicateStopIsRejectedWithoutAdvancingState() {
+        let id = UUID()
+        var state = VoiceNoteLifecycleReducer.reduce(.init(), event: .recordingStarted(id))
+
+        let firstStop = VoiceNoteLifecycleReducer.transition(state, event: .stopRequested(id))
+        XCTAssertTrue(firstStop.accepted)
+        state = firstStop.state
+
+        let duplicateStop = VoiceNoteLifecycleReducer.transition(state, event: .stopRequested(id))
+        XCTAssertFalse(duplicateStop.accepted)
+        XCTAssertEqual(duplicateStop.state.phase, .stopping(id))
+    }
+
+    func testCancelIsAcceptedDuringTranscriptionAndDuplicateIsRejected() {
+        let id = UUID()
+        var state = VoiceNoteLifecycleReducer.reduce(.init(), event: .recordingStarted(id))
+        state = VoiceNoteLifecycleReducer.reduce(state, event: .stopRequested(id))
+        state = VoiceNoteLifecycleReducer.reduce(state, event: .transcriptionStarted(id))
+
+        let firstCancel = VoiceNoteLifecycleReducer.transition(state, event: .cancelRequested(id))
+        XCTAssertTrue(firstCancel.accepted)
+        XCTAssertEqual(firstCancel.state.phase, .cancelling(id))
+
+        let duplicateCancel = VoiceNoteLifecycleReducer.transition(
+            firstCancel.state,
+            event: .cancelRequested(id)
+        )
+        XCTAssertFalse(duplicateCancel.accepted)
+        XCTAssertEqual(duplicateCancel.state, firstCancel.state)
+    }
+
+    func testDuplicateRetryIsRejectedWhileFirstRetryIsQueued() {
+        let id = UUID()
+        let firstRetry = VoiceNoteLifecycleReducer.transition(.init(), event: .retryRequested(id))
+        XCTAssertTrue(firstRetry.accepted)
+        XCTAssertEqual(firstRetry.state.phase, .transcriptionQueued(id))
+
+        let duplicateRetry = VoiceNoteLifecycleReducer.transition(
+            firstRetry.state,
+            event: .retryRequested(id)
+        )
+        XCTAssertFalse(duplicateRetry.accepted)
+        XCTAssertEqual(duplicateRetry.state, firstRetry.state)
+    }
+
+    func testDuplicateAsyncCompletionEventsCannotAdvanceLifecycleTwice() {
+        let id = UUID()
+        var state = VoiceNoteLifecycleReducer.reduce(.init(), event: .recordingStarted(id))
+        state = VoiceNoteLifecycleReducer.reduce(state, event: .stopRequested(id))
+
+        let firstFinalization = VoiceNoteLifecycleReducer.transition(state, event: .audioFinalized(id))
+        XCTAssertTrue(firstFinalization.accepted)
+        let duplicateFinalization = VoiceNoteLifecycleReducer.transition(
+            firstFinalization.state,
+            event: .audioFinalized(id)
+        )
+        XCTAssertFalse(duplicateFinalization.accepted)
+        XCTAssertEqual(duplicateFinalization.state, firstFinalization.state)
+
+        state = VoiceNoteLifecycleReducer.reduce(
+            firstFinalization.state,
+            event: .transcriptionQueued(id)
+        )
+        let firstTranscription = VoiceNoteLifecycleReducer.transition(
+            state,
+            event: .transcriptionStarted(id)
+        )
+        XCTAssertTrue(firstTranscription.accepted)
+        let duplicateTranscription = VoiceNoteLifecycleReducer.transition(
+            firstTranscription.state,
+            event: .transcriptionStarted(id)
+        )
+        XCTAssertFalse(duplicateTranscription.accepted)
+        XCTAssertEqual(duplicateTranscription.state, firstTranscription.state)
+    }
+
+    func testCancellationRejectsLateFailureAndCompletionEvents() {
+        let id = UUID()
+        var state = VoiceNoteLifecycleReducer.reduce(.init(), event: .recordingStarted(id))
+        state = VoiceNoteLifecycleReducer.reduce(state, event: .stopRequested(id))
+        state = VoiceNoteLifecycleReducer.reduce(state, event: .transcriptionStarted(id))
+        state = VoiceNoteLifecycleReducer.reduce(state, event: .cancelRequested(id))
+        XCTAssertEqual(state.phase, .cancelling(id))
+
+        for event in [
+            VoiceNoteLifecycleEvent.audioFinalized(id),
+            .transcriptionQueued(id),
+            .transcriptionStarted(id),
+            .transcriptionFailed(id),
+        ] {
+            let lateTransition = VoiceNoteLifecycleReducer.transition(state, event: event)
+            XCTAssertFalse(lateTransition.accepted)
+            XCTAssertEqual(lateTransition.state, state)
+        }
+    }
+
     func testLifecycleRejectsOutOfOrderFinalizationAndQueueEvents() {
         let id = UUID()
         let recording = VoiceNoteLifecycleReducer.reduce(.init(), event: .recordingStarted(id))
@@ -154,11 +250,14 @@ final class VoiceNoteLifecycleTests: XCTestCase {
             "audioSaved.transcriptionQueued",
             "audioSaved.transcriptionStarted",
             "audioSaved.transcriptionFailed",
+            "audioSaved.cancelRequested",
             "audioSaved.finished",
             "transcriptionQueued.transcriptionStarted",
             "transcriptionQueued.transcriptionFailed",
+            "transcriptionQueued.cancelRequested",
             "transcriptionQueued.finished",
             "transcribing.transcriptionFailed",
+            "transcribing.cancelRequested",
             "transcribing.finished",
             "failedRetryable.recordingStarted",
             "failedRetryable.retryRequested",

--- a/Tests/MuesliTests/VoiceNoteLifecycleTests.swift
+++ b/Tests/MuesliTests/VoiceNoteLifecycleTests.swift
@@ -58,6 +58,91 @@ final class VoiceNoteLifecycleTests: XCTestCase {
         XCTAssertEqual(state.phase, .transcriptionQueued(id))
     }
 
+    func testOnlyActiveLifecyclePhasesOwnAudioWork() {
+        let id = UUID()
+        var state = VoiceNoteLifecycleReducer.reduce(.init(), event: .recordingStarted(id))
+        XCTAssertTrue(state.isWorkActive)
+
+        state = VoiceNoteLifecycleReducer.reduce(state, event: .stopRequested(id))
+        XCTAssertTrue(state.isWorkActive)
+        state = VoiceNoteLifecycleReducer.reduce(state, event: .transcriptionStarted(id))
+        XCTAssertTrue(state.isWorkActive)
+
+        state = VoiceNoteLifecycleReducer.reduce(state, event: .transcriptionFailed(id))
+        XCTAssertFalse(state.isWorkActive)
+    }
+
+    func testRequestOwnershipRejectsForeignCommandsOnlyWhileWorkIsActive() {
+        let owner = UUID()
+        let foreign = UUID()
+        let activeOwnership = VoiceNoteRequestOwnership(requestID: owner, isWorkActive: true)
+
+        XCTAssertTrue(activeOwnership.accepts(requestID: owner))
+        XCTAssertFalse(activeOwnership.accepts(requestID: foreign))
+
+        let retryableOwnership = VoiceNoteRequestOwnership(requestID: owner, isWorkActive: false)
+        XCTAssertTrue(retryableOwnership.accepts(requestID: foreign))
+
+        let unknownActiveOwnership = VoiceNoteRequestOwnership(requestID: nil, isWorkActive: true)
+        XCTAssertFalse(unknownActiveOwnership.accepts(requestID: foreign))
+    }
+
+    func testLifecycleRunnerGenerationDistinguishesRetriesOfTheSameRequest() {
+        let sessionID = UUID()
+        let requestID = UUID()
+        let first = VoiceNoteLifecycleRunner(sessionID: sessionID, requestID: requestID)
+        let retry = VoiceNoteLifecycleRunner(sessionID: sessionID, requestID: requestID)
+
+        XCTAssertEqual(first.sessionID, retry.sessionID)
+        XCTAssertEqual(first.requestID, retry.requestID)
+        XCTAssertNotEqual(first.id, retry.id)
+    }
+
+    func testCheckpointRetentionPolicyKeepsOnlyRecoverableAudio() {
+        let protectedFailure = Muesli.RecordingSession(
+            kind: .quickDictation,
+            phase: .failed,
+            audioFileName: "protected.wav",
+            protectedAudioUntilTranscriptCompletes: true
+        )
+        XCTAssertFalse(
+            VoiceNoteCheckpointRetentionPolicy.shouldDeleteCheckpoints(for: protectedFailure)
+        )
+
+        let explicitlyDeleted = Muesli.RecordingSession(
+            kind: .quickDictation,
+            phase: .failed,
+            audioFileName: nil,
+            protectedAudioUntilTranscriptCompletes: false
+        )
+        XCTAssertTrue(
+            VoiceNoteCheckpointRetentionPolicy.shouldDeleteCheckpoints(for: explicitlyDeleted)
+        )
+
+        let failedShortNote = Muesli.RecordingSession(
+            kind: .keyboardDictation,
+            phase: .failed,
+            audioFileName: "short.wav",
+            longFormThresholdSeconds: 60
+        )
+        XCTAssertTrue(
+            VoiceNoteCheckpointRetentionPolicy.shouldDeleteCheckpoints(for: failedShortNote)
+        )
+
+        let activeShortNote = Muesli.RecordingSession(
+            kind: .keyboardDictation,
+            phase: .recording,
+            longFormThresholdSeconds: 60
+        )
+        XCTAssertFalse(
+            VoiceNoteCheckpointRetentionPolicy.shouldDeleteCheckpoints(for: activeShortNote)
+        )
+
+        let completed = Muesli.RecordingSession(kind: .quickDictation, phase: .completed)
+        XCTAssertTrue(VoiceNoteCheckpointRetentionPolicy.shouldDeleteCheckpoints(for: completed))
+        XCTAssertTrue(VoiceNoteCheckpointRetentionPolicy.shouldDeleteCheckpoints(for: nil))
+    }
+
     func testProtectedAudioSurvivesFailureUntilExplicitlyRetainedOrCompleted() {
         let protected = Muesli.RecordingSession(
             kind: .quickDictation,

--- a/Tests/MuesliTests/VoiceNoteLifecycleTests.swift
+++ b/Tests/MuesliTests/VoiceNoteLifecycleTests.swift
@@ -2,6 +2,22 @@ import XCTest
 @testable import Muesli
 
 final class VoiceNoteLifecycleTests: XCTestCase {
+    private enum RecoveryInventoryError: Error {
+        case unavailable
+    }
+
+    func testRecoveryInventoryDistinguishesLoadFailureFromEmptyInventory() throws {
+        let failure = VoiceNoteRecoveryInventory.load {
+            throw RecoveryInventoryError.unavailable
+        }
+        if case .success = failure {
+            XCTFail("A failed inventory load must abort destructive recovery cleanup")
+        }
+
+        let empty = VoiceNoteRecoveryInventory.load { [] }
+        XCTAssertEqual(try empty.get().sessions.count, 0)
+    }
+
     func testStopAndCancelRemainDeferredWhileRecorderStartupIsInFlight() {
         for action in [Muesli.DictationCommandAction.stop, .cancel] {
             XCTAssertTrue(KeyboardCommandArbitration.shouldDeferUntilRecorderStarts(
@@ -319,6 +335,20 @@ final class VoiceNoteLifecycleTests: XCTestCase {
 
         XCTAssertFalse(transition.accepted)
         XCTAssertEqual(transition.state, state)
+    }
+
+    func testPersistedRetryReleasesPreviousInactiveFailureThroughReducer() {
+        let previousID = UUID()
+        let retryID = UUID()
+        var state = VoiceNoteLifecycleState(phase: .failedRetryable(previousID))
+
+        let release = VoiceNoteLifecycleReducer.transition(state, event: .finished(previousID))
+        XCTAssertTrue(release.accepted)
+        state = release.state
+
+        let retry = VoiceNoteLifecycleReducer.transition(state, event: .retryRequested(retryID))
+        XCTAssertTrue(retry.accepted)
+        XCTAssertEqual(retry.state.phase, .transcriptionQueued(retryID))
     }
 
     func testFailureCanRetry() {

--- a/Tests/MuesliTests/VoiceNoteLifecycleTests.swift
+++ b/Tests/MuesliTests/VoiceNoteLifecycleTests.swift
@@ -250,6 +250,38 @@ final class VoiceNoteLifecycleTests: XCTestCase {
         XCTAssertNotEqual(first.id, retry.id)
     }
 
+    func testThirtySecondThresholdCheckpointsBeforeLongFormActivation() {
+        var schedule = VoiceNoteRecordingSchedule(thresholdSeconds: 30)
+
+        XCTAssertEqual(schedule.nextDeadlineSeconds, 30)
+        XCTAssertEqual(
+            schedule.consumeNextDeadline(),
+            [.checkpoint, .activateLongForm]
+        )
+        XCTAssertEqual(schedule.nextDeadlineSeconds, 60)
+    }
+
+    func testNonCheckpointThresholdActivatesAfterEarlierCheckpoint() {
+        var schedule = VoiceNoteRecordingSchedule(thresholdSeconds: 45)
+
+        XCTAssertEqual(schedule.consumeNextDeadline(), [.checkpoint])
+        XCTAssertEqual(schedule.nextDeadlineSeconds, 45)
+        XCTAssertEqual(schedule.consumeNextDeadline(), [.activateLongForm])
+        XCTAssertEqual(schedule.nextDeadlineSeconds, 60)
+    }
+
+    func testSixtySecondThresholdKeepsCheckpointAndActivationSerialized() {
+        var schedule = VoiceNoteRecordingSchedule(thresholdSeconds: 60)
+
+        XCTAssertEqual(schedule.consumeNextDeadline(), [.checkpoint])
+        XCTAssertEqual(schedule.nextDeadlineSeconds, 60)
+        XCTAssertEqual(
+            schedule.consumeNextDeadline(),
+            [.checkpoint, .activateLongForm]
+        )
+        XCTAssertEqual(schedule.nextDeadlineSeconds, 90)
+    }
+
     func testCheckpointRetentionPolicyKeepsOnlyRecoverableAudio() {
         let protectedFailure = Muesli.RecordingSession(
             kind: .quickDictation,

--- a/Tests/MuesliTests/VoiceNoteLifecycleTests.swift
+++ b/Tests/MuesliTests/VoiceNoteLifecycleTests.swift
@@ -316,4 +316,55 @@ final class VoiceNoteLifecycleTests: XCTestCase {
         XCTAssertEqual(VoiceNoteFailureLifecycleDisposition.resolve(for: short), .finished)
         XCTAssertEqual(VoiceNoteFailureLifecycleDisposition.resolve(for: long), .retryable)
     }
+
+    func testRecordingTerminationCausePreservesSpecificFailureReason() {
+        XCTAssertEqual(
+            VoiceNoteRecordingTerminationCause.interrupted.failureReason,
+            .interrupted
+        )
+        XCTAssertEqual(
+            VoiceNoteRecordingTerminationCause.checkpointFailure.failureReason,
+            .checkpointFailure
+        )
+    }
+
+    func testFailureSessionPolicyProtectsOnlyRecoverableLongFormAudio() {
+        let shortSession = Muesli.RecordingSession(
+            kind: .keyboardDictation,
+            phase: .transcribing,
+            audioFileName: "short.wav"
+        )
+        let failedShortSession = VoiceNoteFailureSessionPolicy.prepare(
+            shortSession,
+            reason: .timeout,
+            message: "Timed out",
+            hasRecoverableAudio: true
+        )
+
+        XCTAssertEqual(failedShortSession.phase, .failed)
+        XCTAssertEqual(failedShortSession.lastTranscriptionFailureReason, .timeout)
+        XCTAssertFalse(failedShortSession.protectedAudioUntilTranscriptCompletes)
+
+        let longSession = Muesli.RecordingSession(
+            kind: .keyboardDictation,
+            phase: .transcribing,
+            audioFileName: "long.wav",
+            isLongForm: true
+        )
+        let recoverableLongSession = VoiceNoteFailureSessionPolicy.prepare(
+            longSession,
+            reason: .timeout,
+            message: "Timed out",
+            hasRecoverableAudio: true
+        )
+        let unavailableLongSession = VoiceNoteFailureSessionPolicy.prepare(
+            longSession,
+            reason: .timeout,
+            message: "Timed out",
+            hasRecoverableAudio: false
+        )
+
+        XCTAssertTrue(recoverableLongSession.protectedAudioUntilTranscriptCompletes)
+        XCTAssertFalse(unavailableLongSession.protectedAudioUntilTranscriptCompletes)
+    }
 }

--- a/Tests/MuesliTests/VoiceNoteLifecycleTests.swift
+++ b/Tests/MuesliTests/VoiceNoteLifecycleTests.swift
@@ -29,6 +29,69 @@ final class VoiceNoteLifecycleTests: XCTestCase {
         )
     }
 
+    func testLifecycleRejectsLongFormActivationAfterStop() {
+        let id = UUID()
+        var state = VoiceNoteLifecycleReducer.reduce(.init(), event: .recordingStarted(id))
+        state = VoiceNoteLifecycleReducer.reduce(state, event: .stopRequested(id))
+
+        let transition = VoiceNoteLifecycleReducer.transition(
+            state,
+            event: .longFormActivated(id)
+        )
+
+        XCTAssertFalse(transition.accepted)
+        XCTAssertEqual(transition.state.phase, .stopping(id))
+    }
+
+    func testLifecycleRejectsOutOfOrderFinalizationAndQueueEvents() {
+        let id = UUID()
+        let recording = VoiceNoteLifecycleReducer.reduce(.init(), event: .recordingStarted(id))
+
+        let finalized = VoiceNoteLifecycleReducer.transition(
+            recording,
+            event: .audioFinalized(id)
+        )
+        let queued = VoiceNoteLifecycleReducer.transition(
+            recording,
+            event: .transcriptionQueued(id)
+        )
+
+        XCTAssertFalse(finalized.accepted)
+        XCTAssertFalse(queued.accepted)
+        XCTAssertEqual(finalized.state, recording)
+        XCTAssertEqual(queued.state, recording)
+    }
+
+    func testNewRecordingCanReplaceARecoverableFailedSession() {
+        let failedID = UUID()
+        let newID = UUID()
+        var state = VoiceNoteLifecycleReducer.reduce(.init(), event: .retryRequested(failedID))
+        state = VoiceNoteLifecycleReducer.reduce(state, event: .transcriptionStarted(failedID))
+        state = VoiceNoteLifecycleReducer.reduce(state, event: .transcriptionFailed(failedID))
+
+        let transition = VoiceNoteLifecycleReducer.transition(
+            state,
+            event: .recordingStarted(newID)
+        )
+
+        XCTAssertTrue(transition.accepted)
+        XCTAssertEqual(transition.state.phase, .recordingShort(newID))
+    }
+
+    func testCheckpointDisabledPathCanMoveFromStoppingDirectlyToTranscribing() {
+        let id = UUID()
+        var state = VoiceNoteLifecycleReducer.reduce(.init(), event: .recordingStarted(id))
+        state = VoiceNoteLifecycleReducer.reduce(state, event: .stopRequested(id))
+
+        let transition = VoiceNoteLifecycleReducer.transition(
+            state,
+            event: .transcriptionStarted(id)
+        )
+
+        XCTAssertTrue(transition.accepted)
+        XCTAssertEqual(transition.state.phase, .transcribing(id))
+    }
+
     func testLifecycleRejectsLateEventsAfterFinishing() {
         let id = UUID()
         let idle = VoiceNoteLifecycleState()
@@ -45,6 +108,95 @@ final class VoiceNoteLifecycleTests: XCTestCase {
             VoiceNoteLifecycleReducer.reduce(idle, event: .cancelRequested(id)),
             idle
         )
+    }
+
+    func testLifecycleTransitionGraphIsExplicit() {
+        let id = UUID()
+        let states: [(name: String, state: VoiceNoteLifecycleState)] = [
+            ("idle", .init()),
+            ("recordingShort", .init(phase: .recordingShort(id))),
+            ("recordingLongProtected", .init(phase: .recordingLongProtected(id))),
+            ("stopping", .init(phase: .stopping(id))),
+            ("audioSaved", .init(phase: .audioSaved(id))),
+            ("transcriptionQueued", .init(phase: .transcriptionQueued(id))),
+            ("transcribing", .init(phase: .transcribing(id))),
+            ("failedRetryable", .init(phase: .failedRetryable(id))),
+            ("cancelling", .init(phase: .cancelling(id))),
+        ]
+        let events: [(name: String, event: VoiceNoteLifecycleEvent)] = [
+            ("recordingStarted", .recordingStarted(id)),
+            ("longFormActivated", .longFormActivated(id)),
+            ("stopRequested", .stopRequested(id)),
+            ("audioFinalized", .audioFinalized(id)),
+            ("transcriptionQueued", .transcriptionQueued(id)),
+            ("transcriptionStarted", .transcriptionStarted(id)),
+            ("transcriptionFailed", .transcriptionFailed(id)),
+            ("retryRequested", .retryRequested(id)),
+            ("cancelRequested", .cancelRequested(id)),
+            ("finished", .finished(id)),
+        ]
+        let acceptedPairs: Set<String> = [
+            "idle.recordingStarted",
+            "idle.retryRequested",
+            "recordingShort.recordingStarted",
+            "recordingShort.longFormActivated",
+            "recordingShort.stopRequested",
+            "recordingShort.cancelRequested",
+            "recordingShort.finished",
+            "recordingLongProtected.stopRequested",
+            "recordingLongProtected.cancelRequested",
+            "recordingLongProtected.finished",
+            "stopping.audioFinalized",
+            "stopping.transcriptionStarted",
+            "stopping.transcriptionFailed",
+            "stopping.cancelRequested",
+            "stopping.finished",
+            "audioSaved.transcriptionQueued",
+            "audioSaved.transcriptionStarted",
+            "audioSaved.transcriptionFailed",
+            "audioSaved.finished",
+            "transcriptionQueued.transcriptionStarted",
+            "transcriptionQueued.transcriptionFailed",
+            "transcriptionQueued.finished",
+            "transcribing.transcriptionFailed",
+            "transcribing.finished",
+            "failedRetryable.recordingStarted",
+            "failedRetryable.retryRequested",
+            "failedRetryable.finished",
+            "cancelling.finished",
+        ]
+
+        for state in states {
+            for event in events {
+                let pair = "\(state.name).\(event.name)"
+                let transition = VoiceNoteLifecycleReducer.transition(
+                    state.state,
+                    event: event.event
+                )
+                XCTAssertEqual(
+                    transition.accepted,
+                    acceptedPairs.contains(pair),
+                    "Unexpected transition contract for \(pair)"
+                )
+                if !transition.accepted {
+                    XCTAssertEqual(transition.state, state.state)
+                }
+            }
+        }
+    }
+
+    func testFailedRetryRejectsAnotherSessionsRequest() {
+        let activeID = UUID()
+        let staleID = UUID()
+        let state = VoiceNoteLifecycleState(phase: .failedRetryable(activeID))
+
+        let transition = VoiceNoteLifecycleReducer.transition(
+            state,
+            event: .retryRequested(staleID)
+        )
+
+        XCTAssertFalse(transition.accepted)
+        XCTAssertEqual(transition.state, state)
     }
 
     func testFailureCanRetry() {
@@ -155,5 +307,13 @@ final class VoiceNoteLifecycleTests: XCTestCase {
 
         let retained = Muesli.RecordingSession(kind: .quickDictation, keepsAudioRecording: true)
         XCTAssertFalse(VoiceNoteAudioRetentionPolicy.shouldDeleteAudioAfterSuccess(retained))
+    }
+
+    func testFailureDispositionKeepsOnlyLongNotesRetryable() {
+        let short = Muesli.RecordingSession(kind: .quickDictation, isLongForm: false)
+        let long = Muesli.RecordingSession(kind: .quickDictation, isLongForm: true)
+
+        XCTAssertEqual(VoiceNoteFailureLifecycleDisposition.resolve(for: short), .finished)
+        XCTAssertEqual(VoiceNoteFailureLifecycleDisposition.resolve(for: long), .retryable)
     }
 }

--- a/Tests/MuesliUITests/MuesliSmokeUITests.swift
+++ b/Tests/MuesliUITests/MuesliSmokeUITests.swift
@@ -32,4 +32,41 @@ final class MuesliSmokeUITests: XCTestCase {
         XCTAssertTrue(app.staticTexts["Meetings"].waitForExistence(timeout: 5))
         XCTAssertTrue(app.staticTexts["Start a new meeting"].waitForExistence(timeout: 5))
     }
+
+    func testLongVoiceNoteAutomaticallyPresentsAfterInjectedThreshold() {
+        let app = XCUIApplication()
+        app.launchArguments = [
+            "--muesli-ui-testing",
+            "--muesli-long-note-threshold-seconds=1",
+        ]
+        addUIInterruptionMonitor(withDescription: "Microphone permission") { alert in
+            let allowButton = alert.buttons["Allow"]
+            if allowButton.exists {
+                allowButton.tap()
+                return true
+            }
+            return false
+        }
+        app.launch()
+
+        let recordButton = app.buttons["Start Voice Note"].firstMatch
+        XCTAssertTrue(recordButton.waitForExistence(timeout: 8))
+        recordButton.tap()
+        app.tap()
+
+        XCTAssertTrue(app.staticTexts["Long Voice Note"].waitForExistence(timeout: 8))
+        XCTAssertTrue(app.buttons["longVoiceNote.stopButton"].exists)
+        XCTAssertTrue(
+            app.staticTexts["Audio saved locally"].exists
+                || app.staticTexts["Securing audio"].exists
+        )
+        let screenshot = XCTAttachment(screenshot: app.screenshot())
+        screenshot.name = "Long Voice Note active state"
+        screenshot.lifetime = .keepAlways
+        add(screenshot)
+
+        app.buttons["Discard voice note"].tap()
+        XCTAssertTrue(app.buttons["Discard Voice Note"].waitForExistence(timeout: 3))
+        app.buttons["Discard Voice Note"].tap()
+    }
 }

--- a/Tests/MuesliUITests/MuesliSmokeUITests.swift
+++ b/Tests/MuesliUITests/MuesliSmokeUITests.swift
@@ -33,33 +33,17 @@ final class MuesliSmokeUITests: XCTestCase {
         XCTAssertTrue(app.staticTexts["Start a new meeting"].waitForExistence(timeout: 5))
     }
 
-    func testLongVoiceNoteAutomaticallyPresentsAfterInjectedThreshold() {
+    func testLongVoiceNoteActiveStateAndDiscardConfirmation() {
         let app = XCUIApplication()
         app.launchArguments = [
             "--muesli-ui-testing",
-            "--muesli-long-note-threshold-seconds=1",
+            "--muesli-ui-testing-long-voice-note",
         ]
-        addUIInterruptionMonitor(withDescription: "Microphone permission") { alert in
-            let allowButton = alert.buttons["Allow"]
-            if allowButton.exists {
-                allowButton.tap()
-                return true
-            }
-            return false
-        }
         app.launch()
-
-        let recordButton = app.buttons["Start Voice Note"].firstMatch
-        XCTAssertTrue(recordButton.waitForExistence(timeout: 8))
-        recordButton.tap()
-        app.tap()
 
         XCTAssertTrue(app.staticTexts["Long Voice Note"].waitForExistence(timeout: 8))
         XCTAssertTrue(app.buttons["longVoiceNote.stopButton"].exists)
-        XCTAssertTrue(
-            app.staticTexts["Audio saved locally"].exists
-                || app.staticTexts["Securing audio"].exists
-        )
+        XCTAssertTrue(app.staticTexts["Audio saved locally"].exists)
         let screenshot = XCTAttachment(screenshot: app.screenshot())
         screenshot.name = "Long Voice Note active state"
         screenshot.lifetime = .keepAlways
@@ -67,6 +51,5 @@ final class MuesliSmokeUITests: XCTestCase {
 
         app.buttons["Discard voice note"].tap()
         XCTAssertTrue(app.buttons["Discard Voice Note"].waitForExistence(timeout: 3))
-        app.buttons["Discard Voice Note"].tap()
     }
 }

--- a/Tests/MuesliUITests/MuesliSmokeUITests.swift
+++ b/Tests/MuesliUITests/MuesliSmokeUITests.swift
@@ -52,4 +52,19 @@ final class MuesliSmokeUITests: XCTestCase {
         app.buttons["Discard voice note"].tap()
         XCTAssertTrue(app.buttons["Discard Voice Note"].waitForExistence(timeout: 3))
     }
+
+    func testCompletedLongVoiceNoteHidesProgressChecklist() {
+        let app = XCUIApplication()
+        app.launchArguments = [
+            "--muesli-ui-testing",
+            "--muesli-ui-testing-completed-long-voice-note",
+        ]
+        app.launch()
+
+        XCTAssertTrue(app.staticTexts["Long Voice Note"].waitForExistence(timeout: 8))
+        XCTAssertTrue(app.staticTexts["Completed long voice note transcript."].exists)
+        XCTAssertFalse(app.staticTexts["Voice note ready"].exists)
+        XCTAssertFalse(app.staticTexts["Audio saved"].exists)
+        XCTAssertFalse(app.staticTexts["Transcribing"].exists)
+    }
 }


### PR DESCRIPTION
## Summary

Adds Long Voice Note Reliability Mode for in-app and keyboard recordings. Recordings crossing the configured threshold retain recoverable audio until transcription succeeds or the user explicitly deletes it.

This revision also replaces app/keyboard polling with event-driven cross-process coordination: SQLite remains authoritative, payload-free Darwin notifications invalidate cached state, and all commands still pass through the coordinator and voice-note reducer.

## Reliability architecture

- Shared voice-note lifecycle reducer and runner own activation, stopping, transcription, retry, cancellation, and stale-task rejection.
- Finalized WAV checkpoints and atomic manifests provide process-death recovery.
- Long-form failures preserve recoverable audio and expose explicit retry/keep/delete actions.
- Long-form promotion is centralized across scheduled activation, stop-time catch-up, and recording interruption.
- Foreground recovery is single-flight, validates failed sessions once, and immediately removes unusable checkpoint directories.
- Checkpoint writer cancellation removes continuous audio and all rotated chunks.

## Keyboard coordination

- App Group SQLite stores durable commands, handoff state, ownership, runtime status, and results.
- Darwin notifications are payload-free change signals posted only after successful database mutations.
- The keyboard performs one initial refresh and event-targeted reads; the old 500 ms/125 ms polling loops and the app's 500 ms/250 ms command loops are removed.
- Start, stop, and cancel commands require persisted acknowledgements, retry their notification once after 750 ms, and fall back to the existing URL handoff after two seconds.
- Stop/cancel intents received during recorder startup remain persisted until startup succeeds or fails.
- The coordinator remains the sole command arbiter and rejects keyboard starts while another voice note or meeting owns capture.
- The keyboard uses an animated activity waveform rather than cross-process microphone-level writes.
- A throttled 10-second liveness update exists only during active keyboard recording; there is no recurring idle reconciliation.

## UX and settings

- Configurable long-note threshold with common presets and custom values.
- Full-screen long-note recording surface with truthful checkpoint status, scratchpad, waveform, and explicit stop/discard actions.
- Completed notes no longer show a redundant three-step status checklist.
- Recovery UI appears only for failures; Retry Transcript requires a durable checkpoint and audio reference.
- Threshold telemetry is centralized across presets, custom entry, and stepper changes.

## Validation

- Full unit and UI suite: 116 tests passed, 0 failures.
- Tests cover post-commit event delivery, two-store visibility, failed-write suppression, duplicate invalidations, Darwin delivery, ownership arbitration, startup stop/cancel deferral, checkpoint cancellation, actor-serialized salvage, persistence compatibility, lifecycle transitions, and long-note UI states.
- `xcodegen generate` and simulator build/test passed.
- `git diff --check` passed.

## Physical-device follow-up

Validate active hot-mic keyboard start/stop/cancel, suspended-app URL fallback, rapid keyboard actions during recorder startup, a 61-second app note, a 61-second keyboard note, screen lock/background recording, process termination after checkpointing, retry success, and audio-retention behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Long Voice Note Mode with configurable activation thresholds.
  * Added a dedicated voice-note screen with live recording status, scratchpad editing, playback, transcription progress, and recovery actions.
  * Added reliable local audio checkpoints to preserve recordings during interruptions or failures.
  * Added voice-note history entries with recovery, retention, deletion, and retry options.
  * Added keyboard blocking and clearer status messaging while an app voice note is active.

* **Bug Fixes**
  * Improved recovery after interruptions, failed transcription, recording finalization, and media-service resets.
  * Improved cross-process status updates and keyboard handoff behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->