### PR TITLE
Refresh navigation and standardize voice note previews

### DIFF
--- a/Muesli/DictationCoordinator.swift
+++ b/Muesli/DictationCoordinator.swift
@@ -216,6 +216,19 @@ struct MeetingLifecycleRunner {
     }
 }
 
+enum RecordingSessionInventory {
+    static func preservingActiveSession(
+        _ activeSession: RecordingSession?,
+        in persistedSessions: [RecordingSession]
+    ) -> [RecordingSession] {
+        guard let activeSession,
+              !persistedSessions.contains(where: { $0.id == activeSession.id })
+        else { return persistedSessions }
+
+        return [activeSession] + persistedSessions
+    }
+}
+
 @MainActor
 @Observable
 final class DictationCoordinator {
@@ -1416,11 +1429,31 @@ final class DictationCoordinator {
             detail: "UI testing"
         )
 
-        if ProcessInfo.processInfo.arguments.contains(MuesliAppConstants.completedLongVoiceNoteUITestLaunchArgument) {
+        if ProcessInfo.processInfo.arguments.contains(MuesliAppConstants.missingActiveMeetingHistoryUITestLaunchArgument) {
+            configureMissingActiveMeetingHistoryUITestFixture()
+        } else if ProcessInfo.processInfo.arguments.contains(MuesliAppConstants.completedLongVoiceNoteUITestLaunchArgument) {
             configureCompletedLongVoiceNoteUITestFixture()
         } else if ProcessInfo.processInfo.arguments.contains(MuesliAppConstants.longVoiceNoteUITestLaunchArgument) {
             configureLongVoiceNoteUITestFixture()
         }
+    }
+
+    private func configureMissingActiveMeetingHistoryUITestFixture() {
+        let session = RecordingSession(
+            kind: .meeting,
+            title: "Recovered Live Meeting",
+            startedAt: Date.now.addingTimeInterval(-20),
+            phase: .recording,
+            source: "iphone"
+        )
+
+        activeSession = session
+        recordingSessions = []
+        isMeetingRecording = true
+        meetingStatusText = "Recording"
+        meetingLifecycleRunner = MeetingLifecycleRunner(sessionID: session.id)
+        transitionMeetingLifecycle(.startRequested(session.id))
+        transitionMeetingLifecycle(.recordingStarted(session.id))
     }
 
     private func configureLongVoiceNoteUITestFixture() {
@@ -1543,7 +1576,25 @@ final class DictationCoordinator {
         #endif
         do {
             dictationHistory = try store.resultsHistory()
-            recordingSessions = try store.recordingSessions()
+            let persistedSessions = try store.recordingSessions()
+            let repairedSessions = RecordingSessionInventory.preservingActiveSession(
+                activeSession,
+                in: persistedSessions
+            )
+            if let activeSession,
+               !persistedSessions.contains(where: { $0.id == activeSession.id }) {
+                AppTelemetry.failure(
+                    "recording_session_inventory_repaired",
+                    domain: .stateMachine,
+                    stage: "history_refresh",
+                    reason: "active_session_missing",
+                    parameters: [
+                        "kind": activeSession.kind.rawValue,
+                        "phase": activeSession.phase.rawValue,
+                    ]
+                )
+            }
+            recordingSessions = repairedSessions
             transcriptCache = transcriptsBySessionID(try store.transcripts())
             lastTranscript = dictationHistory.first?.text ?? lastTranscript
         } catch {
@@ -2054,6 +2105,19 @@ final class DictationCoordinator {
             }
         }
         return nil
+    }
+
+    func meetingSession(id: UUID) -> RecordingSession? {
+        if let cachedSession = recordingSessions.first(where: { $0.id == id && $0.kind == .meeting }) {
+            return cachedSession
+        }
+        if let activeSession, activeSession.id == id, activeSession.kind == .meeting {
+            return activeSession
+        }
+        guard let storedSession = try? store.activeRecordingSession(id: id),
+              storedSession.kind == .meeting
+        else { return nil }
+        return storedSession
     }
 
     func audioFileURL(for result: DictationResult) -> URL? {

--- a/Muesli/DictationView.swift
+++ b/Muesli/DictationView.swift
@@ -19,9 +19,10 @@ struct DictationView: View {
     @State private var shouldShowKeyboardSetupRow = false
     @State private var previewInputLevel = 0.0
     @State private var dashboardStats = DictationDashboardStats.empty
+    @State private var navigationPath = NavigationPath()
 
     var body: some View {
-        NavigationStack {
+        NavigationStack(path: $navigationPath) {
             ScrollView {
                 LazyVStack(alignment: .leading, spacing: MuesliTheme.spacing16) {
                     header
@@ -591,40 +592,24 @@ struct DictationView: View {
                                 coordinator.openLongVoiceNote(session)
                             }
                         case .completed(let result, let session):
-                        let hasRetainedAudio = session?.keepsAudioRecording == true
-                            && session.flatMap { coordinator.audioFileURL(for: $0) } != nil
-                            if session?.isLongForm == true {
-                                Button {
-                                    if let session {
-                                        coordinator.openLongVoiceNote(session)
-                                    }
-                                } label: {
-                                    DictationHistoryRow(
+                            let hasRetainedAudio = session?.keepsAudioRecording == true
+                                && session.flatMap { coordinator.audioFileURL(for: $0) } != nil
+                            let canOpen = session?.isLongForm == true || hasRetainedAudio
+
+                            DictationHistoryRow(
+                                result: result,
+                                session: session,
+                                hasRetainedAudio: hasRetainedAudio,
+                                onOpen: canOpen ? {
+                                    openCompletedVoiceNote(
                                         result: result,
-                                        hasRetainedAudio: hasRetainedAudio,
-                                        onCopy: { coordinator.copyToClipboard(result) },
-                                        onDelete: { coordinator.deleteDictation(result) }
+                                        session: session,
+                                        hasRetainedAudio: hasRetainedAudio
                                     )
-                                }
-                                .buttonStyle(.plain)
-                            } else if hasRetainedAudio {
-                                NavigationLink(value: result.id) {
-                                    DictationHistoryRow(
-                                        result: result,
-                                        hasRetainedAudio: true,
-                                        onCopy: { coordinator.copyToClipboard(result) },
-                                        onDelete: { coordinator.deleteDictation(result) }
-                                    )
-                                }
-                                .buttonStyle(.plain)
-                            } else {
-                                DictationHistoryRow(
-                                    result: result,
-                                    hasRetainedAudio: false,
-                                    onCopy: { coordinator.copyToClipboard(result) },
-                                    onDelete: { coordinator.deleteDictation(result) }
-                                )
-                            }
+                                } : nil,
+                                onCopy: { coordinator.copyToClipboard(result) },
+                                onDelete: { coordinator.deleteDictation(result) }
+                            )
                         }
                     }
                 }
@@ -641,8 +626,15 @@ struct DictationView: View {
     }
 
     private var voiceNoteTimeline: [VoiceNoteTimelineItem] {
+        var sessions = coordinator.recordingSessions
+        #if DEBUG
+        if shouldUseMockDictations {
+            sessions = Self.mockRecordingSessions
+        }
+        #endif
+
         let sessionsByID = Dictionary(
-            uniqueKeysWithValues: coordinator.recordingSessions.map { ($0.id, $0) }
+            uniqueKeysWithValues: sessions.map { ($0.id, $0) }
         )
         let completed = filteredHistory.map { result in
             VoiceNoteTimelineItem.completed(
@@ -652,6 +644,18 @@ struct DictationView: View {
         }
         let recoverable = filteredRecoverableVoiceNotes.map(VoiceNoteTimelineItem.recoverable)
         return VoiceNoteTimelineItem.mergeNewestFirst(completed, recoverable)
+    }
+
+    private func openCompletedVoiceNote(
+        result: DictationResult,
+        session: RecordingSession?,
+        hasRetainedAudio: Bool
+    ) {
+        if let session, session.isLongForm {
+            coordinator.openLongVoiceNote(session)
+        } else if hasRetainedAudio {
+            navigationPath.append(result.id)
+        }
     }
 
     private var statsHistory: [DictationResult] {
@@ -846,31 +850,68 @@ struct DictationView: View {
     }
 
     #if DEBUG
+    private static let mockLongVoiceNoteSessionID = UUID(uuidString: "B5D51EAA-7A0A-42CE-B25A-E01F71000001")!
+    private static let mockNotesSessionID = UUID(uuidString: "B5D51EAA-7A0A-42CE-B25A-E01F71000002")!
+
     private static let mockDictationHistory: [DictationResult] = {
         let calendar = Calendar.current
         let baseDate = calendar.date(from: DateComponents(year: 2026, month: 6, day: 30, hour: 13, minute: 30)) ?? .now
-        let samples: [(String, String?)] = [
-            ("Is this the best animation and UI that we could come up with", "ios"),
-            ("The capture screen should feel like a local first console, fast enough to open and start speaking without thinking about folders or setup.", "ios"),
-            ("Currently bleeding talent to the inference giants", "macOS"),
-            ("We should test the magnified top note while scrolling because this is the exact state people will read after recording a quick thought.", "ios"),
-            ("The Mac companion app can stay focused on longer workflows while the phone stays optimized for immediate capture.", "macOS"),
-            ("Meeting notes need the same private sync language, but the voice note screen should remain lighter and faster.", "ios"),
-            ("If a note is imported from the Mac, keep the provenance visible but do not let the chip overpower the transcript.", "macOS"),
-            ("The tab bar should feel stable and tappable, with blue as the active state and green reserved for sync confidence.", "ios"),
-            ("Keep the interface blue black white and green so the product feels consistent across phone and Mac.", "ios"),
-            ("When the top card grows, the surrounding cards should stay quiet so the reading focus feels intentional rather than busy.", "macOS")
+        let samples: [(String, String?, UUID?)] = [
+            (
+                "A longer voice note should stay easy to scan in the timeline even when the transcript contains several paragraphs. The preview needs a predictable height so one recording cannot take over the entire screen. Keep the first four lines visible, preserve the full transcript, and let the reader expand it only when they want the additional context.",
+                "ios",
+                mockLongVoiceNoteSessionID
+            ),
+            ("The capture screen should feel like a local first console, fast enough to open and start speaking without thinking about folders or setup.", "ios", mockNotesSessionID),
+            ("Currently bleeding talent to the inference giants", "macOS", nil),
+            ("We should test the magnified top note while scrolling because this is the exact state people will read after recording a quick thought.", "ios", nil),
+            ("The Mac companion app can stay focused on longer workflows while the phone stays optimized for immediate capture.", "macOS", nil),
+            ("Meeting notes need the same private sync language, but the voice note screen should remain lighter and faster.", "ios", nil),
+            ("If a note is imported from the Mac, keep the provenance visible but do not let the chip overpower the transcript.", "macOS", nil),
+            ("The tab bar should feel stable and tappable, with blue as the active state and green reserved for sync confidence.", "ios", nil),
+            ("Keep the interface blue black white and green so the product feels consistent across phone and Mac.", "ios", nil),
+            ("When the top card grows, the surrounding cards should stay quiet so the reading focus feels intentional rather than busy.", "macOS", nil)
         ]
 
         return samples.enumerated().map { index, sample in
             DictationResult(
                 requestID: UUID(),
+                sessionID: sample.2,
                 text: sample.0,
                 createdAt: calendar.date(byAdding: .minute, value: -index * 47, to: baseDate) ?? baseDate,
                 engineIdentifier: sample.1 == "macOS" ? "icloud" : "parakeet",
                 source: sample.1
             )
         }
+    }()
+
+    private static let mockRecordingSessions: [RecordingSession] = {
+        let now = Date.now
+        return [
+            RecordingSession(
+                id: mockLongVoiceNoteSessionID,
+                kind: .quickDictation,
+                createdAt: now,
+                startedAt: now.addingTimeInterval(-185),
+                endedAt: now,
+                phase: .completed,
+                source: "ios",
+                isLongForm: true,
+                longFormActivatedAt: now.addingTimeInterval(-125),
+                longFormThresholdSeconds: 60,
+                scratchpadText: "Follow up on the timeline design."
+            ),
+            RecordingSession(
+                id: mockNotesSessionID,
+                kind: .quickDictation,
+                createdAt: now.addingTimeInterval(-47 * 60),
+                startedAt: now.addingTimeInterval(-48 * 60),
+                endedAt: now.addingTimeInterval(-47 * 60),
+                phase: .completed,
+                source: "ios",
+                manualNotes: "Check the capture flow with the team."
+            )
+        ]
     }()
     #endif
 }
@@ -1398,12 +1439,38 @@ private struct DictationSourceFilterPicker: View {
 
 private struct DictationHistoryRow: View {
     let result: DictationResult
+    let session: RecordingSession?
     let hasRetainedAudio: Bool
+    let onOpen: (() -> Void)?
     let onCopy: () -> Void
     let onDelete: () -> Void
     @State private var isConfirmingDelete = false
 
     var body: some View {
+        Group {
+            if let onOpen {
+                rowSurface
+                    .contentShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium, style: .continuous))
+                    .onTapGesture(perform: onOpen)
+                    .accessibilityAddTraits(.isButton)
+                    .accessibilityAction(named: "Open voice note", onOpen)
+            } else {
+                rowSurface
+            }
+        }
+        .confirmationDialog(
+            "Delete this voice note?",
+            isPresented: $isConfirmingDelete,
+            titleVisibility: .visible
+        ) {
+            Button("Delete Voice Note", role: .destructive, action: onDelete)
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("This removes the voice note from local history.")
+        }
+    }
+
+    private var rowSurface: some View {
         MuesliSwipeActionRow(
             leadingAction: .init(
                 title: "Delete",
@@ -1432,16 +1499,6 @@ private struct DictationHistoryRow: View {
                 }
             }
         }
-        .confirmationDialog(
-            "Delete this voice note?",
-            isPresented: $isConfirmingDelete,
-            titleVisibility: .visible
-        ) {
-            Button("Delete Voice Note", role: .destructive, action: onDelete)
-            Button("Cancel", role: .cancel) {}
-        } message: {
-            Text("This removes the voice note from local history.")
-        }
     }
 
     private var rowContent: some View {
@@ -1466,15 +1523,28 @@ private struct DictationHistoryRow: View {
                         .accessibilityHidden(true)
                 }
 
+                if session?.hasUserAuthoredNotes == true {
+                    VoiceNoteAttributeIcon(
+                        systemImage: "note.text",
+                        accessibilityLabel: "Has manual notes",
+                        identifier: "voiceNote.badge.notes",
+                        tint: MuesliTheme.textSecondary
+                    )
+                }
+
+                if session?.isLongForm == true {
+                    VoiceNoteAttributeIcon(
+                        systemImage: "clock",
+                        accessibilityLabel: "Long voice note",
+                        identifier: "voiceNote.badge.longForm",
+                        tint: MuesliTheme.accent
+                    )
+                }
+
                 DictationOriginChip(origin: origin)
             }
 
-            Text(result.text)
-                .font(MuesliTheme.transcript())
-                .foregroundStyle(MuesliTheme.textPrimary)
-                .lineSpacing(2)
-                .textSelection(.enabled)
-                .fixedSize(horizontal: false, vertical: true)
+            ExpandableTranscriptPreview(text: result.text, resultID: result.id)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
     }
@@ -1489,6 +1559,94 @@ private struct DictationHistoryRow: View {
         formatter.timeStyle = .short
         return formatter
     }()
+}
+
+private struct VoiceNoteAttributeIcon: View {
+    let systemImage: String
+    let accessibilityLabel: String
+    let identifier: String
+    let tint: Color
+
+    var body: some View {
+        Image(systemName: systemImage)
+            .font(.system(size: 11, weight: .semibold))
+            .foregroundStyle(tint)
+            .frame(width: 24, height: 24)
+            .background(tint.opacity(0.10))
+            .clipShape(Circle())
+            .overlay(Circle().strokeBorder(tint.opacity(0.18), lineWidth: 0.7))
+            .accessibilityLabel(accessibilityLabel)
+            .accessibilityIdentifier(identifier)
+    }
+}
+
+private struct ExpandableTranscriptPreview: View {
+    let text: String
+    let resultID: UUID
+    @State private var isExpanded = false
+    @State private var collapsedHeight: CGFloat = 0
+    @State private var fullHeight: CGFloat = 0
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: MuesliTheme.spacing4) {
+            transcript(lineLimit: isExpanded ? nil : 4)
+                .background(measuredTranscript(lineLimit: 4, key: "collapsed"))
+                .background(measuredTranscript(lineLimit: nil, key: "full"))
+                .textSelection(.enabled)
+
+            if isTruncated {
+                Button(isExpanded ? "Show less" : "Read more") {
+                    withAnimation(.snappy(duration: 0.22)) {
+                        isExpanded.toggle()
+                    }
+                }
+                .font(MuesliTheme.captionMedium())
+                .foregroundStyle(MuesliTheme.accent)
+                .buttonStyle(.plain)
+                .accessibilityIdentifier("dictation.readMore.\(resultID.uuidString)")
+            }
+        }
+        .onPreferenceChange(TranscriptPreviewHeightKey.self) { heights in
+            collapsedHeight = heights["collapsed"] ?? collapsedHeight
+            fullHeight = heights["full"] ?? fullHeight
+        }
+    }
+
+    private var isTruncated: Bool {
+        fullHeight > collapsedHeight + 1
+    }
+
+    private func transcript(lineLimit: Int?) -> some View {
+        Text(text)
+            .font(MuesliTheme.transcript())
+            .foregroundStyle(MuesliTheme.textPrimary)
+            .lineSpacing(2)
+            .lineLimit(lineLimit)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .fixedSize(horizontal: false, vertical: true)
+    }
+
+    private func measuredTranscript(lineLimit: Int?, key: String) -> some View {
+        transcript(lineLimit: lineLimit)
+            .hidden()
+            .accessibilityHidden(true)
+            .background {
+                GeometryReader { proxy in
+                    Color.clear.preference(
+                        key: TranscriptPreviewHeightKey.self,
+                        value: [key: proxy.size.height]
+                    )
+                }
+            }
+    }
+}
+
+private struct TranscriptPreviewHeightKey: PreferenceKey {
+    static let defaultValue: [String: CGFloat] = [:]
+
+    static func reduce(value: inout [String: CGFloat], nextValue: () -> [String: CGFloat]) {
+        value.merge(nextValue(), uniquingKeysWith: { _, new in new })
+    }
 }
 
 private struct DictationAudioDetailView: View {

--- a/Muesli/DictationView.swift
+++ b/Muesli/DictationView.swift
@@ -1453,6 +1453,7 @@ private struct DictationHistoryRow: View {
                 rowSurface
                     .contentShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium, style: .continuous))
                     .onTapGesture(perform: onOpen)
+                    .accessibilityElement(children: .contain)
                     .accessibilityAddTraits(.isButton)
                     .accessibilityAction(named: "Open voice note", onOpen)
             } else {

--- a/Muesli/DictationView.swift
+++ b/Muesli/DictationView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 import UniformTypeIdentifiers
 #if canImport(UIKit)
+import CoreText
 import UIKit
 #endif
 
@@ -1583,15 +1584,25 @@ private struct VoiceNoteAttributeIcon: View {
 private struct ExpandableTranscriptPreview: View {
     let text: String
     let resultID: UUID
+    @Environment(\.sizeCategory) private var sizeCategory
     @State private var isExpanded = false
-    @State private var collapsedHeight: CGFloat = 0
-    @State private var fullHeight: CGFloat = 0
+    @State private var availableWidth: CGFloat = 0
+    @State private var isTruncated = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: MuesliTheme.spacing4) {
             transcript(lineLimit: isExpanded ? nil : 4)
-                .background(measuredTranscript(lineLimit: 4, key: "collapsed"))
-                .background(measuredTranscript(lineLimit: nil, key: "full"))
+                .background {
+                    GeometryReader { proxy in
+                        Color.clear
+                            .onAppear {
+                                updateOverflow(for: proxy.size.width)
+                            }
+                            .onChange(of: proxy.size.width) { _, width in
+                                updateOverflow(for: width)
+                            }
+                    }
+                }
                 .textSelection(.enabled)
 
             if isTruncated {
@@ -1606,14 +1617,12 @@ private struct ExpandableTranscriptPreview: View {
                 .accessibilityIdentifier("dictation.readMore.\(resultID.uuidString)")
             }
         }
-        .onPreferenceChange(TranscriptPreviewHeightKey.self) { heights in
-            collapsedHeight = heights["collapsed"] ?? collapsedHeight
-            fullHeight = heights["full"] ?? fullHeight
+        .onChange(of: text) { _, _ in
+            updateOverflow(for: availableWidth)
         }
-    }
-
-    private var isTruncated: Bool {
-        fullHeight > collapsedHeight + 1
+        .onChange(of: sizeCategory) { _, _ in
+            updateOverflow(for: availableWidth)
+        }
     }
 
     private func transcript(lineLimit: Int?) -> some View {
@@ -1626,26 +1635,78 @@ private struct ExpandableTranscriptPreview: View {
             .fixedSize(horizontal: false, vertical: true)
     }
 
-    private func measuredTranscript(lineLimit: Int?, key: String) -> some View {
-        transcript(lineLimit: lineLimit)
-            .hidden()
-            .accessibilityHidden(true)
-            .background {
-                GeometryReader { proxy in
-                    Color.clear.preference(
-                        key: TranscriptPreviewHeightKey.self,
-                        value: [key: proxy.size.height]
-                    )
-                }
-            }
+    private func updateOverflow(for width: CGFloat) {
+        guard width > 0 else { return }
+        if abs(availableWidth - width) > 0.5 {
+            availableWidth = width
+        }
+        let overflow = TranscriptOverflowDetector.isTruncated(
+            text,
+            width: width,
+            lineLimit: 4,
+            sizeCategory: sizeCategory
+        )
+        if isTruncated != overflow {
+            isTruncated = overflow
+        }
     }
 }
 
-private struct TranscriptPreviewHeightKey: PreferenceKey {
-    static let defaultValue: [String: CGFloat] = [:]
+@MainActor
+enum TranscriptOverflowDetector {
+    private static let sampleCharacterLimit = 2_048
 
-    static func reduce(value: inout [String: CGFloat], nextValue: () -> [String: CGFloat]) {
-        value.merge(nextValue(), uniquingKeysWith: { _, new in new })
+    static func isTruncated(
+        _ text: String,
+        width: CGFloat,
+        lineLimit: Int,
+        sizeCategory: ContentSizeCategory
+    ) -> Bool {
+        guard !text.isEmpty, width > 0, lineLimit > 0 else { return false }
+
+        let traits = UITraitCollection(preferredContentSizeCategory: sizeCategory.uiKitCategory)
+        let font = UIFont.preferredFont(forTextStyle: .body, compatibleWith: traits)
+        let sampleEnd = text.index(
+            text.startIndex,
+            offsetBy: sampleCharacterLimit,
+            limitedBy: text.endIndex
+        ) ?? text.endIndex
+        let omittedRemainder = sampleEnd < text.endIndex
+        let attributedText = NSAttributedString(
+            string: String(text[..<sampleEnd]),
+            attributes: [.font: font]
+        )
+        let typesetter = CTTypesetterCreateWithAttributedString(attributedText)
+        var location = 0
+
+        for _ in 0..<lineLimit {
+            guard location < attributedText.length else { return false }
+            let lineLength = CTTypesetterSuggestLineBreak(typesetter, location, width)
+            guard lineLength > 0 else { return true }
+            location += lineLength
+        }
+
+        return location < attributedText.length || omittedRemainder
+    }
+}
+
+private extension ContentSizeCategory {
+    var uiKitCategory: UIContentSizeCategory {
+        switch self {
+        case .extraSmall: .extraSmall
+        case .small: .small
+        case .medium: .medium
+        case .large: .large
+        case .extraLarge: .extraLarge
+        case .extraExtraLarge: .extraExtraLarge
+        case .extraExtraExtraLarge: .extraExtraExtraLarge
+        case .accessibilityMedium: .accessibilityMedium
+        case .accessibilityLarge: .accessibilityLarge
+        case .accessibilityExtraLarge: .accessibilityExtraLarge
+        case .accessibilityExtraExtraLarge: .accessibilityExtraExtraLarge
+        case .accessibilityExtraExtraExtraLarge: .accessibilityExtraExtraExtraLarge
+        @unknown default: .large
+        }
     }
 }
 

--- a/Muesli/MeetingsView.swift
+++ b/Muesli/MeetingsView.swift
@@ -101,7 +101,7 @@ struct MeetingsView: View {
                 refreshVisibleStateIfNeeded()
             }
             .navigationDestination(for: UUID.self) { sessionID in
-                if let session = coordinator.recordingSessions.first(where: { $0.id == sessionID }) {
+                if let session = coordinator.meetingSession(id: sessionID) {
                     MeetingSessionDetailView(
                         session: session,
                         transcript: coordinator.transcript(for: session),

--- a/Muesli/RootView.swift
+++ b/Muesli/RootView.swift
@@ -93,7 +93,7 @@ struct RootView: View {
                         selectedSection: $selectedSection,
                         pinnedSections: pinnedSections
                     )
-                        .padding(.horizontal, 28)
+                        .padding(.horizontal, MuesliTheme.Navigation.horizontalInset)
                         .padding(.bottom, MuesliTheme.spacing8)
                         .padding(.top, MuesliTheme.spacing4)
                         .background(MuesliTheme.backgroundBase)
@@ -384,7 +384,7 @@ private struct MuesliTabSwitcher: View {
 
     var body: some View {
         MuesliGlassGroup(spacing: MuesliTheme.spacing8) {
-            HStack(spacing: MuesliTheme.spacing4) {
+            HStack(spacing: MuesliTheme.Navigation.itemSpacing) {
                 ForEach(pinnedSections, id: \.self) { section in
                     let isSelected = selectedSection == section
 
@@ -406,13 +406,18 @@ private struct MuesliTabSwitcher: View {
                         }
                             .foregroundStyle(isSelected ? MuesliTheme.textPrimary : MuesliTheme.textSecondary)
                             .frame(maxWidth: .infinity)
-                            .frame(height: 44)
+                            .frame(height: MuesliTheme.Navigation.itemHeight)
                             .muesliNavigationSelection(
                                 isSelected: isSelected,
                                 tint: accent,
                                 namespace: glassNamespace
                             )
-                            .contentShape(RoundedRectangle(cornerRadius: 23, style: .continuous))
+                            .contentShape(
+                                RoundedRectangle(
+                                    cornerRadius: MuesliTheme.Navigation.selectionCornerRadius,
+                                    style: .continuous
+                                )
+                            )
                     }
                     .buttonStyle(.plain)
                     .accessibilityLabel(section.title)
@@ -420,8 +425,10 @@ private struct MuesliTabSwitcher: View {
                     .accessibilityIdentifier("tab.\(section.rawValue)")
                 }
             }
-            .padding(2)
-            .muesliNavigationGlassSurface(cornerRadius: 24)
+            .padding(MuesliTheme.Navigation.containerPadding)
+            .muesliNavigationGlassSurface(
+                cornerRadius: MuesliTheme.Navigation.containerCornerRadius
+            )
         }
     }
 }

--- a/Muesli/RootView.swift
+++ b/Muesli/RootView.swift
@@ -93,9 +93,9 @@ struct RootView: View {
                         selectedSection: $selectedSection,
                         pinnedSections: pinnedSections
                     )
-                        .padding(.horizontal, MuesliTheme.spacing12)
-                        .padding(.bottom, MuesliTheme.spacing12)
-                        .padding(.top, MuesliTheme.spacing8)
+                        .padding(.horizontal, 28)
+                        .padding(.bottom, MuesliTheme.spacing8)
+                        .padding(.top, MuesliTheme.spacing4)
                         .background(MuesliTheme.backgroundBase)
                 }
                 .overlay(alignment: .topTrailing) {
@@ -380,34 +380,48 @@ private struct MuesliTabSwitcher: View {
     @Environment(\.muesliAccent) private var accent
     @Binding var selectedSection: AppSection
     let pinnedSections: [AppSection]
+    @Namespace private var glassNamespace
 
     var body: some View {
         MuesliGlassGroup(spacing: MuesliTheme.spacing8) {
             HStack(spacing: MuesliTheme.spacing4) {
                 ForEach(pinnedSections, id: \.self) { section in
+                    let isSelected = selectedSection == section
+
                     Button {
-                        withAnimation(.snappy(duration: 0.18)) {
+                        withAnimation(.snappy(duration: 0.24, extraBounce: 0.05)) {
                             selectedSection = section
                         }
                     } label: {
-                        Label(section.title, systemImage: section.icon)
-                            .labelStyle(.titleAndIcon)
-                            .font(.system(size: 13, weight: .semibold))
-                            .lineLimit(1)
-                            .minimumScaleFactor(0.82)
-                            .foregroundStyle(selectedSection == section ? accent : MuesliTheme.textSecondary)
+                        VStack(spacing: 1) {
+                            Image(systemName: section.icon)
+                                .font(.system(size: 17, weight: .semibold))
+                                .symbolRenderingMode(.monochrome)
+                                .frame(height: 20)
+
+                            Text(section.title)
+                                .font(.system(size: 10.5, weight: .medium))
+                                .lineLimit(1)
+                                .minimumScaleFactor(0.78)
+                        }
+                            .foregroundStyle(isSelected ? MuesliTheme.textPrimary : MuesliTheme.textSecondary)
                             .frame(maxWidth: .infinity)
                             .frame(height: 44)
-                            .background(selectedSection == section ? accent.opacity(0.13) : Color.clear)
-                            .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium, style: .continuous))
-                            .contentShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerMedium, style: .continuous))
+                            .muesliNavigationSelection(
+                                isSelected: isSelected,
+                                tint: accent,
+                                namespace: glassNamespace
+                            )
+                            .contentShape(RoundedRectangle(cornerRadius: 23, style: .continuous))
                     }
                     .buttonStyle(.plain)
+                    .accessibilityLabel(section.title)
+                    .accessibilityAddTraits(isSelected ? .isSelected : [])
                     .accessibilityIdentifier("tab.\(section.rawValue)")
                 }
             }
-            .padding(MuesliTheme.spacing4)
-            .muesliGlassSurface(cornerRadius: MuesliTheme.cornerLarge, tint: accent, isInteractive: true)
+            .padding(2)
+            .muesliNavigationGlassSurface(cornerRadius: 24)
         }
     }
 }

--- a/Shared/AppConstants.swift
+++ b/Shared/AppConstants.swift
@@ -12,6 +12,7 @@ enum MuesliAppConstants {
     static let uiTestingLaunchArgument = "--muesli-ui-testing"
     static let longVoiceNoteUITestLaunchArgument = "--muesli-ui-testing-long-voice-note"
     static let completedLongVoiceNoteUITestLaunchArgument = "--muesli-ui-testing-completed-long-voice-note"
+    static let missingActiveMeetingHistoryUITestLaunchArgument = "--muesli-ui-testing-missing-active-meeting-history"
     static let requestQueryItem = "request"
     static let actionQueryItem = "action"
     static let sourceQueryItem = "source"

--- a/Shared/DictationModels.swift
+++ b/Shared/DictationModels.swift
@@ -468,6 +468,13 @@ struct RecordingSession: Codable, Sendable, Equatable, Identifiable {
         return (endedAt ?? .now).timeIntervalSince(startedAt)
     }
 
+    var hasUserAuthoredNotes: Bool {
+        [manualNotes, scratchpadText].contains { value in
+            guard let value else { return false }
+            return !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        }
+    }
+
     var isKeyboardOwnedVoiceNote: Bool {
         kind == .keyboardDictation
             || source?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "keyboard"

--- a/Shared/MuesliTheme.swift
+++ b/Shared/MuesliTheme.swift
@@ -215,6 +215,114 @@ extension View {
     ) -> some View {
         modifier(MuesliGlassButtonModifier(cornerRadius: cornerRadius, tint: tint))
     }
+
+    func muesliNavigationGlassSurface(cornerRadius: CGFloat) -> some View {
+        modifier(MuesliNavigationGlassSurfaceModifier(cornerRadius: cornerRadius))
+    }
+
+    func muesliNavigationSelection(
+        isSelected: Bool,
+        tint: Color,
+        namespace: Namespace.ID
+    ) -> some View {
+        modifier(
+            MuesliNavigationSelectionModifier(
+                isSelected: isSelected,
+                tint: tint,
+                namespace: namespace
+            )
+        )
+    }
+}
+
+private struct MuesliNavigationGlassSurfaceModifier: ViewModifier {
+    let cornerRadius: CGFloat
+
+    func body(content: Content) -> some View {
+        let shape = RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+
+        #if compiler(>=6.2)
+        if #available(iOS 26.0, *) {
+            content
+                .background(Color.white.opacity(0.055), in: shape)
+                .glassEffect(
+                    .regular.tint(Color.black.opacity(0.16)),
+                    in: .rect(cornerRadius: cornerRadius)
+                )
+                .overlay(shape.strokeBorder(Color.white.opacity(0.18), lineWidth: 0.8))
+                .shadow(color: Color.black.opacity(0.28), radius: 12, x: 0, y: 6)
+        } else {
+            fallback(content: content, shape: shape)
+        }
+        #else
+        fallback(content: content, shape: shape)
+        #endif
+    }
+
+    private func fallback(content: Content, shape: RoundedRectangle) -> some View {
+        content
+            .background {
+                shape.fill(.ultraThinMaterial)
+                shape.fill(Color.black.opacity(0.34))
+            }
+            .overlay(shape.strokeBorder(Color.white.opacity(0.16), lineWidth: 0.8))
+            .shadow(color: Color.black.opacity(0.28), radius: 12, x: 0, y: 6)
+    }
+}
+
+private struct MuesliNavigationSelectionModifier: ViewModifier {
+    let isSelected: Bool
+    let tint: Color
+    let namespace: Namespace.ID
+
+    @ViewBuilder
+    func body(content: Content) -> some View {
+        if isSelected {
+            selected(content)
+        } else {
+            content
+        }
+    }
+
+    @ViewBuilder
+    private func selected(_ content: Content) -> some View {
+        let shape = RoundedRectangle(cornerRadius: 23, style: .continuous)
+
+        #if compiler(>=6.2)
+        if #available(iOS 26.0, *) {
+            content
+                .background(tint.opacity(0.12), in: shape)
+                .glassEffect(
+                    .regular.tint(tint.opacity(0.30)).interactive(),
+                    in: .rect(cornerRadius: 23)
+                )
+                .glassEffectID("navigation-selection", in: namespace)
+                .overlay(shape.strokeBorder(Color.white.opacity(0.23), lineWidth: 0.9))
+                .overlay(alignment: .top) {
+                    Capsule()
+                        .fill(Color.white.opacity(0.20))
+                        .frame(height: 1)
+                        .padding(.horizontal, 16)
+                        .padding(.top, 1)
+                }
+                .shadow(color: tint.opacity(0.22), radius: 8, x: 0, y: 2)
+        } else {
+            fallback(content: content, shape: shape)
+        }
+        #else
+        fallback(content: content, shape: shape)
+        #endif
+    }
+
+    private func fallback(content: Content, shape: RoundedRectangle) -> some View {
+        content
+            .background {
+                shape.fill(.ultraThinMaterial)
+                shape.fill(tint.opacity(0.24))
+            }
+            .overlay(shape.strokeBorder(Color.white.opacity(0.20), lineWidth: 0.9))
+            .shadow(color: tint.opacity(0.20), radius: 7, x: 0, y: 2)
+    }
 }
 
 private struct MuesliGlassSurfaceModifier: ViewModifier {

--- a/Shared/MuesliTheme.swift
+++ b/Shared/MuesliTheme.swift
@@ -85,6 +85,15 @@ enum MuesliTheme {
     static let cornerLarge: CGFloat = 16
     static let cornerXL: CGFloat = 22
 
+    enum Navigation {
+        static let horizontalInset: CGFloat = 28
+        static let itemSpacing: CGFloat = 4
+        static let itemHeight: CGFloat = 44
+        static let containerPadding: CGFloat = 2
+        static let containerCornerRadius: CGFloat = 24
+        static let selectionCornerRadius: CGFloat = 23
+    }
+
     static func color(for accent: MuesliAccentTheme) -> Color {
         Color.adaptive(dark: accent.darkHex, light: accent.lightHex)
     }
@@ -286,7 +295,10 @@ private struct MuesliNavigationSelectionModifier: ViewModifier {
 
     @ViewBuilder
     private func selected(_ content: Content) -> some View {
-        let shape = RoundedRectangle(cornerRadius: 23, style: .continuous)
+        let shape = RoundedRectangle(
+            cornerRadius: MuesliTheme.Navigation.selectionCornerRadius,
+            style: .continuous
+        )
 
         #if compiler(>=6.2)
         if #available(iOS 26.0, *) {
@@ -294,7 +306,7 @@ private struct MuesliNavigationSelectionModifier: ViewModifier {
                 .background(tint.opacity(0.12), in: shape)
                 .glassEffect(
                     .regular.tint(tint.opacity(0.30)).interactive(),
-                    in: .rect(cornerRadius: 23)
+                    in: .rect(cornerRadius: MuesliTheme.Navigation.selectionCornerRadius)
                 )
                 .glassEffectID("navigation-selection", in: namespace)
                 .overlay(shape.strokeBorder(Color.white.opacity(0.23), lineWidth: 0.9))

--- a/Tests/MuesliTests/LongVoiceNotePersistenceTests.swift
+++ b/Tests/MuesliTests/LongVoiceNotePersistenceTests.swift
@@ -129,4 +129,19 @@ final class LongVoiceNotePersistenceTests: XCTestCase {
         )
         XCTAssertFalse(completedAppSession.hasActiveVoiceNoteWork)
     }
+
+    func testUserAuthoredNotesRecognizeManualNotesAndScratchpadText() {
+        var session = RecordingSession(kind: .quickDictation, phase: .completed)
+        XCTAssertFalse(session.hasUserAuthoredNotes)
+
+        session.manualNotes = "  Follow up with the team.  "
+        XCTAssertTrue(session.hasUserAuthoredNotes)
+
+        session.manualNotes = "  \n "
+        session.scratchpadText = "Capture the launch idea."
+        XCTAssertTrue(session.hasUserAuthoredNotes)
+
+        session.scratchpadText = "\n  "
+        XCTAssertFalse(session.hasUserAuthoredNotes)
+    }
 }

--- a/Tests/MuesliTests/MeetingLifecycleReducerTests.swift
+++ b/Tests/MuesliTests/MeetingLifecycleReducerTests.swift
@@ -74,4 +74,35 @@ final class MeetingLifecycleReducerTests: XCTestCase {
         XCTAssertFalse(state.isStarting(sessionID: otherID))
         XCTAssertFalse(MeetingLifecycleState().isStarting(sessionID: sessionID))
     }
+
+    func testSessionInventoryPreservesActiveMeetingMissingFromPersistedSnapshot() {
+        let activeMeeting = Muesli.RecordingSession(
+            kind: .meeting,
+            title: "Live meeting",
+            phase: .recording
+        )
+        let completedMeeting = Muesli.RecordingSession(
+            kind: .meeting,
+            title: "Earlier meeting",
+            phase: .completed
+        )
+
+        let sessions = RecordingSessionInventory.preservingActiveSession(
+            activeMeeting,
+            in: [completedMeeting]
+        )
+
+        XCTAssertEqual(sessions.map { $0.id }, [activeMeeting.id, completedMeeting.id])
+    }
+
+    func testSessionInventoryDoesNotDuplicatePersistedActiveMeeting() {
+        let activeMeeting = Muesli.RecordingSession(kind: .meeting, phase: .recording)
+
+        let sessions = RecordingSessionInventory.preservingActiveSession(
+            activeMeeting,
+            in: [activeMeeting]
+        )
+
+        XCTAssertEqual(sessions, [activeMeeting])
+    }
 }

--- a/Tests/MuesliTests/TranscriptOverflowDetectorTests.swift
+++ b/Tests/MuesliTests/TranscriptOverflowDetectorTests.swift
@@ -1,0 +1,53 @@
+import SwiftUI
+import XCTest
+@testable import Muesli
+
+@MainActor
+final class TranscriptOverflowDetectorTests: XCTestCase {
+    func testShortTranscriptDoesNotOverflow() {
+        XCTAssertFalse(
+            TranscriptOverflowDetector.isTruncated(
+                "A short voice note.",
+                width: 240,
+                lineLimit: 4,
+                sizeCategory: .large
+            )
+        )
+    }
+
+    func testFifthExplicitLineOverflows() {
+        XCTAssertTrue(
+            TranscriptOverflowDetector.isTruncated(
+                "One\nTwo\nThree\nFour\nFive",
+                width: 240,
+                lineLimit: 4,
+                sizeCategory: .large
+            )
+        )
+    }
+
+    func testFourExplicitLinesFit() {
+        XCTAssertFalse(
+            TranscriptOverflowDetector.isTruncated(
+                "One\nTwo\nThree\nFour",
+                width: 240,
+                lineLimit: 4,
+                sizeCategory: .large
+            )
+        )
+    }
+
+    func testLongTranscriptOverflowsWithoutFullHeightLayout() {
+        let transcript = Array(repeating: "A deliberately long transcript segment", count: 2_000)
+            .joined(separator: " ")
+
+        XCTAssertTrue(
+            TranscriptOverflowDetector.isTruncated(
+                transcript,
+                width: 240,
+                lineLimit: 4,
+                sizeCategory: .large
+            )
+        )
+    }
+}

--- a/Tests/MuesliUITests/MuesliSmokeUITests.swift
+++ b/Tests/MuesliUITests/MuesliSmokeUITests.swift
@@ -62,6 +62,25 @@ final class MuesliSmokeUITests: XCTestCase {
         add(collapsedScreenshot)
     }
 
+    func testLiveMeetingRemainsReachableWhenHistorySnapshotOmitsActiveSession() {
+        let app = XCUIApplication()
+        app.launchArguments = [
+            "--muesli-ui-testing",
+            "--muesli-ui-testing-missing-active-meeting-history",
+        ]
+        app.launch()
+
+        XCTAssertTrue(app.buttons["tab.meetings"].waitForExistence(timeout: 8))
+        app.buttons["tab.meetings"].tap()
+
+        XCTAssertTrue(app.staticTexts["Live meeting"].waitForExistence(timeout: 5))
+        app.buttons["Return to Meeting"].tap()
+
+        XCTAssertTrue(app.staticTexts["Recovered Live Meeting"].waitForExistence(timeout: 5))
+        XCTAssertTrue(app.buttons["meetingDetail.stopButton"].exists)
+        XCTAssertFalse(app.staticTexts["Meeting not found"].exists)
+    }
+
     func testLongVoiceNoteActiveStateAndDiscardConfirmation() {
         let app = XCUIApplication()
         app.launchArguments = [

--- a/Tests/MuesliUITests/MuesliSmokeUITests.swift
+++ b/Tests/MuesliUITests/MuesliSmokeUITests.swift
@@ -33,6 +33,35 @@ final class MuesliSmokeUITests: XCTestCase {
         XCTAssertTrue(app.staticTexts["Start a new meeting"].waitForExistence(timeout: 5))
     }
 
+    func testVoiceNotePreviewExpandsAndShowsMetadataBadges() {
+        let app = XCUIApplication()
+        app.launchArguments = ["--muesli-ui-testing", "--muesli-mock-dictations"]
+        app.launch()
+
+        let readMore = app.buttons.matching(
+            NSPredicate(format: "identifier BEGINSWITH 'dictation.readMore.'")
+        ).firstMatch
+        XCTAssertTrue(readMore.waitForExistence(timeout: 8))
+        XCTAssertTrue(app.descendants(matching: .any)["voiceNote.badge.notes"].firstMatch.exists)
+        XCTAssertTrue(app.descendants(matching: .any)["voiceNote.badge.longForm"].firstMatch.exists)
+
+        readMore.tap()
+
+        XCTAssertTrue(app.buttons[readMore.identifier].waitForExistence(timeout: 3))
+        XCTAssertEqual(app.buttons[readMore.identifier].label, "Show less")
+        let screenshot = XCTAttachment(screenshot: app.screenshot())
+        screenshot.name = "Expanded voice note preview with metadata badges"
+        screenshot.lifetime = .keepAlways
+        add(screenshot)
+
+        app.buttons[readMore.identifier].tap()
+        XCTAssertEqual(app.buttons[readMore.identifier].label, "Read more")
+        let collapsedScreenshot = XCTAttachment(screenshot: app.screenshot())
+        collapsedScreenshot.name = "Collapsed four-line voice note preview"
+        collapsedScreenshot.lifetime = .keepAlways
+        add(collapsedScreenshot)
+    }
+
     func testLongVoiceNoteActiveStateAndDiscardConfirmation() {
         let app = XCUIApplication()
         app.launchArguments = [


### PR DESCRIPTION
## What changed

- Replaces the bottom navigation with a compact, vertically arranged Liquid Glass treatment on iOS 26, with a material fallback for earlier versions.
- Caps voice-note transcript previews at four rendered lines and adds Read more / Show less controls only when content actually overflows.
- Adds compact indicators for manual notes and extended-duration voice notes.
- Keeps child accessibility controls, including Read more, independently reachable inside tappable voice-note rows.
- Preserves an active meeting across history refreshes and resolves meeting navigation from active, cached, or persisted state so Return to Meeting cannot lead to Meeting not found.
- Adds UI, reducer, overflow-detection, accessibility, and persistence coverage for the new behavior.

## Why

Long dictations could dominate the voice-notes feed, while the prior navigation used more vertical space and did not match the app’s newer glass visual direction. These changes make scanning and navigation more compact without hiding access to the full transcript.

History refreshes could also replace the visible session inventory while a meeting remained active, leaving the recorder running but making its detail screen unreachable. The active meeting is now treated as an invariant of the visible inventory, with defensive lookup fallbacks.

## Validation

- GitHub CI build and security checks passed.
- Targeted meeting lifecycle unit tests and the missing-active-meeting UI regression passed.
- The Read more interaction UI test passed, verifying expand/collapse stays within the row and does not trigger row navigation.
- Transcript overflow detection tests cover explicit line breaks, rendered overflow, and bounded measurement for very long transcripts.
- Built and installed successfully on the physical picophone device running iOS 26.5 with app data preserved.
- Verified the branch is clean and synchronized with origin.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli-ios/pr/20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<!-- /codesmith:footer -->
