### PR TITLE
Improve settings and local model management

### DIFF
--- a/Muesli/AboutSettingsContent.swift
+++ b/Muesli/AboutSettingsContent.swift
@@ -1,0 +1,189 @@
+import SwiftUI
+
+struct AboutSettingsContent: View {
+    private let sourceURL = URL(string: "https://github.com/Muesli-HQ/muesli-ios")!
+    private let libraries = OpenSourceLibrary.all
+
+    private var version: String {
+        Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "—"
+    }
+
+    private var build: String {
+        Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? "—"
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: MuesliTheme.spacing16) {
+            MuesliSurface {
+                VStack(alignment: .leading, spacing: MuesliTheme.spacing12) {
+                    AboutValueRow(icon: "app.badge", title: "Version", value: "\(version) (\(build))")
+                    Divider().overlay(MuesliTheme.surfaceBorder)
+                    AboutValueRow(icon: "lock.shield", title: "Processing", value: "On device")
+                    Divider().overlay(MuesliTheme.surfaceBorder)
+                    AboutValueRow(icon: "externaldrive", title: "App data", value: "Local SQLite")
+                    Divider().overlay(MuesliTheme.surfaceBorder)
+                    Link(destination: sourceURL) {
+                        HStack(spacing: MuesliTheme.spacing12) {
+                            Image(systemName: "chevron.left.forwardslash.chevron.right")
+                                .font(.system(size: 15, weight: .medium))
+                                .foregroundStyle(MuesliTheme.accent)
+                                .frame(width: 22)
+                            Text("Source code")
+                                .font(MuesliTheme.headline())
+                                .foregroundStyle(MuesliTheme.textPrimary)
+                            Spacer()
+                            Text("GitHub")
+                                .font(MuesliTheme.callout())
+                                .foregroundStyle(MuesliTheme.accent)
+                            Image(systemName: "arrow.up.right")
+                                .font(.system(size: 12, weight: .semibold))
+                                .foregroundStyle(MuesliTheme.accent)
+                        }
+                        .contentShape(Rectangle())
+                    }
+                }
+                .padding(MuesliTheme.spacing16)
+            }
+
+            VStack(alignment: .leading, spacing: MuesliTheme.spacing8) {
+                Text("OPEN SOURCE LIBRARIES")
+                    .font(MuesliTheme.captionMedium())
+                    .foregroundStyle(MuesliTheme.textTertiary)
+                    .tracking(0.8)
+                    .padding(.leading, MuesliTheme.spacing4)
+
+                MuesliSurface {
+                    VStack(spacing: 0) {
+                        ForEach(Array(libraries.enumerated()), id: \.element.id) { index, library in
+                            OpenSourceLibraryRow(library: library)
+                            if index < libraries.count - 1 {
+                                Divider().overlay(MuesliTheme.surfaceBorder)
+                            }
+                        }
+                    }
+                    .padding(.horizontal, MuesliTheme.spacing16)
+                }
+            }
+
+            MuesliSurface {
+                VStack(alignment: .leading, spacing: MuesliTheme.spacing8) {
+                    Label("Local-first by design", systemImage: "hand.raised.fill")
+                        .font(MuesliTheme.headline())
+                        .foregroundStyle(MuesliTheme.textPrimary)
+                    Text("Voice recordings and downloaded speech models stay on this iPhone. Only text is eligible for private iCloud sync when you enable it.")
+                        .font(MuesliTheme.body())
+                        .foregroundStyle(MuesliTheme.textSecondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                .padding(MuesliTheme.spacing16)
+            }
+        }
+    }
+}
+
+private struct AboutValueRow: View {
+    let icon: String
+    let title: String
+    let value: String
+
+    var body: some View {
+        HStack(spacing: MuesliTheme.spacing12) {
+            Image(systemName: icon)
+                .font(.system(size: 15, weight: .medium))
+                .foregroundStyle(MuesliTheme.accent)
+                .frame(width: 22)
+            Text(title)
+                .font(MuesliTheme.headline())
+                .foregroundStyle(MuesliTheme.textPrimary)
+            Spacer()
+            Text(value)
+                .font(MuesliTheme.callout())
+                .foregroundStyle(MuesliTheme.textSecondary)
+                .multilineTextAlignment(.trailing)
+        }
+    }
+}
+
+private struct OpenSourceLibraryRow: View {
+    let library: OpenSourceLibrary
+
+    var body: some View {
+        Link(destination: library.url) {
+            HStack(alignment: .top, spacing: MuesliTheme.spacing12) {
+                Image(systemName: library.icon)
+                    .font(.system(size: 15, weight: .medium))
+                    .foregroundStyle(MuesliTheme.accent)
+                    .frame(width: 22, height: 22)
+
+                VStack(alignment: .leading, spacing: MuesliTheme.spacing4) {
+                    HStack(spacing: MuesliTheme.spacing8) {
+                        Text(library.name)
+                            .font(MuesliTheme.headline())
+                            .foregroundStyle(MuesliTheme.textPrimary)
+                        Text(library.license)
+                            .font(MuesliTheme.captionMedium())
+                            .foregroundStyle(MuesliTheme.textTertiary)
+                    }
+                    Text(library.detail)
+                        .font(MuesliTheme.caption())
+                        .foregroundStyle(MuesliTheme.textSecondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                Spacer(minLength: MuesliTheme.spacing8)
+
+                Image(systemName: "arrow.up.right")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(MuesliTheme.textTertiary)
+                    .padding(.top, MuesliTheme.spacing4)
+            }
+            .padding(.vertical, MuesliTheme.spacing12)
+            .contentShape(Rectangle())
+        }
+        .accessibilityLabel("\(library.name), \(library.license), open project website")
+    }
+}
+
+struct OpenSourceLibrary: Identifiable, Equatable {
+    let id: String
+    let name: String
+    let license: String
+    let detail: String
+    let icon: String
+    let url: URL
+
+    static let all: [OpenSourceLibrary] = [
+        OpenSourceLibrary(
+            id: "fluidaudio",
+            name: "FluidAudio",
+            license: "Apache 2.0",
+            detail: "CoreML speech inference, streaming recognition, VAD, and speaker diarization.",
+            icon: "waveform",
+            url: URL(string: "https://github.com/FluidInference/FluidAudio")!
+        ),
+        OpenSourceLibrary(
+            id: "whisperkit",
+            name: "WhisperKit",
+            license: "MIT",
+            detail: "Argmax's Swift runtime for OpenAI Whisper models on CoreML and the Apple Neural Engine.",
+            icon: "quote.bubble",
+            url: URL(string: "https://github.com/argmaxinc/WhisperKit")!
+        ),
+        OpenSourceLibrary(
+            id: "telemetrydeck",
+            name: "TelemetryDeck Swift SDK",
+            license: "MIT",
+            detail: "Privacy-conscious product telemetry used to understand reliability and failures.",
+            icon: "chart.bar",
+            url: URL(string: "https://github.com/TelemetryDeck/SwiftSDK")!
+        ),
+        OpenSourceLibrary(
+            id: "sqlite",
+            name: "SQLite",
+            license: "Public domain",
+            detail: "Durable local storage for voice notes, meeting sessions, transcripts, and app state.",
+            icon: "cylinder",
+            url: URL(string: "https://sqlite.org")!
+        ),
+    ]
+}

--- a/Muesli/DictationCoordinator.swift
+++ b/Muesli/DictationCoordinator.swift
@@ -161,7 +161,7 @@ final class DictationCoordinator {
     private var keyboardCommandProcessingInProgress = false
     private var keyboardSessionRetryTask: Task<Void, Never>?
     private var keyboardSessionRetryAttempt = 0
-    private var lastKeyboardRuntimeHeartbeatAt = Date.distantPast
+    private var keyboardWaveformLevelThrottle = MuesliWaveformLevelThrottle()
     private var keyboardSessionLiveActivityRequestIDs = Set<UUID>()
     private var iCloudSyncTask: Task<Void, Never>?
     private var iCloudSyncDebounceTask: Task<Void, Never>?
@@ -3549,7 +3549,7 @@ final class DictationCoordinator {
                     guard let self else { return }
                     self.inputLevel = level
                     if source == "keyboard" {
-                        self.publishKeyboardRecordingHeartbeat(requestID: request.id)
+                        self.publishKeyboardRuntimeLevel(level, requestID: request.id)
                     }
                 }
                 statusText = "Recording"
@@ -5673,8 +5673,10 @@ final class DictationCoordinator {
         activeRequestID: UUID?,
         phase: DictationPhase,
         message: String?,
-        supportsBackgroundStart: Bool = false
+        supportsBackgroundStart: Bool = false,
+        inputLevel: Double? = nil
     ) {
+        let runtimeInputLevel = inputLevel ?? (phase == .recording ? self.inputLevel : 0)
         let canAcceptStartCommand = isActive
             && supportsBackgroundStart
             && activeRequestID == nil
@@ -5686,21 +5688,20 @@ final class DictationCoordinator {
             message: message,
             supportsBackgroundStart: supportsBackgroundStart,
             canAcceptStartCommand: canAcceptStartCommand,
-            inputLevel: 0
+            inputLevel: runtimeInputLevel
         ))
     }
 
-    private func publishKeyboardRecordingHeartbeat(requestID: UUID) {
+    private func publishKeyboardRuntimeLevel(_ level: Double, requestID: UUID) {
         guard activeRequest?.id == requestID, isRecording else { return }
-        let now = Date()
-        guard now.timeIntervalSince(lastKeyboardRuntimeHeartbeatAt) >= 10 else { return }
-        lastKeyboardRuntimeHeartbeatAt = now
+        guard let publishedLevel = keyboardWaveformLevelThrottle.valueToPublish(level) else { return }
         saveKeyboardRuntimeStatus(
             isActive: true,
             activeRequestID: requestID,
             phase: .recording,
             message: "Listening",
-            supportsBackgroundStart: false
+            supportsBackgroundStart: false,
+            inputLevel: publishedLevel
         )
     }
 

--- a/Muesli/DictationCoordinator.swift
+++ b/Muesli/DictationCoordinator.swift
@@ -238,7 +238,9 @@ final class DictationCoordinator {
                 selectedTranscriptionModel.rawValue,
                 forKey: MuesliPreferences.transcriptionModelKey
             )
-            modelPreparationTask?.cancel()
+            let preparationTask = modelPreparationTask
+            modelPreparationTask = nil
+            preparationTask?.cancel()
             modelPrewarmTask?.cancel()
             modelPrewarmTask = nil
             modelPreparation = ModelPreparationState(
@@ -5979,7 +5981,7 @@ private enum TranscriptionModelRemovalError: LocalizedError {
     case modelInUse
 
     var errorDescription: String? {
-        "Finish the active recording or transcription before removing a model."
+        "Finish active recording, transcription, or model preparation before removing a model."
     }
 }
 

--- a/Muesli/DictationCoordinator.swift
+++ b/Muesli/DictationCoordinator.swift
@@ -192,7 +192,7 @@ final class DictationCoordinator {
         #if DEBUG
         guard !Self.shouldSkipModelPrewarmForTesting() else { return false }
         #endif
-        return hasCompletedOnboarding
+        return hasCompletedOnboarding && !isSelectedModelDownloadSuppressed
     }
     private var isKeyboardHotMicEngineReady: Bool {
         isKeyboardSessionArmed && keyboardSessionKeeper.canAcceptStartCommand
@@ -203,6 +203,7 @@ final class DictationCoordinator {
             && !hasMeetingRecordingInProgress
             && activeRequest == nil
             && statusText != "Transcribing"
+            && !isRemovingTranscriptionModel
     }
     var keyboardSessionStatusText: String { keyboardSessionState.statusText }
     var iCloudSyncStatusText: String?
@@ -230,6 +231,9 @@ final class DictationCoordinator {
     var selectedTranscriptionModel = MuesliPreferences.transcriptionModel {
         didSet {
             guard oldValue != selectedTranscriptionModel else { return }
+            UserDefaults.standard.removeObject(
+                forKey: MuesliPreferences.manuallyRemovedTranscriptionModelKey
+            )
             UserDefaults.standard.set(
                 selectedTranscriptionModel.rawValue,
                 forKey: MuesliPreferences.transcriptionModelKey
@@ -241,16 +245,31 @@ final class DictationCoordinator {
                 status: "\(selectedTranscriptionModel.shortName) is not downloaded",
                 detail: selectedTranscriptionModel.detail
             )
-            Task { [engine, selectedTranscriptionModel] in
-                await engine.selectModel(selectedTranscriptionModel)
-            }
             AppTelemetry.signal(
                 "transcription_model_selected",
                 parameters: ["engine": selectedTranscriptionModel.engineIdentifier]
             )
+            automaticallyPrepareSelectedModelIfNeeded()
         }
     }
     var modelPreparation = ModelPreparationState()
+    var isRemovingTranscriptionModel = false
+    var canRemoveDownloadedModels: Bool {
+        !isRemovingTranscriptionModel
+            && !modelPreparation.isPreparing
+            && !isModelPrewarmInProgress
+            && !isRecording
+            && !hasMeetingRecordingInProgress
+            && !isMeetingTranscribing
+            && !voiceNoteLifecycleState.isWorkActive
+            && !keyboardSessionState.isWorkflowActive
+            && activeRequest == nil
+            && statusText != "Transcribing"
+    }
+    private var isSelectedModelDownloadSuppressed: Bool {
+        MuesliPreferences.manuallyRemovedTranscriptionModel == selectedTranscriptionModel
+            && !selectedTranscriptionModel.isDownloaded
+    }
     var isOnboardingTestRecording = false
     var isOnboardingTestTranscribing = false
     var onboardingTestInputLevel = 0.0
@@ -2144,6 +2163,7 @@ final class DictationCoordinator {
               !hasMeetingRecordingInProgress,
               !voiceNoteLifecycleState.isWorkActive,
               statusText != "Transcribing",
+              !isRemovingTranscriptionModel,
               var session = try? store.activeRecordingSession(id: sessionID),
               session.canRetryVoiceNoteTranscription,
               let requestID = session.requestID,
@@ -2852,6 +2872,79 @@ final class DictationCoordinator {
     }
 
     func prepareModelForOnboarding() {
+        prepareSelectedModel(reason: "onboarding")
+    }
+
+    func prepareModel() {
+        prepareSelectedModel(reason: "retry")
+    }
+
+    func selectTranscriptionModel(_ model: LocalTranscriptionModel) {
+        UserDefaults.standard.removeObject(
+            forKey: MuesliPreferences.manuallyRemovedTranscriptionModelKey
+        )
+        if selectedTranscriptionModel == model {
+            guard !model.isDownloaded else { return }
+            modelPreparation = ModelPreparationState(
+                status: "\(model.shortName) is not downloaded",
+                detail: model.detail
+            )
+            automaticallyPrepareSelectedModelIfNeeded()
+            return
+        }
+        selectedTranscriptionModel = model
+    }
+
+    func removeDownloadedModel(_ model: LocalTranscriptionModel) async throws {
+        guard canRemoveDownloadedModels else {
+            throw TranscriptionModelRemovalError.modelInUse
+        }
+
+        isRemovingTranscriptionModel = true
+        defer { isRemovingTranscriptionModel = false }
+
+        if selectedTranscriptionModel == model {
+            modelPreparationTask?.cancel()
+            modelPreparationTask = nil
+            modelPrewarmTask?.cancel()
+            modelPrewarmTask = nil
+            await engine.unloadModel(model)
+        }
+
+        try await Task.detached(priority: .userInitiated) {
+            try ModelBackgroundDownloadService.removeDownloadedModel(model)
+        }.value
+
+        if selectedTranscriptionModel == model {
+            UserDefaults.standard.set(
+                model.rawValue,
+                forKey: MuesliPreferences.manuallyRemovedTranscriptionModelKey
+            )
+            modelPreparation = ModelPreparationState(
+                status: "\(model.shortName) removed",
+                detail: "Select this model again when you want to download it."
+            )
+        }
+
+        AppTelemetry.signal(
+            "transcription_model_removed",
+            parameters: [
+                "engine": model.engineIdentifier,
+                "was_active": selectedTranscriptionModel == model ? "true" : "false",
+            ]
+        )
+    }
+
+    private func automaticallyPrepareSelectedModelIfNeeded() {
+        #if DEBUG
+        guard !Self.shouldSkipModelPrewarmForTesting() else { return }
+        #endif
+        guard hasCompletedOnboarding else { return }
+        guard !isSelectedModelDownloadSuppressed else { return }
+        prepareSelectedModel(reason: "selection")
+    }
+
+    private func prepareSelectedModel(reason: String) {
         guard !modelPreparation.isPreparing, !modelPreparation.isReady else { return }
 
         let model = selectedTranscriptionModel
@@ -2862,7 +2955,13 @@ final class DictationCoordinator {
             status: "Checking model files...",
             detail: model.shortName
         )
-        AppTelemetry.signal("model_prepare_started", parameters: ["engine": model.engineIdentifier])
+        AppTelemetry.signal(
+            "model_prepare_started",
+            parameters: [
+                "engine": model.engineIdentifier,
+                "reason": reason,
+            ]
+        )
 
         let coordinator = self
         modelPreparationTask = Task { [engine, model] in
@@ -2871,17 +2970,20 @@ final class DictationCoordinator {
                 let didStartBackgroundDownload = try await ModelBackgroundDownloadService.shared.startDownload(for: model)
                 if didStartBackgroundDownload {
                     await MainActor.run {
-                        coordinator.modelPreparationTask = nil
+                        if coordinator.selectedTranscriptionModel == model {
+                            coordinator.modelPreparationTask = nil
+                        }
                     }
                     return
                 }
                 try await engine.prepare { progress, status in
                     Task { @MainActor in
-                        coordinator.applyModelPreparationProgress(progress, status: status)
+                        coordinator.applyModelPreparationProgress(progress, status: status, model: model)
                     }
                 }
 
                 await MainActor.run {
+                    guard coordinator.selectedTranscriptionModel == model else { return }
                     coordinator.modelPreparationTask = nil
                     coordinator.modelPreparation = ModelPreparationState(
                         phase: .ready,
@@ -2894,10 +2996,13 @@ final class DictationCoordinator {
                 }
             } catch is CancellationError {
                 await MainActor.run {
-                    coordinator.modelPreparationTask = nil
+                    if coordinator.selectedTranscriptionModel == model {
+                        coordinator.modelPreparationTask = nil
+                    }
                 }
             } catch {
                 await MainActor.run {
+                    guard coordinator.selectedTranscriptionModel == model else { return }
                     coordinator.modelPreparationTask = nil
                     coordinator.modelPreparation = ModelPreparationState(
                         phase: .failed,
@@ -2917,15 +3022,12 @@ final class DictationCoordinator {
         }
     }
 
-    func prepareModel() {
-        prepareModelForOnboarding()
-    }
-
     func prewarmModelIfNeeded(reason: String) {
         #if DEBUG
         guard !Self.shouldSkipModelPrewarmForTesting() else { return }
         #endif
         guard hasCompletedOnboarding else { return }
+        guard !isSelectedModelDownloadSuppressed else { return }
         guard modelPrewarmTask == nil else { return }
         guard modelPreparationTask == nil, !modelPreparation.isPreparing else { return }
         guard !isRecording, !hasMeetingRecordingInProgress else { return }
@@ -2943,6 +3045,7 @@ final class DictationCoordinator {
                 await engine.selectModel(model)
                 guard await !engine.isLoaded(for: model) else {
                     await MainActor.run {
+                        guard coordinator.selectedTranscriptionModel == model else { return }
                         coordinator.modelPrewarmTask = nil
                         coordinator.modelPreparation = ModelPreparationState(
                             phase: .ready,
@@ -2960,11 +3063,12 @@ final class DictationCoordinator {
                 )
                 try await engine.prepare { progress, status in
                     Task { @MainActor in
-                        coordinator.applyModelPreparationProgress(progress, status: status)
+                        coordinator.applyModelPreparationProgress(progress, status: status, model: model)
                     }
                 }
 
                 await MainActor.run {
+                    guard coordinator.selectedTranscriptionModel == model else { return }
                     coordinator.modelPrewarmTask = nil
                     coordinator.modelPreparation = ModelPreparationState(
                         phase: .ready,
@@ -2979,10 +3083,13 @@ final class DictationCoordinator {
                 }
             } catch is CancellationError {
                 await MainActor.run {
-                    coordinator.modelPrewarmTask = nil
+                    if coordinator.selectedTranscriptionModel == model {
+                        coordinator.modelPrewarmTask = nil
+                    }
                 }
             } catch {
                 await MainActor.run {
+                    guard coordinator.selectedTranscriptionModel == model else { return }
                     coordinator.modelPrewarmTask = nil
                     coordinator.modelPreparation = ModelPreparationState(
                         phase: .failed,
@@ -3117,7 +3224,12 @@ final class DictationCoordinator {
         prewarmModelIfNeeded(reason: "onboarding_completed")
     }
 
-    private func applyModelPreparationProgress(_ progress: Double, status: String?) {
+    private func applyModelPreparationProgress(
+        _ progress: Double,
+        status: String?,
+        model: LocalTranscriptionModel
+    ) {
+        guard selectedTranscriptionModel == model else { return }
         let normalizedProgress = min(max(progress, 0), 1)
         let detail = status ?? "\(Int((normalizedProgress * 100).rounded()))% complete"
         let phase: ModelPreparationPhase = detail.localizedCaseInsensitiveContains("compil")
@@ -3130,7 +3242,7 @@ final class DictationCoordinator {
             progress: normalizedProgress,
             status: phase == .preparing
                 ? "Optimizing for this iPhone..."
-                : "Downloading \(selectedTranscriptionModel.shortName)",
+                : "Downloading \(model.shortName)",
             detail: detail
         )
     }
@@ -3152,11 +3264,12 @@ final class DictationCoordinator {
                 await engine.selectModel(model)
                 try await engine.prepare { progress, status in
                     Task { @MainActor in
-                        coordinator.applyModelPreparationProgress(progress, status: status)
+                        coordinator.applyModelPreparationProgress(progress, status: status, model: model)
                     }
                 }
 
                 await MainActor.run {
+                    guard coordinator.selectedTranscriptionModel == model else { return }
                     coordinator.modelPreparationTask = nil
                     coordinator.modelPreparation = ModelPreparationState(
                         phase: .ready,
@@ -3169,10 +3282,13 @@ final class DictationCoordinator {
                 }
             } catch is CancellationError {
                 await MainActor.run {
-                    coordinator.modelPreparationTask = nil
+                    if coordinator.selectedTranscriptionModel == model {
+                        coordinator.modelPreparationTask = nil
+                    }
                 }
             } catch {
                 await MainActor.run {
+                    guard coordinator.selectedTranscriptionModel == model else { return }
                     coordinator.modelPreparationTask = nil
                     coordinator.modelPreparation = ModelPreparationState(
                         phase: .failed,
@@ -3305,7 +3421,8 @@ final class DictationCoordinator {
         guard !isRecording,
               !hasMeetingRecordingInProgress,
               !voiceNoteLifecycleState.isWorkActive,
-              statusText != "Transcribing"
+              statusText != "Transcribing",
+              !isRemovingTranscriptionModel
         else {
             if source == "keyboard" {
                 if refreshActiveKeyboardRequestIfNeeded(request) {
@@ -4160,7 +4277,8 @@ final class DictationCoordinator {
               !isMeetingTranscribing,
               !voiceNoteLifecycleState.isWorkActive,
               activeRequest == nil,
-              statusText != "Transcribing"
+              statusText != "Transcribing",
+              !isRemovingTranscriptionModel
         else { return nil }
         MuesliHaptics.dictationStart()
         activeMeetingTitle = title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
@@ -4828,7 +4946,11 @@ final class DictationCoordinator {
     }
 
     private func startMeetingTranscription(_ queuedSession: RecordingSession, useStreamingChunks: Bool) {
-        guard !isRecording, !hasMeetingRecordingInProgress, !isMeetingTranscribing else { return }
+        guard !isRecording,
+              !hasMeetingRecordingInProgress,
+              !isMeetingTranscribing,
+              !isRemovingTranscriptionModel
+        else { return }
         guard let audioFileName = queuedSession.audioFileName else { return }
         let operationID = UUID()
         let session: RecordingSession
@@ -5850,6 +5972,14 @@ final class DictationCoordinator {
         realtimeDictationChunksDirectory = nil
         realtimeDictationCommittedText = ""
         liveDictationTranscript = ""
+    }
+}
+
+private enum TranscriptionModelRemovalError: LocalizedError {
+    case modelInUse
+
+    var errorDescription: String? {
+        "Finish the active recording or transcription before removing a model."
     }
 }
 

--- a/Muesli/DictationCoordinator.swift
+++ b/Muesli/DictationCoordinator.swift
@@ -162,6 +162,10 @@ final class DictationCoordinator {
     private var keyboardSessionRetryTask: Task<Void, Never>?
     private var keyboardSessionRetryAttempt = 0
     private var keyboardWaveformLevelThrottle = MuesliWaveformLevelThrottle()
+    private let keyboardRuntimeStatusQueue = DispatchQueue(
+        label: "com.phequals7.muesli.keyboard-runtime-status",
+        qos: .utility
+    )
     private var keyboardSessionLiveActivityRequestIDs = Set<UUID>()
     private var iCloudSyncTask: Task<Void, Never>?
     private var iCloudSyncDebounceTask: Task<Void, Never>?
@@ -5676,12 +5680,36 @@ final class DictationCoordinator {
         supportsBackgroundStart: Bool = false,
         inputLevel: Double? = nil
     ) {
+        let status = keyboardRuntimeStatus(
+            isActive: isActive,
+            activeRequestID: activeRequestID,
+            phase: phase,
+            message: message,
+            supportsBackgroundStart: supportsBackgroundStart,
+            inputLevel: inputLevel
+        )
+
+        // Lifecycle writes stay ordered behind any queued waveform samples so a
+        // stale recording level cannot overwrite a later terminal phase.
+        keyboardRuntimeStatusQueue.sync {
+            try? store.saveKeyboardRuntimeStatus(status)
+        }
+    }
+
+    private func keyboardRuntimeStatus(
+        isActive: Bool,
+        activeRequestID: UUID?,
+        phase: DictationPhase,
+        message: String?,
+        supportsBackgroundStart: Bool,
+        inputLevel: Double?
+    ) -> KeyboardRuntimeStatus {
         let runtimeInputLevel = inputLevel ?? (phase == .recording ? self.inputLevel : 0)
         let canAcceptStartCommand = isActive
             && supportsBackgroundStart
             && activeRequestID == nil
             && phase == .idle
-        try? store.saveKeyboardRuntimeStatus(.init(
+        return KeyboardRuntimeStatus(
             isActive: isActive,
             activeRequestID: activeRequestID,
             phase: phase,
@@ -5689,13 +5717,13 @@ final class DictationCoordinator {
             supportsBackgroundStart: supportsBackgroundStart,
             canAcceptStartCommand: canAcceptStartCommand,
             inputLevel: runtimeInputLevel
-        ))
+        )
     }
 
     private func publishKeyboardRuntimeLevel(_ level: Double, requestID: UUID) {
         guard activeRequest?.id == requestID, isRecording else { return }
         guard let publishedLevel = keyboardWaveformLevelThrottle.valueToPublish(level) else { return }
-        saveKeyboardRuntimeStatus(
+        let status = keyboardRuntimeStatus(
             isActive: true,
             activeRequestID: requestID,
             phase: .recording,
@@ -5703,6 +5731,10 @@ final class DictationCoordinator {
             supportsBackgroundStart: false,
             inputLevel: publishedLevel
         )
+        let store = store
+        keyboardRuntimeStatusQueue.async {
+            try? store.saveKeyboardRuntimeStatus(status)
+        }
     }
 
     private func saveKeyboardHandoff(

--- a/Muesli/FluidAudioTranscriptionEngine.swift
+++ b/Muesli/FluidAudioTranscriptionEngine.swift
@@ -19,8 +19,11 @@ actor FluidAudioTranscriptionEngine: TranscriptionEngine {
 
     private var manager: AsrManager?
     private var streamingManager: StreamingEouAsrManager?
+    private var whisperRuntime: WhisperKitTranscriptionRuntime?
+    private var loadedWhisperModel: LocalTranscriptionModel?
     private var isLoadingManager = false
     private var isLoadingStreamingManager = false
+    private var isLoadingWhisperRuntime = false
     private var selectedModel = MuesliPreferences.transcriptionModel
     private var diarizationRuntime: FluidAudioDiarizationRuntime?
 
@@ -29,20 +32,42 @@ actor FluidAudioTranscriptionEngine: TranscriptionEngine {
         selectedModel = model
         manager = nil
         streamingManager = nil
+        whisperRuntime = nil
+        loadedWhisperModel = nil
         isLoadingManager = false
         isLoadingStreamingManager = false
+        isLoadingWhisperRuntime = false
     }
 
     func isLoaded(for model: LocalTranscriptionModel) -> Bool {
         guard selectedModel == model else { return false }
+        if model.family == .whisper {
+            return loadedWhisperModel == model && whisperRuntime != nil
+        }
         if model.supportsRealtimeStreaming {
             return streamingManager != nil
         }
         return manager != nil
     }
 
+    func unloadModel(_ model: LocalTranscriptionModel) async {
+        guard selectedModel == model else { return }
+        if let whisperRuntime {
+            await whisperRuntime.unload()
+        }
+        manager = nil
+        streamingManager = nil
+        whisperRuntime = nil
+        loadedWhisperModel = nil
+        isLoadingManager = false
+        isLoadingStreamingManager = false
+        isLoadingWhisperRuntime = false
+    }
+
     func prepare(progress: (@Sendable (Double, String?) -> Void)? = nil) async throws {
-        if selectedModel.supportsRealtimeStreaming {
+        if selectedModel.family == .whisper {
+            _ = try await loadedWhisperRuntime(progress: progress)
+        } else if selectedModel.supportsRealtimeStreaming {
             _ = try await loadedStreamingManager(progress: progress)
         } else {
             _ = try await loadedManager(progress: progress)
@@ -61,6 +86,9 @@ actor FluidAudioTranscriptionEngine: TranscriptionEngine {
         audioURL: URL,
         progress: (@Sendable (TranscriptionProgressUpdate) -> Void)? = nil
     ) async throws -> DetailedTranscriptionResult {
+        if selectedModel.family == .whisper {
+            return try await transcribeWithWhisperKit(audioURL: audioURL, progress: progress)
+        }
         if selectedModel.supportsRealtimeStreaming {
             return try await transcribeWithStreamingManager(audioURL: audioURL, progress: progress)
         }
@@ -219,6 +247,59 @@ actor FluidAudioTranscriptionEngine: TranscriptionEngine {
         self.streamingManager = manager
         progress?(1.0, "\(model.shortName) ready")
         return manager
+    }
+
+    private func loadedWhisperRuntime(
+        progress: (@Sendable (Double, String?) -> Void)?
+    ) async throws -> WhisperKitTranscriptionRuntime {
+        if let whisperRuntime, loadedWhisperModel == selectedModel {
+            return whisperRuntime
+        }
+
+        while isLoadingWhisperRuntime {
+            try await Task.sleep(for: .milliseconds(150))
+            if let whisperRuntime, loadedWhisperModel == selectedModel {
+                return whisperRuntime
+            }
+        }
+
+        let model = selectedModel
+        guard let variant = model.whisperVariant else {
+            throw TranscriptionEngineError.unsupportedOfflineModel(model.shortName)
+        }
+
+        isLoadingWhisperRuntime = true
+        defer {
+            isLoadingWhisperRuntime = false
+        }
+
+        let runtime = WhisperKitTranscriptionRuntime()
+        try await runtime.load(variant: variant, progress: progress)
+        try Task.checkCancellation()
+        guard selectedModel == model else { throw CancellationError() }
+        whisperRuntime = runtime
+        loadedWhisperModel = model
+        return runtime
+    }
+
+    private func transcribeWithWhisperKit(
+        audioURL: URL,
+        progress: (@Sendable (TranscriptionProgressUpdate) -> Void)?
+    ) async throws -> DetailedTranscriptionResult {
+        let runtime = try await loadedWhisperRuntime { fraction, message in
+            progress?(.init(fractionCompleted: fraction, message: message))
+        }
+        progress?(.init(fractionCompleted: 0, message: "Transcribing with WhisperKit"))
+        let text = try await runtime.transcribe(audioURL: audioURL)
+        let duration: TimeInterval
+        if let audioFile = try? AVAudioFile(forReading: audioURL),
+           audioFile.fileFormat.sampleRate > 0 {
+            duration = Double(audioFile.length) / audioFile.fileFormat.sampleRate
+        } else {
+            duration = 0
+        }
+        progress?(.init(fractionCompleted: 1, message: "Transcription complete"))
+        return DetailedTranscriptionResult(text: text, duration: duration, tokens: [])
     }
 
     private func transcribeWithStreamingManager(

--- a/Muesli/FluidAudioTranscriptionEngine.swift
+++ b/Muesli/FluidAudioTranscriptionEngine.swift
@@ -27,8 +27,9 @@ actor FluidAudioTranscriptionEngine: TranscriptionEngine {
     private var selectedModel = MuesliPreferences.transcriptionModel
     private var diarizationRuntime: FluidAudioDiarizationRuntime?
 
-    func selectModel(_ model: LocalTranscriptionModel) {
+    func selectModel(_ model: LocalTranscriptionModel) async {
         guard selectedModel != model else { return }
+        let runtimeToUnload = whisperRuntime
         selectedModel = model
         manager = nil
         streamingManager = nil
@@ -37,6 +38,7 @@ actor FluidAudioTranscriptionEngine: TranscriptionEngine {
         isLoadingManager = false
         isLoadingStreamingManager = false
         isLoadingWhisperRuntime = false
+        await runtimeToUnload?.unload()
     }
 
     func isLoaded(for model: LocalTranscriptionModel) -> Bool {
@@ -274,12 +276,17 @@ actor FluidAudioTranscriptionEngine: TranscriptionEngine {
         }
 
         let runtime = WhisperKitTranscriptionRuntime()
-        try await runtime.load(variant: variant, progress: progress)
-        try Task.checkCancellation()
-        guard selectedModel == model else { throw CancellationError() }
-        whisperRuntime = runtime
-        loadedWhisperModel = model
-        return runtime
+        do {
+            try await runtime.load(variant: variant, progress: progress)
+            try Task.checkCancellation()
+            guard selectedModel == model else { throw CancellationError() }
+            whisperRuntime = runtime
+            loadedWhisperModel = model
+            return runtime
+        } catch {
+            await runtime.unload()
+            throw error
+        }
     }
 
     private func transcribeWithWhisperKit(

--- a/Muesli/ICloudTextSyncEngine.swift
+++ b/Muesli/ICloudTextSyncEngine.swift
@@ -186,8 +186,10 @@ enum MuesliBridgeDeviceIdentity {
 }
 
 final class ICloudTextSyncEngine {
+    static let containerIdentifier = "iCloud.com.mueslihq.muesli"
+
     private enum Schema {
-        static let containerIdentifier = "iCloud.com.mueslihq.muesli"
+        static let containerIdentifier = ICloudTextSyncEngine.containerIdentifier
         static let syncZoneName = "MuesliSyncZone"
         static let textRecordType = "MuesliTextRecord"
         static let bridgeDeviceRecordType = "MuesliBridgeDevice"

--- a/Muesli/LocalTranscriptionModel.swift
+++ b/Muesli/LocalTranscriptionModel.swift
@@ -1,10 +1,14 @@
 import FluidAudio
 import Foundation
 
-enum LocalTranscriptionModel: String, CaseIterable, Identifiable {
+enum LocalTranscriptionModel: String, CaseIterable, Identifiable, Sendable {
     case parakeetTdtCtc110m = "parakeet-tdt-ctc-110m"
     case parakeetRealtimeEou120m = "parakeet-realtime-eou-120m"
     case parakeetV3 = "parakeet-v3"
+    case whisperTinyEnglish = "whisper-tiny-en"
+    case whisperSmallEnglish = "whisper-small-en"
+    case whisperMediumEnglish = "whisper-medium-en"
+    case whisperLargeTurbo = "whisper-large-turbo"
 
     var id: String { rawValue }
 
@@ -16,6 +20,14 @@ enum LocalTranscriptionModel: String, CaseIterable, Identifiable {
             "Parakeet Realtime EOU 120M"
         case .parakeetV3:
             "Parakeet v3 600M"
+        case .whisperTinyEnglish:
+            "Whisper Tiny English"
+        case .whisperSmallEnglish:
+            "Whisper Small English"
+        case .whisperMediumEnglish:
+            "Whisper Medium English"
+        case .whisperLargeTurbo:
+            "Whisper Large Turbo"
         }
     }
 
@@ -27,6 +39,14 @@ enum LocalTranscriptionModel: String, CaseIterable, Identifiable {
             "Parakeet Realtime"
         case .parakeetV3:
             "Parakeet v3"
+        case .whisperTinyEnglish:
+            "Whisper Tiny"
+        case .whisperSmallEnglish:
+            "Whisper Small"
+        case .whisperMediumEnglish:
+            "Whisper Medium"
+        case .whisperLargeTurbo:
+            "Whisper Turbo"
         }
     }
 
@@ -38,6 +58,14 @@ enum LocalTranscriptionModel: String, CaseIterable, Identifiable {
             "English-only CoreML streaming model with end-of-utterance detection for low-latency voice notes and meeting chunks."
         case .parakeetV3:
             "Larger multilingual CoreML model. Better coverage, slower first setup."
+        case .whisperTinyEnglish:
+            "Smallest English WhisperKit model. Fastest download and lightest storage footprint."
+        case .whisperSmallEnglish:
+            "Fast English Whisper model with a practical accuracy and storage balance."
+        case .whisperMediumEnglish:
+            "Higher-accuracy English Whisper model for longer recordings, with a larger download."
+        case .whisperLargeTurbo:
+            "Highest-accuracy multilingual Whisper option, quantized for faster CoreML inference."
         }
     }
 
@@ -48,6 +76,10 @@ enum LocalTranscriptionModel: String, CaseIterable, Identifiable {
         case .parakeetRealtimeEou120m:
             "English realtime"
         case .parakeetV3:
+            "Multilingual"
+        case .whisperTinyEnglish, .whisperSmallEnglish, .whisperMediumEnglish:
+            "English only"
+        case .whisperLargeTurbo:
             "Multilingual"
         }
     }
@@ -60,6 +92,14 @@ enum LocalTranscriptionModel: String, CaseIterable, Identifiable {
             "120M streaming model"
         case .parakeetV3:
             "~450 MB 600M model"
+        case .whisperTinyEnglish:
+            "~153 MB"
+        case .whisperSmallEnglish:
+            "~250 MB"
+        case .whisperMediumEnglish:
+            "~1.5 GB"
+        case .whisperLargeTurbo:
+            "~626 MB"
         }
     }
 
@@ -71,6 +111,14 @@ enum LocalTranscriptionModel: String, CaseIterable, Identifiable {
             "parakeet-realtime-eou-120m"
         case .parakeetV3:
             "parakeet-v3"
+        case .whisperTinyEnglish:
+            "whisper-tiny-en"
+        case .whisperSmallEnglish:
+            "whisper-small-en"
+        case .whisperMediumEnglish:
+            "whisper-medium-en"
+        case .whisperLargeTurbo:
+            "whisper-large-turbo"
         }
     }
 
@@ -82,6 +130,8 @@ enum LocalTranscriptionModel: String, CaseIterable, Identifiable {
             nil
         case .parakeetV3:
             .v3
+        case .whisperTinyEnglish, .whisperSmallEnglish, .whisperMediumEnglish, .whisperLargeTurbo:
+            nil
         }
     }
 
@@ -89,7 +139,8 @@ enum LocalTranscriptionModel: String, CaseIterable, Identifiable {
         switch self {
         case .parakeetRealtimeEou120m:
             .parakeetEou320ms
-        case .parakeetTdtCtc110m, .parakeetV3:
+        case .parakeetTdtCtc110m, .parakeetV3,
+             .whisperTinyEnglish, .whisperSmallEnglish, .whisperMediumEnglish, .whisperLargeTurbo:
             nil
         }
     }
@@ -98,5 +149,61 @@ enum LocalTranscriptionModel: String, CaseIterable, Identifiable {
         streamingVariant != nil
     }
 
+    var family: LocalTranscriptionModelFamily {
+        switch self {
+        case .parakeetTdtCtc110m, .parakeetRealtimeEou120m, .parakeetV3:
+            .parakeet
+        case .whisperTinyEnglish, .whisperSmallEnglish, .whisperMediumEnglish, .whisperLargeTurbo:
+            .whisper
+        }
+    }
+
+    var whisperVariant: String? {
+        switch self {
+        case .whisperTinyEnglish:
+            "tiny.en"
+        case .whisperSmallEnglish:
+            "small.en"
+        case .whisperMediumEnglish:
+            "medium.en"
+        case .whisperLargeTurbo:
+            "large-v3-v20240930_626MB"
+        case .parakeetTdtCtc110m, .parakeetRealtimeEou120m, .parakeetV3:
+            nil
+        }
+    }
+
+    var isDownloaded: Bool {
+        ModelBackgroundDownloadService.isModelDownloaded(self)
+    }
+
+    static let parakeetModels = allCases.filter { $0.family == .parakeet }
+    static let whisperModels = allCases.filter { $0.family == .whisper }
+
     static let defaultModel: LocalTranscriptionModel = .parakeetTdtCtc110m
+}
+
+enum LocalTranscriptionModelFamily: String, CaseIterable, Identifiable {
+    case parakeet
+    case whisper
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .parakeet:
+            "Parakeet"
+        case .whisper:
+            "WhisperKit"
+        }
+    }
+
+    var models: [LocalTranscriptionModel] {
+        switch self {
+        case .parakeet:
+            LocalTranscriptionModel.parakeetModels
+        case .whisper:
+            LocalTranscriptionModel.whisperModels
+        }
+    }
 }

--- a/Muesli/ModelBackgroundDownloadService.swift
+++ b/Muesli/ModelBackgroundDownloadService.swift
@@ -38,6 +38,57 @@ final class ModelBackgroundDownloadService: NSObject, @unchecked Sendable {
         super.init()
     }
 
+    static func storageDirectory(for model: LocalTranscriptionModel) -> URL? {
+        if let whisperVariant = model.whisperVariant {
+            return WhisperKitTranscriptionRuntime.modelDirectory(for: whisperVariant)
+        }
+
+        if model == .parakeetRealtimeEou120m {
+            return FileManager.default.urls(
+                for: .applicationSupportDirectory,
+                in: .userDomainMask
+            )[0]
+                .appendingPathComponent("FluidAudio", isDirectory: true)
+                .appendingPathComponent("Models", isDirectory: true)
+                .appendingPathComponent("parakeet-eou-streaming", isDirectory: true)
+                .appendingPathComponent("320ms", isDirectory: true)
+        }
+
+        return ModelDownloadSpec(model: model)?.repoRoot
+    }
+
+    static func isModelDownloaded(_ model: LocalTranscriptionModel) -> Bool {
+        if let whisperVariant = model.whisperVariant {
+            return WhisperKitTranscriptionRuntime.isModelDownloaded(whisperVariant)
+        }
+
+        if model == .parakeetRealtimeEou120m {
+            guard let modelDirectory = storageDirectory(for: model) else { return false }
+            return ModelNames.ParakeetEOU.requiredModels.allSatisfy { modelName in
+                FileManager.default.fileExists(
+                    atPath: modelDirectory.appendingPathComponent(modelName).path
+                )
+            }
+        }
+
+        guard let spec = ModelDownloadSpec(model: model) else { return false }
+        return spec.requiredModels.allSatisfy { modelName in
+            FileManager.default.fileExists(
+                atPath: spec.repoRoot.appendingPathComponent(modelName).path
+            )
+        }
+    }
+
+    static func removeDownloadedModel(_ model: LocalTranscriptionModel) throws {
+        guard let directory = storageDirectory(for: model) else { return }
+        try removeDownloadedModel(at: directory)
+    }
+
+    static func removeDownloadedModel(at directory: URL) throws {
+        guard FileManager.default.fileExists(atPath: directory.path) else { return }
+        try FileManager.default.removeItem(at: directory)
+    }
+
     func setBackgroundCompletionHandler(_ handler: @escaping () -> Void) {
         let handler = SendableCompletionHandler(handler)
         _ = session
@@ -47,6 +98,21 @@ final class ModelBackgroundDownloadService: NSObject, @unchecked Sendable {
     }
 
     func startDownload(for model: LocalTranscriptionModel) async throws -> Bool {
+        let activeModelRawValue = stateQueue.sync { activePlan?.modelRawValue }
+        if activeModelRawValue == model.rawValue {
+            return true
+        }
+        if activeModelRawValue != nil {
+            let tasks = await session.allTasks
+            tasks.forEach { $0.cancel() }
+            stateQueue.sync {
+                activePlan = nil
+                taskBytes = [:]
+                activeTaskIDs = []
+                failedTaskIDs = []
+            }
+        }
+
         guard let spec = ModelDownloadSpec(model: model) else {
             return false
         }
@@ -243,6 +309,11 @@ final class ModelBackgroundDownloadService: NSObject, @unchecked Sendable {
     private func fail(_ task: URLSessionTask?, error: Error) {
         let taskModel = task?.taskDescription.flatMap { ModelDownloadFile(taskDescription: $0)?.model }
         let (model, handler): (LocalTranscriptionModel?, SendableCompletionHandler?) = stateQueue.sync {
+            if let taskModel,
+               let activePlan,
+               activePlan.modelRawValue != taskModel.rawValue {
+                return (nil, nil)
+            }
             let resolvedModel = taskModel ?? activePlan.flatMap { LocalTranscriptionModel(rawValue: $0.modelRawValue) }
             if let resolvedModel, failedModelRawValues.contains(resolvedModel.rawValue) {
                 return (nil, nil)
@@ -419,7 +490,8 @@ private struct ModelDownloadSpec {
                 "Decoder.mlmodelc",
                 "JointDecisionv3.mlmodelc"
             ]
-        case .parakeetRealtimeEou120m:
+        case .parakeetRealtimeEou120m,
+             .whisperTinyEnglish, .whisperSmallEnglish, .whisperMediumEnglish, .whisperLargeTurbo:
             return nil
         }
     }

--- a/Muesli/ModelBackgroundDownloadService.swift
+++ b/Muesli/ModelBackgroundDownloadService.swift
@@ -16,10 +16,12 @@ final class ModelBackgroundDownloadService: NSObject, @unchecked Sendable {
     @MainActor weak var delegate: ModelBackgroundDownloadServiceDelegate?
 
     private let stateQueue = DispatchQueue(label: "com.phequals7.muesli.model-background-download")
+    private var requestedAttempt: ModelDownloadAttempt?
     private var activePlan: DownloadPlan?
     private var taskBytes: [Int: Int64] = [:]
     private var activeTaskIDs = Set<Int>()
     private var failedTaskIDs = Set<Int>()
+    private var failedAttemptIDs = Set<UUID>()
     private var failedModelRawValues = Set<String>()
     private var backgroundCompletionHandler: SendableCompletionHandler?
     private var completedModelsDuringBackgroundEvents = Set<String>()
@@ -98,38 +100,69 @@ final class ModelBackgroundDownloadService: NSObject, @unchecked Sendable {
     }
 
     func startDownload(for model: LocalTranscriptionModel) async throws -> Bool {
-        let activeModelRawValue = stateQueue.sync { activePlan?.modelRawValue }
-        if activeModelRawValue == model.rawValue {
-            return true
-        }
-        if activeModelRawValue != nil {
-            let tasks = await session.allTasks
-            tasks.forEach { $0.cancel() }
-            stateQueue.sync {
-                activePlan = nil
-                taskBytes = [:]
-                activeTaskIDs = []
-                failedTaskIDs = []
+        let attemptID = UUID()
+        let attempt = ModelDownloadAttempt(modelRawValue: model.rawValue, id: attemptID)
+        let startDecision: (shouldStart: Bool, previousAttempt: ModelDownloadAttempt?) = stateQueue.sync {
+            if requestedAttempt?.modelRawValue == model.rawValue
+                || activePlan?.modelRawValue == model.rawValue {
+                return (false, nil)
             }
+
+            let previousAttempt = requestedAttempt ?? activePlan?.attempt
+            requestedAttempt = attempt
+            activePlan = nil
+            taskBytes = [:]
+            activeTaskIDs = []
+            failedTaskIDs = []
+            return (true, previousAttempt)
+        }
+        guard startDecision.shouldStart else { return true }
+
+        if let previousAttempt = startDecision.previousAttempt {
+            await cancelTasks(for: previousAttempt)
         }
 
         guard let spec = ModelDownloadSpec(model: model) else {
+            clearRequestedAttempt(ifMatching: attempt)
             return false
         }
 
-        let files = try await Self.listFiles(for: spec)
+        let files: [ModelDownloadFile]
+        do {
+            files = try await Self.listFiles(for: spec)
+        } catch {
+            clearRequestedAttempt(ifMatching: attempt)
+            throw error
+        }
         let missingFiles = files.filter { file in
             !FileManager.default.fileExists(atPath: spec.destinationURL(for: file.localPath).path)
         }
 
         guard !missingFiles.isEmpty else {
+            clearRequestedAttempt(ifMatching: attempt)
             return false
         }
 
         let totalBytes = missingFiles.reduce(Int64(0)) { partial, file in
             partial + max(0, file.size)
         }
-        let plan = DownloadPlan(modelRawValue: model.rawValue, totalBytes: max(totalBytes, 1), pendingCount: missingFiles.count)
+        let plan = DownloadPlan(
+            attempt: attempt,
+            totalBytes: max(totalBytes, 1),
+            pendingCount: missingFiles.count
+        )
+
+        let shouldStart: Bool = stateQueue.sync {
+            guard requestedAttempt == attempt else { return false }
+            activePlan = plan
+            taskBytes = [:]
+            activeTaskIDs = []
+            failedTaskIDs = []
+            failedAttemptIDs.remove(attemptID)
+            failedModelRawValues.remove(model.rawValue)
+            return true
+        }
+        guard shouldStart else { return false }
 
         await MainActor.run {
             delegate?.modelBackgroundDownloadDidUpdate(
@@ -139,43 +172,75 @@ final class ModelBackgroundDownloadService: NSObject, @unchecked Sendable {
             )
         }
 
-        stateQueue.sync {
-            activePlan = plan
-            taskBytes = [:]
-            activeTaskIDs = []
-            failedTaskIDs = []
-            failedModelRawValues.remove(model.rawValue)
-        }
-
-        for file in missingFiles {
-            try Task.checkCancellation()
-            let destination = spec.destinationURL(for: file.localPath)
-            try FileManager.default.createDirectory(
-                at: destination.deletingLastPathComponent(),
-                withIntermediateDirectories: true
-            )
-
-            if file.size == 0 {
-                FileManager.default.createFile(atPath: destination.path, contents: Data())
-                stateQueue.async {
-                    self.activePlan?.pendingCount -= 1
-                    self.completeIfNeeded()
+        do {
+            for file in missingFiles {
+                try Task.checkCancellation()
+                guard stateQueue.sync(execute: { activePlan?.attempt == attempt }) else {
+                    return false
                 }
-                continue
-            }
+                let destination = spec.destinationURL(for: file.localPath)
+                try FileManager.default.createDirectory(
+                    at: destination.deletingLastPathComponent(),
+                    withIntermediateDirectories: true
+                )
 
-            var request = URLRequest(url: file.remoteURL)
-            request.timeoutInterval = 60 * 30
-            let task = session.downloadTask(with: request)
-            task.taskDescription = file.taskDescription(model: model)
-            stateQueue.sync {
-                taskBytes[task.taskIdentifier] = 0
-                activeTaskIDs.insert(task.taskIdentifier)
+                if file.size == 0 {
+                    FileManager.default.createFile(atPath: destination.path, contents: Data())
+                    stateQueue.async {
+                        guard self.activePlan?.attempt == attempt else { return }
+                        self.activePlan?.pendingCount -= 1
+                        self.completeIfNeeded()
+                    }
+                    continue
+                }
+
+                var request = URLRequest(url: file.remoteURL)
+                request.timeoutInterval = 60 * 30
+                let task = session.downloadTask(with: request)
+                task.taskDescription = file.taskDescription(model: model, attemptID: attemptID)
+                let shouldResume: Bool = stateQueue.sync {
+                    guard activePlan?.attempt == attempt else { return false }
+                    taskBytes[task.taskIdentifier] = 0
+                    activeTaskIDs.insert(task.taskIdentifier)
+                    return true
+                }
+                guard shouldResume else {
+                    task.cancel()
+                    return false
+                }
+                task.resume()
             }
-            task.resume()
+        } catch {
+            clearRequestedAttempt(ifMatching: attempt)
+            await cancelTasks(for: attempt)
+            throw error
         }
 
         return true
+    }
+
+    private func clearRequestedAttempt(ifMatching attempt: ModelDownloadAttempt) {
+        stateQueue.sync {
+            guard requestedAttempt == attempt else { return }
+            requestedAttempt = nil
+            if activePlan?.attempt == attempt {
+                activePlan = nil
+                taskBytes = [:]
+                activeTaskIDs = []
+                failedTaskIDs = []
+            }
+        }
+    }
+
+    private func cancelTasks(for attempt: ModelDownloadAttempt) async {
+        let tasks = await session.allTasks
+        tasks.filter { task in
+            guard let description = task.taskDescription,
+                  let file = ModelDownloadFile(taskDescription: description)
+            else { return false }
+            return attempt.matches(file)
+        }
+        .forEach { $0.cancel() }
     }
 
     private static func listFiles(for spec: ModelDownloadSpec) async throws -> [ModelDownloadFile] {
@@ -223,17 +288,20 @@ final class ModelBackgroundDownloadService: NSObject, @unchecked Sendable {
         return files
     }
 
-    private func updateProgress(taskIdentifier: Int, bytesWritten: Int64) {
+    private func updateProgress(task: URLSessionTask, bytesWritten: Int64) {
         var snapshot: (LocalTranscriptionModel, Double)?
         stateQueue.sync {
             guard let plan = activePlan,
-                  activeTaskIDs.contains(taskIdentifier),
+                  let description = task.taskDescription,
+                  let file = ModelDownloadFile(taskDescription: description),
+                  plan.matches(file),
+                  activeTaskIDs.contains(task.taskIdentifier),
                   let model = LocalTranscriptionModel(rawValue: plan.modelRawValue)
             else {
                 snapshot = nil
                 return
             }
-            taskBytes[taskIdentifier] = bytesWritten
+            taskBytes[task.taskIdentifier] = bytesWritten
             let completed = taskBytes.values.reduce(Int64(0), +)
             snapshot = (model, min(max(Double(completed) / Double(plan.totalBytes), 0), 0.98))
         }
@@ -256,6 +324,20 @@ final class ModelBackgroundDownloadService: NSObject, @unchecked Sendable {
             throw URLError(.badURL)
         }
 
+        let shouldProcess = stateQueue.sync {
+            if let plan = activePlan {
+                return plan.matches(file) && activeTaskIDs.contains(task.taskIdentifier)
+            }
+            if let requestedAttempt {
+                return requestedAttempt.matches(file)
+            }
+            if let attemptID = file.attemptID {
+                return !failedAttemptIDs.contains(attemptID)
+            }
+            return !failedModelRawValues.contains(file.model.rawValue)
+        }
+        guard shouldProcess else { return }
+
         let destination = spec.destinationURL(for: file.localPath)
         try FileManager.default.createDirectory(
             at: destination.deletingLastPathComponent(),
@@ -268,14 +350,22 @@ final class ModelBackgroundDownloadService: NSObject, @unchecked Sendable {
 
         stateQueue.async {
             if self.activePlan == nil {
-                guard !self.failedModelRawValues.contains(file.model.rawValue) else { return }
+                if let requestedAttempt = self.requestedAttempt,
+                   !requestedAttempt.matches(file) {
+                    return
+                }
+                if let attemptID = file.attemptID {
+                    guard !self.failedAttemptIDs.contains(attemptID) else { return }
+                } else {
+                    guard !self.failedModelRawValues.contains(file.model.rawValue) else { return }
+                }
                 self.completedModelsDuringBackgroundEvents.insert(file.model.rawValue)
                 return
             }
 
             guard self.activeTaskIDs.remove(task.taskIdentifier) != nil,
                   self.failedTaskIDs.remove(task.taskIdentifier) == nil,
-                  self.activePlan?.modelRawValue == file.model.rawValue
+                  self.activePlan?.matches(file) == true
             else { return }
 
             self.activePlan?.pendingCount -= 1
@@ -287,6 +377,9 @@ final class ModelBackgroundDownloadService: NSObject, @unchecked Sendable {
     private func completeIfNeeded() {
         guard let plan = activePlan, plan.pendingCount <= 0 else { return }
         activePlan = nil
+        if requestedAttempt == plan.attempt {
+            requestedAttempt = nil
+        }
         taskBytes = [:]
         activeTaskIDs = []
         failedTaskIDs = []
@@ -307,41 +400,70 @@ final class ModelBackgroundDownloadService: NSObject, @unchecked Sendable {
     }
 
     private func fail(_ task: URLSessionTask?, error: Error) {
-        let taskModel = task?.taskDescription.flatMap { ModelDownloadFile(taskDescription: $0)?.model }
-        let (model, handler): (LocalTranscriptionModel?, SendableCompletionHandler?) = stateQueue.sync {
-            if let taskModel,
-               let activePlan,
-               activePlan.modelRawValue != taskModel.rawValue {
-                return (nil, nil)
+        let taskFile = task?.taskDescription.flatMap(ModelDownloadFile.init(taskDescription:))
+        let result: DownloadFailureResult = stateQueue.sync {
+            let attempt: ModelDownloadAttempt
+            if let taskFile {
+                attempt = ModelDownloadAttempt(
+                    modelRawValue: taskFile.model.rawValue,
+                    id: taskFile.attemptID
+                )
+                if let activePlan, !activePlan.matches(taskFile) {
+                    return .ignored
+                }
+                if activePlan == nil,
+                   let requestedAttempt,
+                   !requestedAttempt.matches(attempt) {
+                    return .ignored
+                }
+            } else if let activePlan {
+                attempt = activePlan.attempt
+            } else {
+                return .ignored
             }
-            let resolvedModel = taskModel ?? activePlan.flatMap { LocalTranscriptionModel(rawValue: $0.modelRawValue) }
-            if let resolvedModel, failedModelRawValues.contains(resolvedModel.rawValue) {
-                return (nil, nil)
+
+            if let attemptID = attempt.id {
+                guard !failedAttemptIDs.contains(attemptID) else { return .ignored }
+                failedAttemptIDs.insert(attemptID)
+            } else {
+                guard !failedModelRawValues.contains(attempt.modelRawValue) else { return .ignored }
+                failedModelRawValues.insert(attempt.modelRawValue)
             }
+
             if let task {
                 failedTaskIDs.insert(task.taskIdentifier)
             }
-            if let resolvedModel {
-                failedModelRawValues.insert(resolvedModel.rawValue)
+            if activePlan?.attempt.matches(attempt) == true {
+                activePlan = nil
+                taskBytes = [:]
+                activeTaskIDs = []
             }
-            activePlan = nil
-            taskBytes = [:]
-            activeTaskIDs = []
+            if requestedAttempt?.matches(attempt) == true {
+                requestedAttempt = nil
+            }
             let handler = backgroundCompletionHandler
             backgroundCompletionHandler = nil
-            return (resolvedModel, handler)
+            return DownloadFailureResult(
+                model: LocalTranscriptionModel(rawValue: attempt.modelRawValue),
+                attempt: attempt,
+                handler: handler
+            )
         }
 
+        guard let attempt = result.attempt else { return }
         session.getAllTasks { tasks in
             let tasksToCancel = tasks.filter { task in
-                task.taskDescription.flatMap(ModelDownloadFile.init(taskDescription:))?.model == model
+                guard let description = task.taskDescription,
+                      let file = ModelDownloadFile(taskDescription: description)
+                else { return false }
+                return attempt.matches(file)
             }
             tasksToCancel.forEach { $0.cancel() }
         }
 
-        guard let model else {
+        guard let model = result.model else {
             Task { @MainActor in
-                handler?()
+                result.handler?()
             }
             return
         }
@@ -351,7 +473,7 @@ final class ModelBackgroundDownloadService: NSObject, @unchecked Sendable {
                 model: model,
                 message: "Download paused. Check your connection and try again."
             )
-            handler?()
+            result.handler?()
         }
     }
 }
@@ -364,7 +486,7 @@ extension ModelBackgroundDownloadService: URLSessionDownloadDelegate {
         totalBytesWritten: Int64,
         totalBytesExpectedToWrite: Int64
     ) {
-        updateProgress(taskIdentifier: downloadTask.taskIdentifier, bytesWritten: totalBytesWritten)
+        updateProgress(task: downloadTask, bytesWritten: totalBytesWritten)
     }
 
     nonisolated func urlSession(
@@ -419,30 +541,63 @@ private final class SendableCompletionHandler: @unchecked Sendable {
     }
 }
 
-private struct DownloadPlan {
+struct ModelDownloadAttempt: Equatable, Sendable {
     let modelRawValue: String
-    let totalBytes: Int64
-    var pendingCount: Int
+    let id: UUID?
+
+    init(modelRawValue: String, id: UUID?) {
+        self.modelRawValue = modelRawValue
+        self.id = id
+    }
+
+    func matches(_ other: ModelDownloadAttempt) -> Bool {
+        modelRawValue == other.modelRawValue && id == other.id
+    }
+
+    func matches(_ file: ModelDownloadFile) -> Bool {
+        modelRawValue == file.model.rawValue && id == file.attemptID
+    }
 }
 
-private struct ModelDownloadFile {
+struct DownloadPlan {
+    let attempt: ModelDownloadAttempt
+    let totalBytes: Int64
+    var pendingCount: Int
+
+    var modelRawValue: String { attempt.modelRawValue }
+
+    func matches(_ file: ModelDownloadFile) -> Bool {
+        attempt.matches(file)
+    }
+}
+
+struct ModelDownloadFile {
     let remotePath: String
     let localPath: String
     let remoteURL: URL
     let size: Int64
     let model: LocalTranscriptionModel
+    let attemptID: UUID?
 
-    init(remotePath: String, localPath: String, remoteURL: URL, size: Int64, model: LocalTranscriptionModel? = nil) {
+    init(
+        remotePath: String,
+        localPath: String,
+        remoteURL: URL,
+        size: Int64,
+        model: LocalTranscriptionModel? = nil,
+        attemptID: UUID? = nil
+    ) {
         self.remotePath = remotePath
         self.localPath = localPath
         self.remoteURL = remoteURL
         self.size = size
         self.model = model ?? .defaultModel
+        self.attemptID = attemptID
     }
 
     init?(taskDescription: String) {
         let parts = taskDescription.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
-        guard parts.count == 5,
+        guard parts.count == 5 || parts.count == 6,
               let model = LocalTranscriptionModel(rawValue: parts[0]),
               let remoteURL = URL(string: parts[3]),
               let size = Int64(parts[4])
@@ -454,11 +609,32 @@ private struct ModelDownloadFile {
         localPath = parts[2]
         self.remoteURL = remoteURL
         self.size = size
+        if parts.count == 6 {
+            guard let attemptID = UUID(uuidString: parts[5]) else { return nil }
+            self.attemptID = attemptID
+        } else {
+            attemptID = nil
+        }
     }
 
-    func taskDescription(model: LocalTranscriptionModel) -> String {
-        [model.rawValue, remotePath, localPath, remoteURL.absoluteString, String(size)].joined(separator: "\n")
+    func taskDescription(model: LocalTranscriptionModel, attemptID: UUID) -> String {
+        [
+            model.rawValue,
+            remotePath,
+            localPath,
+            remoteURL.absoluteString,
+            String(size),
+            attemptID.uuidString,
+        ].joined(separator: "\n")
     }
+}
+
+private struct DownloadFailureResult {
+    let model: LocalTranscriptionModel?
+    let attempt: ModelDownloadAttempt?
+    let handler: SendableCompletionHandler?
+
+    static let ignored = DownloadFailureResult(model: nil, attempt: nil, handler: nil)
 }
 
 private struct ModelDownloadSpec {

--- a/Muesli/ModelBackgroundDownloadService.swift
+++ b/Muesli/ModelBackgroundDownloadService.swift
@@ -21,10 +21,8 @@ final class ModelBackgroundDownloadService: NSObject, @unchecked Sendable {
     private var taskBytes: [Int: Int64] = [:]
     private var activeTaskIDs = Set<Int>()
     private var failedTaskIDs = Set<Int>()
-    private var failedAttemptIDs = Set<UUID>()
-    private var failedModelRawValues = Set<String>()
+    private var attemptOutcomes = ModelDownloadAttemptOutcomeTracker()
     private var backgroundCompletionHandler: SendableCompletionHandler?
-    private var completedModelsDuringBackgroundEvents = Set<String>()
 
     private lazy var session: URLSession = {
         let configuration = URLSessionConfiguration.background(withIdentifier: Self.sessionIdentifier)
@@ -158,8 +156,7 @@ final class ModelBackgroundDownloadService: NSObject, @unchecked Sendable {
             taskBytes = [:]
             activeTaskIDs = []
             failedTaskIDs = []
-            failedAttemptIDs.remove(attemptID)
-            failedModelRawValues.remove(model.rawValue)
+            attemptOutcomes.clearFailure(for: attempt)
             return true
         }
         guard shouldStart else { return false }
@@ -331,10 +328,9 @@ final class ModelBackgroundDownloadService: NSObject, @unchecked Sendable {
             if let requestedAttempt {
                 return requestedAttempt.matches(file)
             }
-            if let attemptID = file.attemptID {
-                return !failedAttemptIDs.contains(attemptID)
-            }
-            return !failedModelRawValues.contains(file.model.rawValue)
+            return !attemptOutcomes.hasFailed(
+                ModelDownloadAttempt(modelRawValue: file.model.rawValue, id: file.attemptID)
+            )
         }
         guard shouldProcess else { return }
 
@@ -354,12 +350,9 @@ final class ModelBackgroundDownloadService: NSObject, @unchecked Sendable {
                    !requestedAttempt.matches(file) {
                     return
                 }
-                if let attemptID = file.attemptID {
-                    guard !self.failedAttemptIDs.contains(attemptID) else { return }
-                } else {
-                    guard !self.failedModelRawValues.contains(file.model.rawValue) else { return }
-                }
-                self.completedModelsDuringBackgroundEvents.insert(file.model.rawValue)
+                self.attemptOutcomes.recordCompletion(
+                    ModelDownloadAttempt(modelRawValue: file.model.rawValue, id: file.attemptID)
+                )
                 return
             }
 
@@ -422,13 +415,7 @@ final class ModelBackgroundDownloadService: NSObject, @unchecked Sendable {
                 return .ignored
             }
 
-            if let attemptID = attempt.id {
-                guard !failedAttemptIDs.contains(attemptID) else { return .ignored }
-                failedAttemptIDs.insert(attemptID)
-            } else {
-                guard !failedModelRawValues.contains(attempt.modelRawValue) else { return .ignored }
-                failedModelRawValues.insert(attempt.modelRawValue)
-            }
+            guard attemptOutcomes.recordFailure(attempt) else { return .ignored }
 
             if let task {
                 failedTaskIDs.insert(task.taskIdentifier)
@@ -515,9 +502,11 @@ extension ModelBackgroundDownloadService: URLSessionDownloadDelegate {
         stateQueue.async {
             guard self.activePlan == nil else { return }
             let handler = self.backgroundCompletionHandler
-            let completedModels = self.completedModelsDuringBackgroundEvents.compactMap(LocalTranscriptionModel.init(rawValue:))
-            self.completedModelsDuringBackgroundEvents = []
-            completedModels.forEach { self.failedModelRawValues.remove($0.rawValue) }
+            let completedModels = Set(
+                self.attemptOutcomes
+                    .drainCompletedAttempts()
+                    .compactMap { LocalTranscriptionModel(rawValue: $0.modelRawValue) }
+            )
             self.backgroundCompletionHandler = nil
             DispatchQueue.main.async {
                 completedModels.forEach { model in
@@ -541,7 +530,7 @@ private final class SendableCompletionHandler: @unchecked Sendable {
     }
 }
 
-struct ModelDownloadAttempt: Equatable, Sendable {
+struct ModelDownloadAttempt: Hashable, Sendable {
     let modelRawValue: String
     let id: UUID?
 
@@ -556,6 +545,50 @@ struct ModelDownloadAttempt: Equatable, Sendable {
 
     func matches(_ file: ModelDownloadFile) -> Bool {
         modelRawValue == file.model.rawValue && id == file.attemptID
+    }
+}
+
+struct ModelDownloadAttemptOutcomeTracker {
+    private var completedAttempts = Set<ModelDownloadAttempt>()
+    private var failedAttemptIDs = Set<UUID>()
+    private var failedLegacyModelRawValues = Set<String>()
+
+    func hasFailed(_ attempt: ModelDownloadAttempt) -> Bool {
+        if let id = attempt.id {
+            return failedAttemptIDs.contains(id)
+        }
+        return failedLegacyModelRawValues.contains(attempt.modelRawValue)
+    }
+
+    mutating func recordCompletion(_ attempt: ModelDownloadAttempt) {
+        guard !hasFailed(attempt) else { return }
+        completedAttempts.insert(attempt)
+    }
+
+    @discardableResult
+    mutating func recordFailure(_ attempt: ModelDownloadAttempt) -> Bool {
+        completedAttempts.remove(attempt)
+        if let id = attempt.id {
+            return failedAttemptIDs.insert(id).inserted
+        }
+        return failedLegacyModelRawValues.insert(attempt.modelRawValue).inserted
+    }
+
+    mutating func clearFailure(for attempt: ModelDownloadAttempt) {
+        if let id = attempt.id {
+            failedAttemptIDs.remove(id)
+        } else {
+            failedLegacyModelRawValues.remove(attempt.modelRawValue)
+        }
+    }
+
+    mutating func drainCompletedAttempts() -> Set<ModelDownloadAttempt> {
+        defer {
+            completedAttempts = []
+            failedAttemptIDs = []
+            failedLegacyModelRawValues = []
+        }
+        return completedAttempts.filter { !hasFailed($0) }
     }
 }
 

--- a/Muesli/ModelsView.swift
+++ b/Muesli/ModelsView.swift
@@ -64,7 +64,9 @@ struct ModelsView: View {
 
                 TranscriptionModelSelector(
                     selection: $coordinator.selectedTranscriptionModel,
-                    showsHeader: false
+                    showsHeader: false,
+                    preparation: coordinator.modelPreparation,
+                    onSelect: coordinator.selectTranscriptionModel
                 )
 
                 VStack(alignment: .leading, spacing: MuesliTheme.spacing8) {
@@ -83,20 +85,21 @@ struct ModelsView: View {
                         .tint(MuesliTheme.accent)
                 }
 
-                Button {
-                    coordinator.prepareModel()
-                } label: {
-                    Label(modelButtonTitle, systemImage: modelButtonIcon)
-                        .font(MuesliTheme.headline())
-                        .frame(maxWidth: .infinity)
-                        .frame(height: 48)
-                        .foregroundStyle(modelButtonDisabled ? MuesliTheme.textTertiary : .white)
-                        .background(modelButtonDisabled ? MuesliTheme.surfacePrimary : MuesliTheme.accent)
-                        .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
-                        .contentShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+                if coordinator.modelPreparation.phase == .failed {
+                    Button {
+                        coordinator.prepareModel()
+                    } label: {
+                        Label("Retry Download", systemImage: "arrow.clockwise")
+                            .font(MuesliTheme.headline())
+                            .frame(maxWidth: .infinity)
+                            .frame(height: 48)
+                            .foregroundStyle(.white)
+                            .background(MuesliTheme.accent)
+                            .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+                            .contentShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+                    }
+                    .buttonStyle(.plain)
                 }
-                .buttonStyle(.plain)
-                .disabled(modelButtonDisabled)
             }
             .padding(MuesliTheme.spacing16)
         }
@@ -105,7 +108,13 @@ struct ModelsView: View {
     private var runtimePanel: some View {
         MuesliSurface {
             VStack(alignment: .leading, spacing: MuesliTheme.spacing12) {
-                ModelInfoRow(icon: "cpu", title: "Runtime", value: "CoreML / ANE")
+                ModelInfoRow(
+                    icon: "cpu",
+                    title: "Runtime",
+                    value: coordinator.selectedTranscriptionModel.family == .whisper
+                        ? "WhisperKit / CoreML"
+                        : "FluidAudio / CoreML"
+                )
                 Divider().overlay(MuesliTheme.surfaceBorder)
                 ModelInfoRow(icon: "waveform", title: "Engine", value: coordinator.selectedTranscriptionModel.shortName)
                 Divider().overlay(MuesliTheme.surfaceBorder)
@@ -158,35 +167,6 @@ struct ModelsView: View {
         }
     }
 
-    private var modelButtonTitle: String {
-        switch coordinator.modelPreparation.phase {
-        case .ready:
-            "Model Ready"
-        case .downloading, .preparing:
-            "Preparing"
-        case .failed:
-            "Try Again"
-        case .idle:
-            "Prepare Model"
-        }
-    }
-
-    private var modelButtonIcon: String {
-        switch coordinator.modelPreparation.phase {
-        case .ready:
-            "checkmark"
-        case .downloading, .preparing:
-            "arrow.down"
-        case .failed:
-            "arrow.clockwise"
-        case .idle:
-            "square.and.arrow.down"
-        }
-    }
-
-    private var modelButtonDisabled: Bool {
-        coordinator.modelPreparation.isReady || coordinator.modelPreparation.isPreparing
-    }
 }
 
 private struct ModelInfoRow: View {

--- a/Muesli/MuesliPreferences.swift
+++ b/Muesli/MuesliPreferences.swift
@@ -9,6 +9,7 @@ enum MuesliPreferences {
     static let fillerWordRemovalKey = "muesli.transcription.fillerWordRemoval"
     static let customDictionaryKey = "muesli.transcription.customDictionary"
     static let transcriptionModelKey = "muesli.transcription.localModel"
+    static let manuallyRemovedTranscriptionModelKey = "muesli.transcription.manuallyRemovedModel"
     static let keepDictationAudioRecordingsKey = "muesli.dictations.keepAudioRecordings"
     static let longVoiceNoteModeEnabledKey = "muesli.dictations.longVoiceNoteMode.enabled"
     static let longVoiceNoteThresholdSecondsKey = "muesli.dictations.longVoiceNoteMode.thresholdSeconds"
@@ -58,6 +59,12 @@ enum MuesliPreferences {
         LocalTranscriptionModel(
             rawValue: UserDefaults.standard.string(forKey: transcriptionModelKey) ?? ""
         ) ?? .defaultModel
+    }
+
+    static var manuallyRemovedTranscriptionModel: LocalTranscriptionModel? {
+        LocalTranscriptionModel(
+            rawValue: UserDefaults.standard.string(forKey: manuallyRemovedTranscriptionModelKey) ?? ""
+        )
     }
 
     static var keepDictationAudioRecordingsEnabled: Bool {

--- a/Muesli/OnboardingView.swift
+++ b/Muesli/OnboardingView.swift
@@ -608,7 +608,10 @@ struct OnboardingView: View {
 
     private var modelPicker: some View {
         MuesliSurface(cornerRadius: MuesliTheme.cornerLarge) {
-            TranscriptionModelSelector(selection: $coordinator.selectedTranscriptionModel)
+            TranscriptionModelSelector(
+                selection: $coordinator.selectedTranscriptionModel,
+                preparation: coordinator.modelPreparation
+            )
             .padding(MuesliTheme.spacing16)
         }
     }

--- a/Muesli/SettingsView.swift
+++ b/Muesli/SettingsView.swift
@@ -1547,27 +1547,35 @@ final class AppleSyncAccountManager {
     }
 
     private func iCloudStatus() async -> (label: String, isAvailable: Bool) {
-        await withCheckedContinuation { continuation in
-            CKContainer.default().accountStatus { status, error in
-                if error != nil {
-                    continuation.resume(returning: ("Unavailable", false))
-                    return
+        // UI tests intentionally use an unsigned app bundle. CloudKit aborts
+        // that process before invoking its completion handler because the
+        // signed iCloud entitlements are absent.
+        if ProcessInfo.processInfo.arguments.contains(MuesliAppConstants.uiTestingLaunchArgument) {
+            return ("Unavailable", false)
+        }
+
+        return await withCheckedContinuation { continuation in
+            CKContainer(identifier: ICloudTextSyncEngine.containerIdentifier)
+                .accountStatus { status, error in
+                    if error != nil {
+                        continuation.resume(returning: ("Unavailable", false))
+                        return
+                    }
+                    switch status {
+                    case .available:
+                        continuation.resume(returning: ("Available", true))
+                    case .noAccount:
+                        continuation.resume(returning: ("No iCloud account", false))
+                    case .restricted:
+                        continuation.resume(returning: ("Restricted", false))
+                    case .couldNotDetermine:
+                        continuation.resume(returning: ("Unknown", false))
+                    case .temporarilyUnavailable:
+                        continuation.resume(returning: ("Temporarily unavailable", false))
+                    @unknown default:
+                        continuation.resume(returning: ("Unknown", false))
+                    }
                 }
-                switch status {
-                case .available:
-                    continuation.resume(returning: ("Available", true))
-                case .noAccount:
-                    continuation.resume(returning: ("No iCloud account", false))
-                case .restricted:
-                    continuation.resume(returning: ("Restricted", false))
-                case .couldNotDetermine:
-                    continuation.resume(returning: ("Unknown", false))
-                case .temporarilyUnavailable:
-                    continuation.resume(returning: ("Temporarily unavailable", false))
-                @unknown default:
-                    continuation.resume(returning: ("Unknown", false))
-                }
-            }
         }
     }
 }

--- a/Muesli/SettingsView.swift
+++ b/Muesli/SettingsView.swift
@@ -31,78 +31,97 @@ struct SettingsView: View {
     @State private var selectedSettingsSection: SettingsSection?
     @State private var isSyncQRCodeScannerPresented = false
     @State private var isApplyingQRCodeSyncEnable = false
+    @State private var modelPendingRemoval: LocalTranscriptionModel?
+    @State private var isModelRemovalConfirmationPresented = false
+    @State private var modelBeingRemoved: LocalTranscriptionModel?
+    @State private var modelRemovalErrorMessage: String?
 
     var body: some View {
         NavigationStack {
             settingsContent
-            .background(MuesliTheme.backgroundBase)
-            .toolbar(.hidden, for: .navigationBar)
-            .onAppear {
-                refreshVisibleSettingsIfNeeded()
-                openRequestedSyncPrivacySection()
-                openRequestedInputSection()
-            }
-            .onChange(of: isActive) { _, active in
-                guard active else { return }
-                refreshVisibleSettingsIfNeeded()
-                openRequestedSyncPrivacySection()
-                openRequestedInputSection()
-            }
-            .onChange(of: openSyncPrivacyRequest) { _, _ in
-                openRequestedSyncPrivacySection()
-            }
-            .onChange(of: openInputRequest) { _, _ in
-                openRequestedInputSection()
-            }
-            .sheet(isPresented: $isSyncQRCodeScannerPresented) {
-                SyncQRCodeScannerView(
-                    isSyncAlreadyEnabled: iCloudSyncEnabled,
-                    onOpenSyncURL: { url in
-                        coordinator.handleOpenURL(url)
-                    },
-                    onEnableSyncURL: { _ in
-                        enablePrivateICloudSyncFromQR()
+                .background(MuesliTheme.backgroundBase)
+                .toolbar(.hidden, for: .navigationBar)
+                .onAppear {
+                    refreshVisibleSettingsIfNeeded()
+                    openRequestedSyncPrivacySection()
+                    openRequestedInputSection()
+                }
+                .onChange(of: isActive) { _, active in
+                    guard active else { return }
+                    refreshVisibleSettingsIfNeeded()
+                    openRequestedSyncPrivacySection()
+                    openRequestedInputSection()
+                }
+                .onChange(of: openSyncPrivacyRequest) { _, _ in
+                    openRequestedSyncPrivacySection()
+                }
+                .onChange(of: openInputRequest) { _, _ in
+                    openRequestedInputSection()
+                }
+                .sheet(isPresented: $isSyncQRCodeScannerPresented) {
+                    SyncQRCodeScannerView(
+                        isSyncAlreadyEnabled: iCloudSyncEnabled,
+                        onOpenSyncURL: { url in
+                            coordinator.handleOpenURL(url)
+                        },
+                        onEnableSyncURL: { _ in
+                            enablePrivateICloudSyncFromQR()
+                        }
+                    )
+                }
+                .onChange(of: liveActivitiesForDictations) { _, _ in
+                    coordinator.applyLiveActivityPreferences()
+                }
+                .onChange(of: liveActivitiesForMeetings) { _, _ in
+                    coordinator.applyLiveActivityPreferences()
+                }
+                .onChange(of: keyboardSessionMode) { _, enabled in
+                    guard isActive else { return }
+                    coordinator.setKeyboardSessionModeEnabled(enabled)
+                }
+                .onChange(of: microphonePreference) { _, newValue in
+                    guard isActive else { return }
+                    coordinator.refreshAudioInputRoute()
+                    AppTelemetry.signal("recording_microphone_preference_changed", parameters: ["preference": newValue])
+                }
+                .onChange(of: openRouterAPIKey) { _, newValue in
+                    saveOpenRouterAPIKey(newValue)
+                }
+                .onChange(of: iCloudSyncEnabled) { _, enabled in
+                    if enabled && isApplyingQRCodeSyncEnable {
+                        isApplyingQRCodeSyncEnable = false
+                        return
                     }
-                )
-            }
-            .onChange(of: liveActivitiesForDictations) { _, _ in
-                coordinator.applyLiveActivityPreferences()
-            }
-            .onChange(of: liveActivitiesForMeetings) { _, _ in
-                coordinator.applyLiveActivityPreferences()
-            }
-            .onChange(of: keyboardSessionMode) { _, enabled in
-                guard isActive else { return }
-                coordinator.setKeyboardSessionModeEnabled(enabled)
-            }
-            .onChange(of: microphonePreference) { _, newValue in
-                guard isActive else { return }
-                coordinator.refreshAudioInputRoute()
-                AppTelemetry.signal("recording_microphone_preference_changed", parameters: ["preference": newValue])
-            }
-            .onChange(of: openRouterAPIKey) { _, newValue in
-                saveOpenRouterAPIKey(newValue)
-            }
-            .onChange(of: iCloudSyncEnabled) { _, enabled in
-                if enabled && isApplyingQRCodeSyncEnable {
-                    isApplyingQRCodeSyncEnable = false
-                    return
+                    AppTelemetry.signal(
+                        "icloud_sync_toggled",
+                        parameters: ["enabled": enabled ? "true" : "false"]
+                    )
+                    appleSyncStatusText = enabled
+                        ? "Private iCloud sync is on. Open Muesli on your Mac to see the same text history."
+                        : "iCloud sync is off. Your data stays local on this iPhone."
+                    if enabled {
+                        AppTelemetry.signal("bridge_enable_started", parameters: ["platform": "ios", "source": "settings"])
+                        coordinator.syncICloudTextIfEnabled(reason: "settings_toggle")
+                    } else {
+                        coordinator.iCloudSyncStatusText = "iCloud sync is off."
+                    }
+                    refreshAppleSyncSettings()
                 }
-                AppTelemetry.signal(
-                    "icloud_sync_toggled",
-                    parameters: ["enabled": enabled ? "true" : "false"]
-                )
-                appleSyncStatusText = enabled
-                    ? "Private iCloud sync is on. Open Muesli on your Mac to see the same text history."
-                    : "iCloud sync is off. Your data stays local on this iPhone."
-                if enabled {
-                    AppTelemetry.signal("bridge_enable_started", parameters: ["platform": "ios", "source": "settings"])
-                    coordinator.syncICloudTextIfEnabled(reason: "settings_toggle")
-                } else {
-                    coordinator.iCloudSyncStatusText = "iCloud sync is off."
-                }
-                refreshAppleSyncSettings()
+        }
+        .alert(
+            modelPendingRemoval.map { "Remove \($0.shortName)?" } ?? "Remove model?",
+            isPresented: $isModelRemovalConfirmationPresented,
+            presenting: modelPendingRemoval
+        ) { model in
+            Button("Remove Download", role: .destructive) {
+                removeDownloadedModel(model)
+                modelPendingRemoval = nil
             }
+            Button("Cancel", role: .cancel) {
+                modelPendingRemoval = nil
+            }
+        } message: { model in
+            Text(modelRemovalConfirmationMessage(for: model))
         }
     }
 
@@ -147,7 +166,7 @@ struct SettingsView: View {
             Text("Settings")
                 .font(MuesliTheme.title1())
                 .foregroundStyle(MuesliTheme.textPrimary)
-            Text("Configure Muesli without mixing setup into the main workspace.")
+            Text("Voice notes, meetings, local models, and privacy.")
                 .font(MuesliTheme.callout())
                 .foregroundStyle(MuesliTheme.textSecondary)
         }
@@ -181,8 +200,8 @@ struct SettingsView: View {
     @ViewBuilder
     private func settingsSectionContent(_ section: SettingsSection) -> some View {
         switch section {
-        case .general:
-            generalSettings
+        case .about:
+            AboutSettingsContent()
         case .appearance:
             appearanceSettings
         case .input:
@@ -197,17 +216,6 @@ struct SettingsView: View {
             syncPrivacySettings
         case .aiSummaries:
             aiSummarySettings
-        }
-    }
-
-    private var generalSettings: some View {
-        MuesliSurface {
-            VStack(alignment: .leading, spacing: MuesliTheme.spacing12) {
-                SettingsRow(icon: "lock.shield", title: "Processing", value: "On device")
-                Divider().overlay(MuesliTheme.surfaceBorder)
-                SettingsRow(icon: "iphone", title: "App Data", value: "Local SQLite")
-            }
-            .padding(MuesliTheme.spacing16)
         }
     }
 
@@ -325,9 +333,19 @@ struct SettingsView: View {
                         valueColor: MuesliTheme.textSecondary
                     )
                     Divider().overlay(MuesliTheme.surfaceBorder)
-                    TranscriptionModelSelector(selection: $coordinator.selectedTranscriptionModel)
+                    TranscriptionModelSelector(
+                        selection: $coordinator.selectedTranscriptionModel,
+                        preparation: coordinator.modelPreparation,
+                        onSelect: coordinator.selectTranscriptionModel
+                    )
                     Divider().overlay(MuesliTheme.surfaceBorder)
-                    SettingsRow(icon: "cpu", title: "Runtime", value: "CoreML / ANE")
+                    SettingsRow(
+                        icon: "cpu",
+                        title: "Runtime",
+                        value: coordinator.selectedTranscriptionModel.family == .whisper
+                            ? "WhisperKit / CoreML"
+                            : "FluidAudio / CoreML"
+                    )
                     Divider().overlay(MuesliTheme.surfaceBorder)
                     SettingsRow(icon: "textformat", title: "Language", value: coordinator.selectedTranscriptionModel.capabilityLabel)
                     Divider().overlay(MuesliTheme.surfaceBorder)
@@ -347,23 +365,158 @@ struct SettingsView: View {
                         ProgressView(value: progress)
                             .tint(MuesliTheme.accent)
                     }
-                    Button {
-                        coordinator.prepareModel()
-                    } label: {
-                        Label(modelButtonTitle, systemImage: modelButtonIcon)
-                            .font(MuesliTheme.headline())
-                            .frame(maxWidth: .infinity)
-                            .frame(height: 48)
-                            .foregroundStyle(modelButtonDisabled ? MuesliTheme.textTertiary : .white)
-                            .background(modelButtonDisabled ? MuesliTheme.surfacePrimary : MuesliTheme.accent)
-                            .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
-                            .contentShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+                    if coordinator.modelPreparation.phase == .failed {
+                        Button {
+                            coordinator.prepareModel()
+                        } label: {
+                            Label("Retry Download", systemImage: "arrow.clockwise")
+                                .font(MuesliTheme.headline())
+                                .frame(maxWidth: .infinity)
+                                .frame(height: 48)
+                                .foregroundStyle(.white)
+                                .background(MuesliTheme.accent)
+                                .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+                                .contentShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+                        }
+                        .buttonStyle(.plain)
                     }
-                    .buttonStyle(.plain)
-                    .disabled(modelButtonDisabled)
                 }
                 .padding(MuesliTheme.spacing16)
             }
+
+            downloadedModelsSettings
+        }
+    }
+
+    private var downloadedModelsSettings: some View {
+        MuesliSurface(cornerRadius: MuesliTheme.cornerLarge) {
+            VStack(alignment: .leading, spacing: MuesliTheme.spacing12) {
+                VStack(alignment: .leading, spacing: MuesliTheme.spacing4) {
+                    Label("Downloaded Models", systemImage: "internaldrive")
+                        .font(MuesliTheme.headline())
+                        .foregroundStyle(MuesliTheme.textPrimary)
+                    Text("Remove models you no longer use to reclaim local storage.")
+                        .font(MuesliTheme.caption())
+                        .foregroundStyle(MuesliTheme.textSecondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                if let modelRemovalErrorMessage {
+                    Label(modelRemovalErrorMessage, systemImage: "exclamationmark.triangle.fill")
+                        .font(MuesliTheme.captionMedium())
+                        .foregroundStyle(MuesliTheme.destructive)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                if downloadedTranscriptionModels.isEmpty {
+                    Text("No transcription models are stored locally.")
+                        .font(MuesliTheme.callout())
+                        .foregroundStyle(MuesliTheme.textTertiary)
+                        .padding(.vertical, MuesliTheme.spacing4)
+                } else {
+                    ForEach(Array(downloadedTranscriptionModels.enumerated()), id: \.element.id) { index, model in
+                        if index > 0 {
+                            Divider().overlay(MuesliTheme.surfaceBorder)
+                        }
+                        downloadedModelRow(model)
+                    }
+                }
+
+                if !coordinator.canRemoveDownloadedModels,
+                   modelBeingRemoved == nil,
+                   !downloadedTranscriptionModels.isEmpty {
+                    Text("Finish the current recording, transcription, or model download before removing a model.")
+                        .font(MuesliTheme.caption())
+                        .foregroundStyle(MuesliTheme.textTertiary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+            .padding(MuesliTheme.spacing16)
+        }
+    }
+
+    private func downloadedModelRow(_ model: LocalTranscriptionModel) -> some View {
+        HStack(spacing: MuesliTheme.spacing12) {
+            Image(systemName: model.family == .whisper ? "waveform" : "waveform.path.ecg")
+                .font(.system(size: 16, weight: .semibold))
+                .foregroundStyle(MuesliTheme.accent)
+                .frame(width: 34, height: 34)
+                .background(MuesliTheme.accentSubtle)
+                .clipShape(RoundedRectangle(cornerRadius: MuesliTheme.cornerSmall))
+
+            VStack(alignment: .leading, spacing: MuesliTheme.spacing4) {
+                HStack(spacing: MuesliTheme.spacing4) {
+                    Text(model.displayName)
+                        .font(MuesliTheme.headline())
+                        .foregroundStyle(MuesliTheme.textPrimary)
+                        .lineLimit(1)
+                    if model == coordinator.selectedTranscriptionModel {
+                        Text("Active")
+                            .font(MuesliTheme.captionMedium())
+                            .foregroundStyle(MuesliTheme.accent)
+                            .padding(.horizontal, MuesliTheme.spacing8)
+                            .padding(.vertical, 2)
+                            .background(MuesliTheme.accentSubtle)
+                            .clipShape(Capsule())
+                    }
+                }
+                Text(model.estimatedSizeLabel)
+                    .font(MuesliTheme.caption())
+                    .foregroundStyle(MuesliTheme.textSecondary)
+            }
+
+            Spacer(minLength: MuesliTheme.spacing8)
+
+            if modelBeingRemoved == model {
+                ProgressView()
+                    .tint(MuesliTheme.destructive)
+                    .frame(width: 36, height: 36)
+                    .accessibilityLabel("Removing \(model.displayName)")
+            } else {
+                Button {
+                    modelRemovalErrorMessage = nil
+                    modelPendingRemoval = model
+                    isModelRemovalConfirmationPresented = true
+                } label: {
+                    Image(systemName: "trash")
+                        .font(.system(size: 15, weight: .semibold))
+                        .foregroundStyle(MuesliTheme.destructive)
+                        .frame(width: 36, height: 36)
+                        .background(MuesliTheme.destructive.opacity(0.10))
+                        .clipShape(Circle())
+                        .contentShape(Circle())
+                }
+                .buttonStyle(.plain)
+                .disabled(!coordinator.canRemoveDownloadedModels)
+                .accessibilityLabel("Remove \(model.displayName)")
+                .accessibilityIdentifier("model.remove.\(model.rawValue)")
+            }
+        }
+    }
+
+    private var downloadedTranscriptionModels: [LocalTranscriptionModel] {
+        LocalTranscriptionModel.allCases.filter { model in
+            model.isDownloaded
+                || (model == coordinator.selectedTranscriptionModel && coordinator.modelPreparation.isReady)
+        }
+    }
+
+    private func modelRemovalConfirmationMessage(for model: LocalTranscriptionModel) -> String {
+        let storage = "This permanently removes \(model.displayName) from this iPhone and frees its local storage."
+        guard model == coordinator.selectedTranscriptionModel else { return storage }
+        return "\(storage) It remains selected but unavailable until you select it again to download it."
+    }
+
+    private func removeDownloadedModel(_ model: LocalTranscriptionModel) {
+        modelBeingRemoved = model
+        modelRemovalErrorMessage = nil
+        Task {
+            do {
+                try await coordinator.removeDownloadedModel(model)
+            } catch {
+                modelRemovalErrorMessage = error.localizedDescription
+            }
+            modelBeingRemoved = nil
         }
     }
 
@@ -536,36 +689,6 @@ struct SettingsView: View {
         MeetingSummaryBackend(rawValue: meetingSummaryBackend) ?? .openRouter
     }
 
-    private var modelButtonTitle: String {
-        switch coordinator.modelPreparation.phase {
-        case .ready:
-            "Model Ready"
-        case .downloading, .preparing:
-            "Preparing"
-        case .failed:
-            "Try Again"
-        case .idle:
-            "Prepare Model"
-        }
-    }
-
-    private var modelButtonIcon: String {
-        switch coordinator.modelPreparation.phase {
-        case .ready:
-            "checkmark"
-        case .downloading, .preparing:
-            "arrow.down"
-        case .failed:
-            "arrow.clockwise"
-        case .idle:
-            "square.and.arrow.down"
-        }
-    }
-
-    private var modelButtonDisabled: Bool {
-        coordinator.modelPreparation.isReady || coordinator.modelPreparation.isPreparing
-    }
-
     private func refreshSummarySettings() {
         openRouterAPIKey = MeetingSummaryClient.storedOpenRouterAPIKey()
         chatGPTSignedIn = ChatGPTAuthManager.shared.isAuthenticated
@@ -659,78 +782,78 @@ struct SettingsView: View {
 
 }
 
-private enum SettingsSection: String, CaseIterable, Identifiable {
-    case general
-    case appearance
+enum SettingsSection: String, CaseIterable, Identifiable {
     case input
-    case dictionary
     case meetings
+    case dictionary
     case models
-    case syncPrivacy
     case aiSummaries
+    case syncPrivacy
+    case appearance
+    case about
 
     var id: String { rawValue }
 
     var title: String {
         switch self {
-        case .general:
-            "Status"
-        case .appearance:
-            "Appearance"
         case .input:
             "Voice Notes"
-        case .dictionary:
-            "Dictionary"
         case .meetings:
             "Meetings"
+        case .dictionary:
+            "Dictionary"
         case .models:
             "Models"
-        case .syncPrivacy:
-            "Sync & Privacy"
         case .aiSummaries:
             "AI Summaries"
+        case .syncPrivacy:
+            "Sync & Privacy"
+        case .appearance:
+            "Appearance"
+        case .about:
+            "About"
         }
     }
 
     var detail: String {
         switch self {
-        case .general:
-            "Current local processing and storage state."
-        case .appearance:
-            "Color theme, light and dark mode, and app accent."
         case .input:
             "Recording retention, live activities, keyboard setup, and voice note sessions."
-        case .dictionary:
-            "Filler word removal, custom phrases, names, and acronyms."
         case .meetings:
             "Recording, audio retention, live activities, and note templates."
+        case .dictionary:
+            "Filler word removal, custom phrases, names, and acronyms."
         case .models:
-            "Local transcription runtime and model preparation."
-        case .syncPrivacy:
-            "Private iCloud sync between this iPhone and your Mac."
+            "Choose and automatically download local Parakeet or Whisper models."
         case .aiSummaries:
             "Meeting summary providers, auth, and model selection."
+        case .syncPrivacy:
+            "Private iCloud sync between this iPhone and your Mac."
+        case .appearance:
+            "Color theme, light and dark mode, and app accent."
+        case .about:
+            "Version, source code, privacy, and open-source acknowledgements."
         }
     }
 
     var icon: String {
         switch self {
-        case .general:
-            "switch.2"
-        case .appearance:
-            "paintpalette"
         case .input:
             "keyboard"
-        case .dictionary:
-            "character.book.closed"
         case .meetings:
             "person.2.wave.2"
+        case .dictionary:
+            "character.book.closed"
         case .models:
             "cpu"
-        case .syncPrivacy:
-            "icloud"
         case .aiSummaries:
             "sparkles"
+        case .syncPrivacy:
+            "icloud"
+        case .appearance:
+            "paintpalette"
+        case .about:
+            "info.circle"
         }
     }
 

--- a/Muesli/TranscriptionModelSelector.swift
+++ b/Muesli/TranscriptionModelSelector.swift
@@ -254,7 +254,7 @@ private enum ModelCatalogState {
         case .preparing:
             "The downloaded model is being compiled for this device"
         case .failed:
-            "Use Retry Download below after checking your connection"
+            "Check your connection, then use the retry option below"
         }
     }
 

--- a/Muesli/TranscriptionModelSelector.swift
+++ b/Muesli/TranscriptionModelSelector.swift
@@ -3,8 +3,8 @@ import SwiftUI
 struct TranscriptionModelSelector: View {
     @Binding var selection: LocalTranscriptionModel
     var showsHeader = true
-
-    private let models = LocalTranscriptionModel.allCases
+    var preparation: ModelPreparationState? = nil
+    var onSelect: ((LocalTranscriptionModel) -> Void)? = nil
 
     var body: some View {
         VStack(alignment: .leading, spacing: MuesliTheme.spacing12) {
@@ -31,21 +31,29 @@ struct TranscriptionModelSelector: View {
             }
 
             Menu {
-                ForEach(models) { model in
-                    Button {
-                        withAnimation(.snappy(duration: 0.18)) {
-                            selection = model
+                ForEach(LocalTranscriptionModelFamily.allCases) { family in
+                    Section(family.title) {
+                        ForEach(family.models) { model in
+                            Button {
+                                withAnimation(.snappy(duration: 0.18)) {
+                                    if let onSelect {
+                                        onSelect(model)
+                                    } else {
+                                        selection = model
+                                    }
+                                }
+                            } label: {
+                                Label(
+                                    "\(model.displayName) · \(catalogState(for: model).menuLabel)",
+                                    systemImage: catalogState(for: model).icon
+                                )
+                            }
                         }
-                    } label: {
-                        Label(
-                            model.displayName,
-                            systemImage: selection == model ? "checkmark" : model.selectorIcon
-                        )
                     }
                 }
             } label: {
                 HStack(alignment: .center, spacing: MuesliTheme.spacing12) {
-                    Image(systemName: selection.selectorIcon)
+                    Image(systemName: catalogState(for: selection).icon)
                         .font(.system(size: 16, weight: .semibold))
                         .foregroundStyle(.white)
                         .frame(width: 34, height: 34)
@@ -61,6 +69,9 @@ struct TranscriptionModelSelector: View {
                             .foregroundStyle(MuesliTheme.textPrimary)
                             .lineLimit(1)
                             .minimumScaleFactor(0.82)
+                        Text(catalogState(for: selection).statusLabel)
+                            .font(MuesliTheme.captionMedium())
+                            .foregroundStyle(catalogState(for: selection).tint)
                     }
 
                     Spacer(minLength: MuesliTheme.spacing8)
@@ -81,16 +92,38 @@ struct TranscriptionModelSelector: View {
             }
             .menuOrder(.fixed)
 
-            SelectedTranscriptionModelDetails(model: selection)
+            SelectedTranscriptionModelDetails(
+                model: selection,
+                state: catalogState(for: selection)
+            )
         }
         .accessibilityElement(children: .contain)
         .accessibilityLabel("Transcription model")
-        .accessibilityValue(selection.displayName)
+        .accessibilityValue("\(selection.displayName), \(catalogState(for: selection).statusLabel)")
+    }
+
+    private func catalogState(for model: LocalTranscriptionModel) -> ModelCatalogState {
+        guard model == selection, let preparation else {
+            return model.isDownloaded ? .ready : .needsDownload
+        }
+        switch preparation.phase {
+        case .ready:
+            return .ready
+        case .downloading:
+            return .downloading
+        case .preparing:
+            return .preparing
+        case .failed:
+            return .failed
+        case .idle:
+            return model.isDownloaded ? .ready : .needsDownload
+        }
     }
 }
 
 private struct SelectedTranscriptionModelDetails: View {
     let model: LocalTranscriptionModel
+    let state: ModelCatalogState
 
     var body: some View {
         VStack(alignment: .leading, spacing: MuesliTheme.spacing10) {
@@ -112,6 +145,10 @@ private struct SelectedTranscriptionModelDetails: View {
                     }
                 }
             }
+
+            Label(state.detailLabel, systemImage: state.icon)
+                .font(MuesliTheme.captionMedium())
+                .foregroundStyle(state.tint)
         }
         .padding(MuesliTheme.spacing12)
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -140,17 +177,6 @@ private extension MuesliTheme {
 }
 
 private extension LocalTranscriptionModel {
-    var selectorIcon: String {
-        switch self {
-        case .parakeetTdtCtc110m:
-            "bolt.fill"
-        case .parakeetRealtimeEou120m:
-            "dot.radiowaves.left.and.right"
-        case .parakeetV3:
-            "globe"
-        }
-    }
-
     var selectorBadges: [(icon: String, label: String)] {
         var badges: [(icon: String, label: String)] = [
             ("textformat", capabilityLabel),
@@ -162,5 +188,84 @@ private extension LocalTranscriptionModel {
         }
 
         return badges
+    }
+}
+
+private enum ModelCatalogState {
+    case ready
+    case needsDownload
+    case downloading
+    case preparing
+    case failed
+
+    var icon: String {
+        switch self {
+        case .ready:
+            "checkmark.circle.fill"
+        case .needsDownload:
+            "arrow.down.circle"
+        case .downloading:
+            "arrow.down.circle.fill"
+        case .preparing:
+            "gearshape.2.fill"
+        case .failed:
+            "exclamationmark.triangle.fill"
+        }
+    }
+
+    var menuLabel: String {
+        switch self {
+        case .ready:
+            "Downloaded"
+        case .needsDownload:
+            "Download"
+        case .downloading:
+            "Downloading"
+        case .preparing:
+            "Preparing"
+        case .failed:
+            "Retry needed"
+        }
+    }
+
+    var statusLabel: String {
+        switch self {
+        case .ready:
+            "Downloaded and ready"
+        case .needsDownload:
+            "Downloads automatically when selected"
+        case .downloading:
+            "Downloading automatically"
+        case .preparing:
+            "Optimizing for this iPhone"
+        case .failed:
+            "Download paused"
+        }
+    }
+
+    var detailLabel: String {
+        switch self {
+        case .ready:
+            "Stored locally on this iPhone"
+        case .needsDownload:
+            "Select to download and prepare automatically"
+        case .downloading:
+            "You can leave this screen while the download continues"
+        case .preparing:
+            "The downloaded model is being compiled for this device"
+        case .failed:
+            "Use Retry Download below after checking your connection"
+        }
+    }
+
+    var tint: Color {
+        switch self {
+        case .ready:
+            MuesliTheme.success
+        case .failed:
+            MuesliTheme.destructive
+        case .needsDownload, .downloading, .preparing:
+            MuesliTheme.accent
+        }
     }
 }

--- a/Muesli/WhisperKitTranscriptionRuntime.swift
+++ b/Muesli/WhisperKitTranscriptionRuntime.swift
@@ -2,6 +2,13 @@ import Foundation
 @preconcurrency import WhisperKit
 
 actor WhisperKitTranscriptionRuntime {
+    private static let completionMarkerName = ".muesli-download-complete"
+    private static let requiredModelComponents = [
+        "MelSpectrogram",
+        "AudioEncoder",
+        "TextDecoder",
+    ]
+
     private var whisperKit: WhisperKit?
     private var loadedVariant: String?
 
@@ -11,10 +18,12 @@ actor WhisperKitTranscriptionRuntime {
     ) async throws {
         if loadedVariant == variant, whisperKit != nil { return }
 
-        let modelFolder: URL?
+        try Self.prepareDownloadStorage()
+
+        let modelFolder: URL
         if Self.isModelDownloaded(variant) {
             progress?(0.92, "Loading downloaded Whisper model...")
-            modelFolder = nil
+            modelFolder = Self.modelDirectory(for: variant)
         } else {
             let estimatedBytes = Self.estimatedDownloadBytes(for: variant)
             progress?(0.02, "Starting \(Self.formattedSize(estimatedBytes)) download...")
@@ -26,20 +35,26 @@ actor WhisperKitTranscriptionRuntime {
                     "\(Self.formattedSize(downloadedBytes)) of \(Self.formattedSize(estimatedBytes))"
                 )
             }
+            try Self.markDownloadComplete(at: modelFolder)
         }
 
         progress?(0.94, "Optimizing WhisperKit for this iPhone...")
         let configuration = WhisperKitConfig(
-            model: modelFolder == nil ? variant : nil,
-            modelFolder: modelFolder?.path,
+            model: nil,
+            modelFolder: modelFolder.path,
             computeOptions: ModelComputeOptions(
                 audioEncoderCompute: .cpuAndNeuralEngine,
                 textDecoderCompute: .cpuAndNeuralEngine
             )
         )
-        whisperKit = try await WhisperKit(configuration)
-        loadedVariant = variant
-        progress?(1, "Whisper model ready")
+        do {
+            whisperKit = try await WhisperKit(configuration)
+            loadedVariant = variant
+            progress?(1, "Whisper model ready")
+        } catch {
+            Self.invalidateCompletionMarker(at: modelFolder)
+            throw error
+        }
     }
 
     func transcribe(audioURL: URL) async throws -> String {
@@ -60,7 +75,13 @@ actor WhisperKitTranscriptionRuntime {
     }
 
     static func isModelDownloaded(_ variant: String) -> Bool {
-        FileManager.default.fileExists(atPath: modelDirectory(for: variant).path)
+        isModelDownloaded(at: modelDirectory(for: variant))
+    }
+
+    static func isModelDownloaded(at directory: URL) -> Bool {
+        let marker = directory.appendingPathComponent(completionMarkerName)
+        guard FileManager.default.fileExists(atPath: marker.path) else { return false }
+        return requiredModelComponents.allSatisfy { modelComponentExists(named: $0, in: directory) }
     }
 
     static func modelDirectory(for variant: String) -> URL {
@@ -73,6 +94,77 @@ actor WhisperKitTranscriptionRuntime {
             .appendingPathComponent("argmaxinc", isDirectory: true)
             .appendingPathComponent("whisperkit-coreml", isDirectory: true)
             .appendingPathComponent(fullName, isDirectory: true)
+    }
+
+    static func markDownloadComplete(at directory: URL) throws {
+        guard requiredModelComponents.allSatisfy({ modelComponentExists(named: $0, in: directory) }) else {
+            throw WhisperKitRuntimeError.incompleteDownload
+        }
+        try Data().write(
+            to: directory.appendingPathComponent(completionMarkerName),
+            options: .atomic
+        )
+    }
+
+    private static func prepareDownloadStorage() throws {
+        try FileManager.default.createDirectory(
+            at: downloadStorageDirectory,
+            withIntermediateDirectories: true
+        )
+        try excludeDownloadStorageFromBackup()
+    }
+
+    private static var downloadStorageDirectory: URL {
+        FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
+            .appendingPathComponent("huggingface", isDirectory: true)
+    }
+
+    private static func excludeDownloadStorageFromBackup() throws {
+        var directory = downloadStorageDirectory
+        var values = URLResourceValues()
+        values.isExcludedFromBackup = true
+        try directory.setResourceValues(values)
+    }
+
+    private static func invalidateCompletionMarker(at directory: URL) {
+        try? FileManager.default.removeItem(
+            at: directory.appendingPathComponent(completionMarkerName)
+        )
+    }
+
+    private static func modelComponentExists(named name: String, in directory: URL) -> Bool {
+        let compiled = directory.appendingPathComponent("\(name).mlmodelc", isDirectory: true)
+        if directoryContainsNonemptyFile(compiled) {
+            return true
+        }
+
+        let packagedModel = directory
+            .appendingPathComponent("\(name).mlpackage", isDirectory: true)
+            .appendingPathComponent("Data/com.apple.CoreML/model.mlmodel")
+        guard let values = try? packagedModel.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey]) else {
+            return false
+        }
+        return values.isRegularFile == true && (values.fileSize ?? 0) > 0
+    }
+
+    private static func directoryContainsNonemptyFile(_ directory: URL) -> Bool {
+        guard let enumerator = FileManager.default.enumerator(
+            at: directory,
+            includingPropertiesForKeys: [.isRegularFileKey, .fileSizeKey],
+            options: [.skipsHiddenFiles]
+        ) else {
+            return false
+        }
+
+        for case let fileURL as URL in enumerator {
+            guard let values = try? fileURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey]) else {
+                continue
+            }
+            if values.isRegularFile == true, (values.fileSize ?? 0) > 0 {
+                return true
+            }
+        }
+        return false
     }
 
     private static func estimatedDownloadBytes(for variant: String) -> Int64 {
@@ -104,8 +196,14 @@ actor WhisperKitTranscriptionRuntime {
 
 private enum WhisperKitRuntimeError: LocalizedError {
     case notLoaded
+    case incompleteDownload
 
     var errorDescription: String? {
-        "WhisperKit model is not loaded."
+        switch self {
+        case .notLoaded:
+            "WhisperKit model is not loaded."
+        case .incompleteDownload:
+            "The WhisperKit model download is incomplete."
+        }
     }
 }

--- a/Muesli/WhisperKitTranscriptionRuntime.swift
+++ b/Muesli/WhisperKitTranscriptionRuntime.swift
@@ -1,0 +1,111 @@
+import Foundation
+@preconcurrency import WhisperKit
+
+actor WhisperKitTranscriptionRuntime {
+    private var whisperKit: WhisperKit?
+    private var loadedVariant: String?
+
+    func load(
+        variant: String,
+        progress: (@Sendable (Double, String?) -> Void)? = nil
+    ) async throws {
+        if loadedVariant == variant, whisperKit != nil { return }
+
+        let modelFolder: URL?
+        if Self.isModelDownloaded(variant) {
+            progress?(0.92, "Loading downloaded Whisper model...")
+            modelFolder = nil
+        } else {
+            let estimatedBytes = Self.estimatedDownloadBytes(for: variant)
+            progress?(0.02, "Starting \(Self.formattedSize(estimatedBytes)) download...")
+            modelFolder = try await WhisperKit.download(variant: variant) { downloadProgress in
+                let fraction = min(max(downloadProgress.fractionCompleted, 0), 1)
+                let downloadedBytes = Int64(Double(estimatedBytes) * fraction)
+                progress?(
+                    max(fraction * 0.9, 0.02),
+                    "\(Self.formattedSize(downloadedBytes)) of \(Self.formattedSize(estimatedBytes))"
+                )
+            }
+        }
+
+        progress?(0.94, "Optimizing WhisperKit for this iPhone...")
+        let configuration = WhisperKitConfig(
+            model: modelFolder == nil ? variant : nil,
+            modelFolder: modelFolder?.path,
+            computeOptions: ModelComputeOptions(
+                audioEncoderCompute: .cpuAndNeuralEngine,
+                textDecoderCompute: .cpuAndNeuralEngine
+            )
+        )
+        whisperKit = try await WhisperKit(configuration)
+        loadedVariant = variant
+        progress?(1, "Whisper model ready")
+    }
+
+    func transcribe(audioURL: URL) async throws -> String {
+        guard let whisperKit else {
+            throw WhisperKitRuntimeError.notLoaded
+        }
+        let results = try await whisperKit.transcribe(audioPath: audioURL.path)
+        return results
+            .map(\.text)
+            .joined(separator: " ")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    func unload() async {
+        await whisperKit?.unloadModels()
+        whisperKit = nil
+        loadedVariant = nil
+    }
+
+    static func isModelDownloaded(_ variant: String) -> Bool {
+        FileManager.default.fileExists(atPath: modelDirectory(for: variant).path)
+    }
+
+    static func modelDirectory(for variant: String) -> URL {
+        let fullName = variant.hasPrefix("openai_whisper-")
+            ? variant
+            : "openai_whisper-\(variant)"
+        return FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
+            .appendingPathComponent("huggingface", isDirectory: true)
+            .appendingPathComponent("models", isDirectory: true)
+            .appendingPathComponent("argmaxinc", isDirectory: true)
+            .appendingPathComponent("whisperkit-coreml", isDirectory: true)
+            .appendingPathComponent(fullName, isDirectory: true)
+    }
+
+    private static func estimatedDownloadBytes(for variant: String) -> Int64 {
+        switch variant {
+        case "tiny.en":
+            153 * 1_000_000
+        case "small.en":
+            250 * 1_000_000
+        case "medium.en":
+            1_500 * 1_000_000
+        case "large-v3-v20240930_626MB":
+            626 * 1_000_000
+        default:
+            250 * 1_000_000
+        }
+    }
+
+    private static func formattedSize(_ bytes: Int64) -> String {
+        let megabytes = Double(bytes) / 1_000_000
+        if megabytes >= 1_000 {
+            return String(format: "%.1f GB", megabytes / 1_000)
+        }
+        if megabytes >= 100 {
+            return "\(Int(megabytes.rounded())) MB"
+        }
+        return String(format: "%.1f MB", megabytes)
+    }
+}
+
+private enum WhisperKitRuntimeError: LocalizedError {
+    case notLoaded
+
+    var errorDescription: String? {
+        "WhisperKit model is not loaded."
+    }
+}

--- a/MuesliKeyboard/KeyboardController.swift
+++ b/MuesliKeyboard/KeyboardController.swift
@@ -137,11 +137,11 @@ final class KeyboardController {
     }
 
     var waveformMode: MuesliFloatingWaveformMode {
-        .waiting
+        MuesliKeyboardWaveformPresentation.mode(for: dictationPhase)
     }
 
     var waveformLevel: Double? {
-        nil
+        MuesliKeyboardWaveformPresentation.level(for: dictationPhase, inputLevel: inputLevel)
     }
 
     var canCancelActiveDictation: Bool {
@@ -605,7 +605,13 @@ final class KeyboardController {
     }
 
     private func apply(runtimeStatus: KeyboardRuntimeStatus?) {
-        inputLevel = 0
+        let now = Date()
+        let hasFreshRecordingLevel = runtimeStatus.map {
+            $0.phase == .recording
+                && $0.activeRequestID == activeRequestID
+                && now.timeIntervalSince($0.updatedAt) < 2
+        } ?? false
+        inputLevel = hasFreshRecordingLevel ? (runtimeStatus?.inputLevel ?? 0) : 0
         canUseRuntimeStart = runtimeStatus?.canAcceptStartCommand == true
 
         guard activeRequestID == nil, canUseRuntimeStart else { return }

--- a/Shared/MuesliWaveformView.swift
+++ b/Shared/MuesliWaveformView.swift
@@ -63,6 +63,34 @@ enum MuesliFloatingWaveformMode: Equatable {
     case waiting
 }
 
+enum MuesliKeyboardWaveformPresentation {
+    static func mode(for phase: DictationPhase) -> MuesliFloatingWaveformMode {
+        phase == .recording ? .level : .waiting
+    }
+
+    static func level(for phase: DictationPhase, inputLevel: Double) -> Double? {
+        phase == .recording ? min(max(inputLevel, 0), 1) : nil
+    }
+}
+
+struct MuesliWaveformLevelThrottle {
+    private var lastPublishedAt = Date.distantPast
+    private var lastPublishedLevel = 0.0
+
+    mutating func valueToPublish(_ rawLevel: Double, at now: Date = .now) -> Double? {
+        let elapsed = now.timeIntervalSince(lastPublishedAt)
+        let normalized = min(max(rawLevel, 0), 1)
+        let quantized = (normalized * 40).rounded() / 40
+        let changed = quantized != lastPublishedLevel
+
+        guard elapsed >= 0.1, changed || elapsed >= 0.5 else { return nil }
+
+        lastPublishedAt = now
+        lastPublishedLevel = quantized
+        return quantized
+    }
+}
+
 struct MuesliInlineWaveformView: View {
     var mode: MuesliFloatingWaveformMode
     var color: Color

--- a/Shared/MuesliWaveformView.swift
+++ b/Shared/MuesliWaveformView.swift
@@ -74,6 +74,9 @@ enum MuesliKeyboardWaveformPresentation {
 }
 
 struct MuesliWaveformLevelThrottle {
+    static let minimumPublishInterval: TimeInterval = 0.16
+    static let heartbeatInterval: TimeInterval = 0.75
+
     private var lastPublishedAt = Date.distantPast
     private var lastPublishedLevel = 0.0
 
@@ -83,7 +86,9 @@ struct MuesliWaveformLevelThrottle {
         let quantized = (normalized * 40).rounded() / 40
         let changed = quantized != lastPublishedLevel
 
-        guard elapsed >= 0.1, changed || elapsed >= 0.5 else { return nil }
+        guard elapsed >= Self.minimumPublishInterval,
+              changed || elapsed >= Self.heartbeatInterval
+        else { return nil }
 
         lastPublishedAt = now
         lastPublishedLevel = quantized

--- a/Shared/TranscriptionDisplayName.swift
+++ b/Shared/TranscriptionDisplayName.swift
@@ -7,6 +7,16 @@ enum TranscriptionDisplayName {
             "Parakeet v3"
         case "parakeet-tdt-ctc-110m":
             "Parakeet 110M"
+        case "parakeet-realtime-eou-120m":
+            "Parakeet Realtime"
+        case "whisper-tiny-en":
+            "Whisper Tiny"
+        case "whisper-small-en":
+            "Whisper Small"
+        case "whisper-medium-en":
+            "Whisper Medium"
+        case "whisper-large-turbo":
+            "Whisper Turbo"
         case "placeholder":
             "Placeholder"
         default:

--- a/Tests/MuesliTests/KeyboardWaveformTests.swift
+++ b/Tests/MuesliTests/KeyboardWaveformTests.swift
@@ -21,9 +21,10 @@ final class KeyboardWaveformTests: XCTestCase {
 
         XCTAssertEqual(throttle.valueToPublish(0.61, at: start), 0.6)
         XCTAssertNil(throttle.valueToPublish(0.62, at: start.addingTimeInterval(0.05)))
-        XCTAssertEqual(throttle.valueToPublish(0.66, at: start.addingTimeInterval(0.1)), 0.65)
+        XCTAssertNil(throttle.valueToPublish(0.66, at: start.addingTimeInterval(0.1)))
+        XCTAssertEqual(throttle.valueToPublish(0.66, at: start.addingTimeInterval(0.17)), 0.65)
         XCTAssertNil(throttle.valueToPublish(0.66, at: start.addingTimeInterval(0.3)))
-        XCTAssertEqual(throttle.valueToPublish(0.66, at: start.addingTimeInterval(0.6)), 0.65)
+        XCTAssertEqual(throttle.valueToPublish(0.66, at: start.addingTimeInterval(0.93)), 0.65)
     }
 
     func testWaveformLevelPublishingClampsOutOfRangeValues() {
@@ -31,6 +32,6 @@ final class KeyboardWaveformTests: XCTestCase {
         let start = Date(timeIntervalSinceReferenceDate: 2_000)
 
         XCTAssertEqual(throttle.valueToPublish(-1, at: start), 0)
-        XCTAssertEqual(throttle.valueToPublish(2, at: start.addingTimeInterval(0.11)), 1)
+        XCTAssertEqual(throttle.valueToPublish(2, at: start.addingTimeInterval(0.17)), 1)
     }
 }

--- a/Tests/MuesliTests/KeyboardWaveformTests.swift
+++ b/Tests/MuesliTests/KeyboardWaveformTests.swift
@@ -1,0 +1,36 @@
+import XCTest
+@testable import Muesli
+
+final class KeyboardWaveformTests: XCTestCase {
+    func testKeyboardWaveformUsesMeteredLevelOnlyWhileRecording() {
+        XCTAssertEqual(MuesliKeyboardWaveformPresentation.mode(for: .recording), .level)
+        XCTAssertEqual(
+            MuesliKeyboardWaveformPresentation.level(for: .recording, inputLevel: 0.62),
+            0.62
+        )
+
+        for phase in [DictationPhase.requested, .transcribing, .idle] {
+            XCTAssertEqual(MuesliKeyboardWaveformPresentation.mode(for: phase), .waiting)
+            XCTAssertNil(MuesliKeyboardWaveformPresentation.level(for: phase, inputLevel: 0.62))
+        }
+    }
+
+    func testWaveformLevelPublishingIsQuantizedAndThrottled() {
+        var throttle = MuesliWaveformLevelThrottle()
+        let start = Date(timeIntervalSinceReferenceDate: 1_000)
+
+        XCTAssertEqual(throttle.valueToPublish(0.61, at: start), 0.6)
+        XCTAssertNil(throttle.valueToPublish(0.62, at: start.addingTimeInterval(0.05)))
+        XCTAssertEqual(throttle.valueToPublish(0.66, at: start.addingTimeInterval(0.1)), 0.65)
+        XCTAssertNil(throttle.valueToPublish(0.66, at: start.addingTimeInterval(0.3)))
+        XCTAssertEqual(throttle.valueToPublish(0.66, at: start.addingTimeInterval(0.6)), 0.65)
+    }
+
+    func testWaveformLevelPublishingClampsOutOfRangeValues() {
+        var throttle = MuesliWaveformLevelThrottle()
+        let start = Date(timeIntervalSinceReferenceDate: 2_000)
+
+        XCTAssertEqual(throttle.valueToPublish(-1, at: start), 0)
+        XCTAssertEqual(throttle.valueToPublish(2, at: start.addingTimeInterval(0.11)), 1)
+    }
+}

--- a/Tests/MuesliTests/SettingsModelCatalogTests.swift
+++ b/Tests/MuesliTests/SettingsModelCatalogTests.swift
@@ -86,4 +86,70 @@ final class SettingsModelCatalogTests: XCTestCase {
         XCTAssertFalse(FileManager.default.fileExists(atPath: target.path))
         XCTAssertTrue(FileManager.default.fileExists(atPath: sibling.path))
     }
+
+    func testBackgroundDownloadTaskDescriptionPreservesAttemptIdentity() throws {
+        let attemptID = UUID()
+        let file = ModelDownloadFile(
+            remotePath: "Encoder.mlmodelc/model.mil",
+            localPath: "Encoder.mlmodelc/model.mil",
+            remoteURL: try XCTUnwrap(URL(string: "https://example.com/model.mil")),
+            size: 42
+        )
+
+        let description = file.taskDescription(model: .parakeetV3, attemptID: attemptID)
+        let restored = try XCTUnwrap(ModelDownloadFile(taskDescription: description))
+
+        XCTAssertEqual(restored.model, .parakeetV3)
+        XCTAssertEqual(restored.remotePath, file.remotePath)
+        XCTAssertEqual(restored.localPath, file.localPath)
+        XCTAssertEqual(restored.remoteURL, file.remoteURL)
+        XCTAssertEqual(restored.size, file.size)
+        XCTAssertEqual(restored.attemptID, attemptID)
+    }
+
+    func testLegacyBackgroundDownloadTaskDescriptionStillRestores() throws {
+        let description = [
+            LocalTranscriptionModel.parakeetV3.rawValue,
+            "Encoder.mlmodelc/model.mil",
+            "Encoder.mlmodelc/model.mil",
+            "https://example.com/model.mil",
+            "42",
+        ].joined(separator: "\n")
+
+        let restored = try XCTUnwrap(ModelDownloadFile(taskDescription: description))
+
+        XCTAssertEqual(restored.model, .parakeetV3)
+        XCTAssertNil(restored.attemptID)
+    }
+
+    func testStaleAttemptCannotMatchNewPlanForSameModel() throws {
+        let staleAttemptID = UUID()
+        let currentAttemptID = UUID()
+        let currentAttempt = ModelDownloadAttempt(
+            modelRawValue: LocalTranscriptionModel.parakeetV3.rawValue,
+            id: currentAttemptID
+        )
+        let plan = DownloadPlan(attempt: currentAttempt, totalBytes: 42, pendingCount: 1)
+        let staleFile = ModelDownloadFile(
+            remotePath: "Encoder.mlmodelc/model.mil",
+            localPath: "Encoder.mlmodelc/model.mil",
+            remoteURL: try XCTUnwrap(URL(string: "https://example.com/model.mil")),
+            size: 42,
+            model: .parakeetV3,
+            attemptID: staleAttemptID
+        )
+        let currentFile = ModelDownloadFile(
+            remotePath: staleFile.remotePath,
+            localPath: staleFile.localPath,
+            remoteURL: staleFile.remoteURL,
+            size: staleFile.size,
+            model: .parakeetV3,
+            attemptID: currentAttemptID
+        )
+
+        XCTAssertFalse(plan.matches(staleFile))
+        XCTAssertFalse(currentAttempt.matches(staleFile))
+        XCTAssertTrue(plan.matches(currentFile))
+        XCTAssertTrue(currentAttempt.matches(currentFile))
+    }
 }

--- a/Tests/MuesliTests/SettingsModelCatalogTests.swift
+++ b/Tests/MuesliTests/SettingsModelCatalogTests.swift
@@ -50,6 +50,37 @@ final class SettingsModelCatalogTests: XCTestCase {
         )
     }
 
+    func testWhisperKitDownloadRequiresCompletionMarkerAndAllCoreModels() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("muesli-whisper-integrity-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        XCTAssertFalse(WhisperKitTranscriptionRuntime.isModelDownloaded(at: root))
+
+        for component in ["MelSpectrogram", "AudioEncoder", "TextDecoder"] {
+            let compiledModel = root.appendingPathComponent("\(component).mlmodelc", isDirectory: true)
+            try FileManager.default.createDirectory(at: compiledModel, withIntermediateDirectories: true)
+            try Data("model".utf8).write(to: compiledModel.appendingPathComponent("model.mil"))
+        }
+
+        XCTAssertFalse(
+            WhisperKitTranscriptionRuntime.isModelDownloaded(at: root),
+            "A structurally complete directory is not trusted until the download commits its marker."
+        )
+
+        try WhisperKitTranscriptionRuntime.markDownloadComplete(at: root)
+        XCTAssertTrue(WhisperKitTranscriptionRuntime.isModelDownloaded(at: root))
+
+        try FileManager.default.removeItem(
+            at: root.appendingPathComponent("AudioEncoder.mlmodelc/model.mil")
+        )
+        XCTAssertFalse(
+            WhisperKitTranscriptionRuntime.isModelDownloaded(at: root),
+            "The marker cannot make a partial model installation appear ready."
+        )
+    }
+
     func testModelCatalogHasStableUniqueIdentifiers() {
         let models = LocalTranscriptionModel.allCases
         XCTAssertEqual(Set(models.map(\.id)).count, models.count)
@@ -151,5 +182,19 @@ final class SettingsModelCatalogTests: XCTestCase {
         XCTAssertFalse(currentAttempt.matches(staleFile))
         XCTAssertTrue(plan.matches(currentFile))
         XCTAssertTrue(currentAttempt.matches(currentFile))
+    }
+
+    func testRestoredAttemptCannotCompleteAfterAnyFileFails() {
+        let attempt = ModelDownloadAttempt(
+            modelRawValue: LocalTranscriptionModel.parakeetV3.rawValue,
+            id: UUID()
+        )
+        var outcomes = ModelDownloadAttemptOutcomeTracker()
+
+        outcomes.recordCompletion(attempt)
+        XCTAssertTrue(outcomes.recordFailure(attempt))
+        outcomes.recordCompletion(attempt)
+
+        XCTAssertTrue(outcomes.drainCompletedAttempts().isEmpty)
     }
 }

--- a/Tests/MuesliTests/SettingsModelCatalogTests.swift
+++ b/Tests/MuesliTests/SettingsModelCatalogTests.swift
@@ -1,0 +1,89 @@
+import XCTest
+@testable import Muesli
+
+final class SettingsModelCatalogTests: XCTestCase {
+    func testSettingsSectionsFollowCoreWorkflowPriority() {
+        XCTAssertEqual(
+            SettingsSection.allCases.map(\.title),
+            [
+                "Voice Notes",
+                "Meetings",
+                "Dictionary",
+                "Models",
+                "AI Summaries",
+                "Sync & Privacy",
+                "Appearance",
+                "About",
+            ]
+        )
+        XCTAssertFalse(SettingsSection.allCases.map(\.title).contains("Status"))
+    }
+
+    func testAboutListsEveryDirectThirdPartyRuntimeDependency() {
+        XCTAssertEqual(
+            OpenSourceLibrary.all.map(\.id),
+            ["fluidaudio", "whisperkit", "telemetrydeck", "sqlite"]
+        )
+        XCTAssertTrue(OpenSourceLibrary.all.allSatisfy { !$0.name.isEmpty && !$0.license.isEmpty })
+    }
+
+    func testWhisperKitCatalogMatchesSupportedMacVariants() {
+        XCTAssertEqual(
+            LocalTranscriptionModel.whisperModels.map(\.whisperVariant),
+            [
+                "tiny.en",
+                "small.en",
+                "medium.en",
+                "large-v3-v20240930_626MB",
+            ]
+        )
+        XCTAssertTrue(LocalTranscriptionModel.whisperModels.allSatisfy { $0.family == .whisper })
+        XCTAssertTrue(LocalTranscriptionModel.whisperModels.allSatisfy { !$0.supportsRealtimeStreaming })
+    }
+
+    func testWhisperKitDownloadStateUsesTheRuntimeCacheLocation() {
+        let modelDirectory = WhisperKitTranscriptionRuntime.modelDirectory(for: "tiny.en")
+        XCTAssertTrue(
+            modelDirectory.path.hasSuffix(
+                "huggingface/models/argmaxinc/whisperkit-coreml/openai_whisper-tiny.en"
+            )
+        )
+    }
+
+    func testModelCatalogHasStableUniqueIdentifiers() {
+        let models = LocalTranscriptionModel.allCases
+        XCTAssertEqual(Set(models.map(\.id)).count, models.count)
+        XCTAssertEqual(
+            models.count,
+            LocalTranscriptionModel.parakeetModels.count + LocalTranscriptionModel.whisperModels.count
+        )
+    }
+
+    func testEveryModelHasAnIsolatedStorageDirectory() {
+        let directories = LocalTranscriptionModel.allCases.compactMap {
+            ModelBackgroundDownloadService.storageDirectory(for: $0)?.standardizedFileURL.path
+        }
+
+        XCTAssertEqual(directories.count, LocalTranscriptionModel.allCases.count)
+        XCTAssertEqual(Set(directories).count, directories.count)
+        XCTAssertTrue(directories.allSatisfy { !$0.isEmpty && $0 != "/" })
+    }
+
+    func testRemovingModelDirectoryDoesNotRemoveSiblingModels() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("muesli-model-removal-\(UUID().uuidString)", isDirectory: true)
+        let target = root.appendingPathComponent("target-model", isDirectory: true)
+        let sibling = root.appendingPathComponent("sibling-model", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        try FileManager.default.createDirectory(at: target, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: sibling, withIntermediateDirectories: true)
+        try Data("target".utf8).write(to: target.appendingPathComponent("model.bin"))
+        try Data("sibling".utf8).write(to: sibling.appendingPathComponent("model.bin"))
+
+        try ModelBackgroundDownloadService.removeDownloadedModel(at: target)
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: target.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: sibling.path))
+    }
+}

--- a/Tests/MuesliUITests/MuesliSmokeUITests.swift
+++ b/Tests/MuesliUITests/MuesliSmokeUITests.swift
@@ -33,6 +33,67 @@ final class MuesliSmokeUITests: XCTestCase {
         XCTAssertTrue(app.staticTexts["Start a new meeting"].waitForExistence(timeout: 5))
     }
 
+    func testSettingsPrioritizeCoreWorkflowsAndAboutListsOpenSourceLibraries() {
+        let app = launchApp()
+
+        XCTAssertTrue(app.buttons["tab.settings"].waitForExistence(timeout: 8))
+        app.buttons["tab.settings"].tap()
+
+        XCTAssertTrue(app.staticTexts["Voice Notes"].waitForExistence(timeout: 5))
+        XCTAssertTrue(app.staticTexts["Meetings"].exists)
+        XCTAssertFalse(app.staticTexts["Status"].exists)
+
+        let about = app.staticTexts["About"]
+        for _ in 0..<5 where !about.exists {
+            app.swipeUp()
+        }
+        XCTAssertTrue(about.exists)
+        about.tap()
+
+        XCTAssertTrue(app.staticTexts["About"].waitForExistence(timeout: 5))
+        let openSourceHeader = app.staticTexts["OPEN SOURCE LIBRARIES"]
+        for _ in 0..<4 where !openSourceHeader.exists {
+            app.swipeUp()
+        }
+        XCTAssertTrue(openSourceHeader.exists)
+        XCTAssertTrue(app.staticTexts["FluidAudio"].exists)
+        XCTAssertTrue(app.staticTexts["WhisperKit"].exists)
+        XCTAssertTrue(app.staticTexts["TelemetryDeck Swift SDK"].exists)
+        XCTAssertTrue(app.staticTexts["SQLite"].exists)
+    }
+
+    func testModelsSettingsPrepareAutomaticallyWithoutPersistentPrepareButton() {
+        let app = launchApp()
+
+        XCTAssertTrue(app.buttons["tab.settings"].waitForExistence(timeout: 8))
+        app.buttons["tab.settings"].tap()
+
+        let models = app.staticTexts["Models"]
+        for _ in 0..<3 where !models.exists {
+            app.swipeUp()
+        }
+        XCTAssertTrue(models.exists)
+        models.tap()
+
+        XCTAssertTrue(app.staticTexts["Choose model"].waitForExistence(timeout: 5))
+        XCTAssertFalse(app.buttons["Prepare Model"].exists)
+        XCTAssertTrue(app.staticTexts["Downloaded and ready"].exists)
+
+        let removeModel = app.buttons["model.remove.parakeet-tdt-ctc-110m"]
+        for _ in 0..<4 where !removeModel.isHittable {
+            app.swipeUp()
+        }
+        XCTAssertTrue(removeModel.isHittable)
+        XCTAssertTrue(removeModel.isEnabled)
+        app.swipeUp()
+        XCTAssertTrue(removeModel.isHittable)
+        removeModel.tap()
+
+        XCTAssertTrue(app.buttons["Remove Download"].waitForExistence(timeout: 3))
+        XCTAssertTrue(app.buttons["Cancel"].exists)
+        app.buttons["Cancel"].tap()
+    }
+
     func testVoiceNotePreviewExpandsAndShowsMetadataBadges() {
         let app = XCUIApplication()
         app.launchArguments = ["--muesli-ui-testing", "--muesli-mock-dictations"]

--- a/Tests/MuesliUITests/MuesliSmokeUITests.swift
+++ b/Tests/MuesliUITests/MuesliSmokeUITests.swift
@@ -80,13 +80,18 @@ final class MuesliSmokeUITests: XCTestCase {
         XCTAssertTrue(app.staticTexts["Downloaded and ready"].exists)
 
         let removeModel = app.buttons["model.remove.parakeet-tdt-ctc-110m"]
-        for _ in 0..<4 where !removeModel.isHittable {
+        let tabBar = app.buttons["tab.settings"]
+        for _ in 0..<4 {
+            if removeModel.exists,
+               removeModel.isHittable,
+               removeModel.frame.maxY < tabBar.frame.minY {
+                break
+            }
             app.swipeUp()
         }
         XCTAssertTrue(removeModel.isHittable)
         XCTAssertTrue(removeModel.isEnabled)
-        app.swipeUp()
-        XCTAssertTrue(removeModel.isHittable)
+        XCTAssertLessThan(removeModel.frame.maxY, tabBar.frame.minY)
         removeModel.tap()
 
         XCTAssertTrue(app.buttons["Remove Download"].waitForExistence(timeout: 3))
@@ -193,9 +198,10 @@ final class MuesliSmokeUITests: XCTestCase {
         XCTAssertTrue(app.buttons["Return to Meeting"].waitForExistence(timeout: 5))
         app.buttons["Return to Meeting"].tap()
 
-        XCTAssertTrue(app.staticTexts["Raw transcript should no longer be selected after processing."].waitForExistence(timeout: 5))
+        let rawTranscript = app.staticTexts["Raw transcript should no longer be selected after processing."]
+        XCTAssertTrue(rawTranscript.waitForExistence(timeout: 5))
         XCTAssertTrue(app.staticTexts["The generated meeting summary is selected by default."].waitForExistence(timeout: 25))
-        XCTAssertFalse(app.staticTexts["Raw transcript should no longer be selected after processing."].exists)
+        XCTAssertTrue(rawTranscript.waitForNonExistence(timeout: 5))
     }
 
     func testLiveMeetingDisplaysCompletedTranscriptChunksWithoutLeavingRecording() {

--- a/project.yml
+++ b/project.yml
@@ -26,6 +26,9 @@ packages:
   TelemetryDeck:
     url: https://github.com/TelemetryDeck/SwiftSDK
     from: "2.12.0"
+  WhisperKit:
+    url: https://github.com/argmaxinc/WhisperKit.git
+    revision: 80d96762fa727f816ffceab76a6529cd12c2726f
 
 targets:
   Muesli:
@@ -48,6 +51,7 @@ targets:
       - target: MuesliLiveActivityExtension
       - package: FluidAudio
       - package: TelemetryDeck
+      - package: WhisperKit
       - sdk: libsqlite3.tbd
 
   MuesliLiveActivityExtension:


### PR DESCRIPTION
## Summary

- reorder Settings around the most frequently used voice-note and meeting workflows
- replace the informational Status screen with an About section that lists direct open-source dependencies
- add Parakeet and WhisperKit model choices with automatic download and preparation on selection
- show clear downloaded/ready state and local storage estimates for each model
- let users remove downloaded models through a destructive confirmation prompt
- safely unload active runtimes and isolate deletion to the selected model directory

## Why

The previous Settings hierarchy overemphasized an informational Status screen, and model setup required a separate Prepare Model action after selection. This streamlines model selection into one action, makes local model state understandable, and gives users explicit control over storage used by downloaded transcription models.

## Safety and behavior

- model removal is disabled during recording, transcription, or model preparation
- deleting an active model unloads its runtime before removing files
- each model has an isolated storage directory, so removing one cannot delete sibling models
- a removed active model remains selected but unavailable until the user selects it again to download it

## Validation

- 156 unit and integration tests passed
- 12 UI tests passed
- `git diff --check` passed
- signed physical-device build installed successfully on picophone with existing app data preserved

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli-ios/pr/22"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786521268&installation_id=136549638&pr_number=22&repository=Muesli-HQ%2Fmuesli-ios&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli-ios%2Fpull%2F22&signature=88a92abcd7e688420a0ced6016ee698498c0ab84684812c77ec45ad231a570d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Whisper transcription models with local execution, including new model family grouping and download/ready status.
  * Expanded Settings with an **About** section showing app details, source code, and open-source library listings.
* **Bug Fixes**
  * Improved stability during model switching/removal by blocking conflicting actions and ignoring stale download/progress updates.
  * Updated model preparation UI to show retry actions only when applicable, and refreshed runtime labeling.
* **Tests**
  * Added/expanded coverage for settings navigation, About content, model catalog/download behavior, and model removal UI flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->