### PR TITLE
Stabilize keyboard transitions and align privacy manifest

### DIFF
--- a/Muesli/DictationCoordinator.swift
+++ b/Muesli/DictationCoordinator.swift
@@ -156,6 +156,7 @@ final class DictationCoordinator {
     private var modelPrewarmTask: Task<Void, Never>?
     private var meteringTask: Task<Void, Never>?
     private var recordingTimerTask: Task<Void, Never>?
+    @ObservationIgnored private var recordingTimerStartedAt: Date?
     @ObservationIgnored nonisolated(unsafe) private var sharedEventObservationTask: Task<Void, Never>?
     @ObservationIgnored nonisolated(unsafe) private var longVoiceNoteRecoveryTask: Task<Void, Never>?
     private var keyboardCommandProcessingInProgress = false
@@ -282,13 +283,23 @@ final class DictationCoordinator {
     var onboardingTestTranscript = ""
     var onboardingTestError: String?
     var isRecording = false
-    var inputLevel = 0.0
-    var recordingElapsedTime: TimeInterval = 0
+    let voiceNoteLiveState = VoiceNoteLiveState()
+    var inputLevel: Double {
+        get { voiceNoteLiveState.inputLevel }
+        set { voiceNoteLiveState.setInputLevel(newValue) }
+    }
+    var recordingElapsedTime: TimeInterval {
+        get { TimeInterval(voiceNoteLiveState.elapsedSeconds) }
+        set { voiceNoteLiveState.setElapsedTime(newValue) }
+    }
     var statusText = "Ready"
     var audioInputRouteText = AudioInputRouteManager.currentSnapshot().displayText
     var meetingStatusText = "Ready"
     var lastTranscript = ""
-    var liveDictationTranscript = ""
+    var liveDictationTranscript: String {
+        get { voiceNoteLiveState.transcript }
+        set { voiceNoteLiveState.setTranscript(newValue) }
+    }
     var dictationHistory: [DictationResult] = []
     var recordingSessions: [RecordingSession] = []
     private var transcriptCache: [UUID: Transcript] = [:]
@@ -1021,7 +1032,7 @@ final class DictationCoordinator {
         else { return }
 
         if let threshold = session.longFormThresholdSeconds,
-           recordingElapsedTime >= Double(threshold),
+           currentRecordingElapsedTime() >= Double(threshold),
            let promotedSession = promoteActiveVoiceNoteToLongForm(sessionID: session.id) {
             session = promotedSession
         }
@@ -1158,7 +1169,7 @@ final class DictationCoordinator {
         checkpointCount: Int? = nil
     ) -> [String: String] {
         guard let session else { return [:] }
-        let duration = max(0, session.duration ?? recordingElapsedTime)
+        let duration = max(0, session.duration ?? currentRecordingElapsedTime())
         let durationBucket: String
         switch duration {
         case ..<60: durationBucket = "under_60"
@@ -3831,7 +3842,7 @@ final class DictationCoordinator {
         if let thresholdSession = session,
            !thresholdSession.isLongForm,
            let threshold = thresholdSession.longFormThresholdSeconds,
-           recordingElapsedTime >= Double(threshold),
+           currentRecordingElapsedTime() >= Double(threshold),
            let promotedSession = promoteActiveVoiceNoteToLongForm(sessionID: thresholdSession.id) {
             session = promotedSession
         }
@@ -5294,33 +5305,53 @@ final class DictationCoordinator {
     }
 
     private func startMetering(update: @escaping @MainActor (Double) -> Void) {
+        beginMetering(
+            readPower: { [weak self] in
+                guard let self else { return -160 }
+                if self.keyboardSessionKeeper.isRecordingSegment {
+                    return Double(self.keyboardSessionKeeper.currentPower())
+                }
+                return Double(self.realtimeDictationRecorder?.currentPower() ?? self.recorder.currentPower())
+            },
+            update: update
+        )
+    }
+
+    private func beginMetering(
+        readPower: @escaping @MainActor () -> Double,
+        update: @escaping @MainActor (Double) -> Void
+    ) {
         meteringTask?.cancel()
         meteringTask = Task { @MainActor [weak self] in
             var smoothedLevel = 0.0
 
             while !Task.isCancelled {
-                guard let self else { return }
-                let power = if self.keyboardSessionKeeper.isRecordingSegment {
-                    Double(self.keyboardSessionKeeper.currentPower())
-                } else {
-                    Double(self.realtimeDictationRecorder?.currentPower() ?? self.recorder.currentPower())
-                }
-                let normalized = min(max((power + 50) / 50, 0), 1)
-                smoothedLevel = (0.35 * normalized) + (0.65 * smoothedLevel)
+                // The callbacks intentionally capture the coordinator weakly.
+                // End this unstructured loop when its owner disappears instead
+                // of leaving a 20 Hz orphan task alive for the process lifetime.
+                guard self != nil else { return }
+                let normalized = min(max((readPower() + 50) / 50, 0), 1)
+                // 0.48 at 20 Hz preserves approximately the same response time
+                // as the previous 0.35 smoothing factor at 30 Hz.
+                smoothedLevel = (0.48 * normalized) + (0.52 * smoothedLevel)
                 update(smoothedLevel)
-                try? await Task.sleep(for: .milliseconds(33))
+                try? await Task.sleep(for: .milliseconds(50))
             }
         }
     }
 
     private func startRecordingTimer(startedAt: Date) {
         recordingTimerTask?.cancel()
-        recordingElapsedTime = 0
+        recordingTimerStartedAt = startedAt
+        recordingElapsedTime = currentRecordingElapsedTime()
         recordingTimerTask = Task { @MainActor [weak self] in
             while !Task.isCancelled {
                 guard let self else { return }
-                self.recordingElapsedTime = max(0, Date().timeIntervalSince(startedAt))
-                try? await Task.sleep(for: .milliseconds(250))
+                let elapsed = self.currentRecordingElapsedTime()
+                self.recordingElapsedTime = elapsed
+                let fractionalSecond = elapsed - elapsed.rounded(.down)
+                let delay = max(0.05, 1 - fractionalSecond)
+                try? await Task.sleep(for: .seconds(delay))
             }
         }
     }
@@ -5328,7 +5359,16 @@ final class DictationCoordinator {
     private func stopRecordingTimer() {
         recordingTimerTask?.cancel()
         recordingTimerTask = nil
+        recordingTimerStartedAt = nil
         recordingElapsedTime = 0
+    }
+
+    private func currentRecordingElapsedTime(now: Date = .now) -> TimeInterval {
+        VoiceNoteElapsedClock.exactElapsed(
+            startedAt: recordingTimerStartedAt,
+            now: now,
+            fallback: recordingElapsedTime
+        )
     }
 
     private func offlineTranscriptionTimeout(for audioURL: URL?) -> TimeInterval {
@@ -5482,19 +5522,14 @@ final class DictationCoordinator {
     }
 
     private func startMeetingMetering() {
-        meteringTask?.cancel()
-        meteringTask = Task { @MainActor [weak self] in
-            var smoothedLevel = 0.0
-
-            while !Task.isCancelled {
-                guard let self else { return }
-                let power = Double(self.meetingRecorder?.currentPower() ?? -160)
-                let normalized = min(max((power + 50) / 50, 0), 1)
-                smoothedLevel = (0.35 * normalized) + (0.65 * smoothedLevel)
-                self.inputLevel = smoothedLevel
-                try? await Task.sleep(for: .milliseconds(33))
+        beginMetering(
+            readPower: { [weak self] in
+                Double(self?.meetingRecorder?.currentPower() ?? -160)
+            },
+            update: { [weak self] level in
+                self?.inputLevel = level
             }
-        }
+        )
     }
 
     private func stopMetering() {

--- a/Muesli/DictationView.swift
+++ b/Muesli/DictationView.swift
@@ -18,8 +18,8 @@ struct DictationView: View {
     @State private var sourceFilter: DictationSourceFilter = .all
     @State private var isSyncSetupPromptPresented = false
     @State private var shouldShowKeyboardSetupRow = false
-    @State private var previewInputLevel = 0.0
     @State private var dashboardStats = DictationDashboardStats.empty
+    @State private var voiceNoteTimelineCache = VoiceNoteTimelineCache()
     @State private var navigationPath = NavigationPath()
 
     var body: some View {
@@ -30,8 +30,7 @@ struct DictationView: View {
                     homeStatsRow
                     keyboardSessionHomeControl
                     recorderPanel
-                    historyHeader
-                    historyRows
+                    voiceNoteHistorySection
                 }
                 .padding(.horizontal, MuesliTheme.spacing20)
                 .padding(.top, MuesliTheme.spacing24)
@@ -330,16 +329,11 @@ struct DictationView: View {
 
                     VStack(alignment: .trailing, spacing: MuesliTheme.spacing8) {
                         if coordinator.isRecording {
-                            Text(formatElapsedTime(coordinator.recordingElapsedTime))
-                                .font(MuesliTheme.captionMedium())
-                                .monospacedDigit()
-                                .foregroundStyle(statusColor)
-                                .padding(.horizontal, MuesliTheme.spacing8)
-                                .padding(.vertical, MuesliTheme.spacing4)
-                                .background(statusColor.opacity(0.13))
-                                .clipShape(Capsule())
-                                .accessibilityLabel("Recording elapsed time")
-                                .accessibilityValue(formatElapsedTime(coordinator.recordingElapsedTime))
+                            VoiceNoteElapsedBadge(
+                                liveState: coordinator.voiceNoteLiveState,
+                                color: statusColor,
+                                isActive: isActive
+                            )
                         }
 
                         microphoneMenu
@@ -349,12 +343,13 @@ struct DictationView: View {
 
                 if isWaveformActive {
                     VStack(spacing: MuesliTheme.spacing8) {
-                        MuesliInlineWaveformView(
+                        VoiceNoteWaveformLeaf(
+                            liveState: coordinator.voiceNoteLiveState,
                             mode: isListeningWaveformActive ? .level : .waiting,
                             color: statusColor,
-                            level: waveformLevel,
                             isActive: isActive,
-                            barCount: 32
+                            barCount: 32,
+                            usesPreviewSignal: isPreviewWaveformActive
                         )
                         .frame(maxWidth: .infinity)
                         .frame(height: 54)
@@ -369,24 +364,8 @@ struct DictationView: View {
                     .muesliGlassSurface(cornerRadius: MuesliTheme.cornerMedium, tint: statusColor)
                 }
 
-                if shouldShowRealtimeTranscript {
-                    VStack(alignment: .leading, spacing: MuesliTheme.spacing8) {
-                        HStack(spacing: MuesliTheme.spacing8) {
-                            Image(systemName: "text.bubble")
-                            Text("Live Transcript")
-                        }
-                        .font(MuesliTheme.captionMedium())
-                        .foregroundStyle(MuesliTheme.accent)
-
-                        Text(coordinator.liveDictationTranscript)
-                            .font(MuesliTheme.body())
-                            .foregroundStyle(MuesliTheme.textPrimary)
-                            .lineLimit(nil)
-                            .fixedSize(horizontal: false, vertical: true)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                    }
-                    .padding(MuesliTheme.spacing12)
-                    .muesliGlassSurface(cornerRadius: MuesliTheme.cornerMedium, tint: MuesliTheme.accent)
+                if shouldReserveRealtimeTranscript {
+                    VoiceNoteLiveTranscriptRegion(liveState: coordinator.voiceNoteLiveState)
                 }
 
                 VStack(spacing: MuesliTheme.spacing8) {
@@ -430,7 +409,7 @@ struct DictationView: View {
                         .accessibilityIdentifier("dictation.cancelButton")
                     }
                 }
-                .padding(.top, isWaveformActive || shouldShowRealtimeTranscript ? 0 : MuesliTheme.spacing4)
+                .padding(.top, isWaveformActive || shouldReserveRealtimeTranscript ? 0 : MuesliTheme.spacing4)
 
                 if longVoiceNoteModeEnabled && !coordinator.isRecording {
                     Button {
@@ -461,10 +440,6 @@ struct DictationView: View {
             .padding(MuesliTheme.spacing16)
         }
         .accessibilityIdentifier("dictation.recorderPanel")
-        .task(id: isActive) {
-            guard isActive else { return }
-            await runPreviewWaveformIfNeeded()
-        }
     }
 
     private var longModeThresholdLabel: String {
@@ -545,14 +520,26 @@ struct DictationView: View {
     }
 
     @ViewBuilder
-    private var historyHeader: some View {
+    private var voiceNoteHistorySection: some View {
+        let timeline = voiceNoteTimelineCache.items(
+            for: VoiceNoteTimelineInput(
+                history: displayHistory,
+                sessions: timelineSessions,
+                sourceFilter: sourceFilter
+            )
+        )
+        historyHeader(timeline: timeline)
+        historyRows(timeline: timeline)
+    }
+
+    private func historyHeader(timeline: [VoiceNoteTimelineItem]) -> some View {
         VStack(alignment: .leading, spacing: MuesliTheme.spacing12) {
             HStack(alignment: .center) {
                 VStack(alignment: .leading, spacing: MuesliTheme.spacing4) {
                     Text("Recent Voice Notes")
                         .font(MuesliTheme.title3())
                         .foregroundStyle(MuesliTheme.textPrimary)
-                    Text("\(voiceNoteTimeline.count) saved")
+                    Text("\(timeline.count) saved")
                         .font(MuesliTheme.caption())
                         .foregroundStyle(MuesliTheme.textTertiary)
                 }
@@ -573,20 +560,20 @@ struct DictationView: View {
                 }
             }
 
-            if !voiceNoteTimeline.isEmpty {
+            if !timeline.isEmpty {
                 DictationSourceFilterPicker(selection: $sourceFilter)
             }
         }
     }
 
     @ViewBuilder
-    private var historyRows: some View {
+    private func historyRows(timeline: [VoiceNoteTimelineItem]) -> some View {
         Group {
-            if voiceNoteTimeline.isEmpty {
+            if timeline.isEmpty {
                 emptyHistory
             } else {
                 LazyVStack(spacing: MuesliTheme.spacing12) {
-                    ForEach(voiceNoteTimeline) { item in
+                    ForEach(timeline) { item in
                         switch item {
                         case .recoverable(let session):
                             RecoverableVoiceNoteRow(session: session) {
@@ -618,33 +605,14 @@ struct DictationView: View {
         }
     }
 
-    private var filteredHistory: [DictationResult] {
-        displayHistory.filter { sourceFilter.includes($0.syncOrigin) }
-    }
-
-    private var filteredRecoverableVoiceNotes: [RecordingSession] {
-        coordinator.recoverableVoiceNoteSessions.filter { sourceFilter.includes($0.syncOrigin) }
-    }
-
-    private var voiceNoteTimeline: [VoiceNoteTimelineItem] {
+    private var timelineSessions: [RecordingSession] {
         var sessions = coordinator.recordingSessions
         #if DEBUG
         if shouldUseMockDictations {
             sessions = Self.mockRecordingSessions
         }
         #endif
-
-        let sessionsByID = Dictionary(
-            uniqueKeysWithValues: sessions.map { ($0.id, $0) }
-        )
-        let completed = filteredHistory.map { result in
-            VoiceNoteTimelineItem.completed(
-                result,
-                result.sessionID.flatMap { sessionsByID[$0] }
-            )
-        }
-        let recoverable = filteredRecoverableVoiceNotes.map(VoiceNoteTimelineItem.recoverable)
-        return VoiceNoteTimelineItem.mergeNewestFirst(completed, recoverable)
+        return sessions
     }
 
     private func openCompletedVoiceNote(
@@ -683,13 +651,6 @@ struct DictationView: View {
 
     private var isPreviewWaveformActive: Bool {
         Self.hasDebugSimulatorLaunchArgument("--muesli-preview-waveform")
-    }
-
-    private var waveformLevel: Double? {
-        if isPreviewWaveformActive {
-            return previewInputLevel
-        }
-        return coordinator.isRecording ? coordinator.inputLevel : nil
     }
 
     private var shouldHideKeyboardSetupRowForMockPreview: Bool {
@@ -750,10 +711,10 @@ struct DictationView: View {
         coordinator.statusText == "Transcribing"
     }
 
-    private var shouldShowRealtimeTranscript: Bool {
-        coordinator.selectedTranscriptionModel.supportsRealtimeStreaming
+    private var shouldReserveRealtimeTranscript: Bool {
+        isActive
+            && coordinator.selectedTranscriptionModel.supportsRealtimeStreaming
             && isWaveformActive
-            && !coordinator.liveDictationTranscript.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 
     private var isDictationButtonDisabled: Bool {
@@ -814,32 +775,6 @@ struct DictationView: View {
         let keyboardConfirmed = UserDefaults.standard.bool(forKey: OnboardingPreferenceKeys.keyboardEnabledConfirmed)
         let fullAccessConfirmed = UserDefaults.standard.bool(forKey: OnboardingPreferenceKeys.fullAccessConfirmed)
         shouldShowKeyboardSetupRow = extensionStatus?.hasOpenAccess != true && !(keyboardConfirmed && fullAccessConfirmed)
-    }
-
-    private func formatElapsedTime(_ time: TimeInterval) -> String {
-        guard time.isFinite, time > 0 else { return "0:00" }
-        let totalSeconds = Int(time.rounded(.down))
-        let minutes = totalSeconds / 60
-        let seconds = totalSeconds % 60
-        return String(format: "%d:%02d", minutes, seconds)
-    }
-
-    private func runPreviewWaveformIfNeeded() async {
-        guard isPreviewWaveformActive else { return }
-
-        var tick = 0.0
-        while !Task.isCancelled {
-            let phrase = (sin(tick * 0.82) + 1) * 0.28
-            let syllable = (sin(tick * 2.7) + 1) * 0.18
-            let transient = (sin(tick * 7.1) + 1) * 0.08
-            if sin(tick * 0.31) > 0.72 {
-                previewInputLevel = 0.02
-            } else {
-                previewInputLevel = min(0.95, max(0.02, 0.08 + phrase + syllable + transient))
-            }
-            tick += 0.18
-            try? await Task.sleep(for: .milliseconds(55))
-        }
     }
 
     private static func hasDebugSimulatorLaunchArgument(_ argument: String) -> Bool {
@@ -985,50 +920,6 @@ private struct DictationHomeStatTile: View {
         .shadow(color: .black.opacity(0.12), radius: 6, x: 0, y: 3)
         .accessibilityElement(children: .ignore)
         .accessibilityLabel("\(value) \(label)")
-    }
-}
-
-private enum VoiceNoteTimelineItem: Identifiable {
-    case completed(DictationResult, RecordingSession?)
-    case recoverable(RecordingSession)
-
-    var id: String {
-        switch self {
-        case .completed(let result, _): "result-\(result.id.uuidString)"
-        case .recoverable(let session): "session-\(session.id.uuidString)"
-        }
-    }
-
-    var createdAt: Date {
-        switch self {
-        case .completed(let result, _): result.createdAt
-        case .recoverable(let session): session.createdAt
-        }
-    }
-
-    static func mergeNewestFirst(
-        _ completed: [VoiceNoteTimelineItem],
-        _ recoverable: [VoiceNoteTimelineItem]
-    ) -> [VoiceNoteTimelineItem] {
-        var completedIndex = 0
-        var recoverableIndex = 0
-        var merged: [VoiceNoteTimelineItem] = []
-        merged.reserveCapacity(completed.count + recoverable.count)
-
-        while completedIndex < completed.count || recoverableIndex < recoverable.count {
-            if completedIndex == completed.count {
-                merged.append(recoverable[recoverableIndex])
-                recoverableIndex += 1
-            } else if recoverableIndex == recoverable.count
-                        || completed[completedIndex].createdAt >= recoverable[recoverableIndex].createdAt {
-                merged.append(completed[completedIndex])
-                completedIndex += 1
-            } else {
-                merged.append(recoverable[recoverableIndex])
-                recoverableIndex += 1
-            }
-        }
-        return merged
     }
 }
 
@@ -1322,47 +1213,6 @@ private struct RotatingSyncGlyph: View {
         rotationDegrees = 0
         withAnimation(.linear(duration: 0.9).repeatForever(autoreverses: false)) {
             rotationDegrees = 360
-        }
-    }
-}
-
-private enum DictationSourceFilter: String, CaseIterable, Identifiable {
-    case all
-    case thisIPhone
-    case fromMac
-
-    var id: String { rawValue }
-
-    var title: String {
-        switch self {
-        case .all:
-            "All"
-        case .thisIPhone:
-            "This iPhone"
-        case .fromMac:
-            "From Mac"
-        }
-    }
-
-    func includes(_ origin: SyncOrigin) -> Bool {
-        switch self {
-        case .all:
-            true
-        case .thisIPhone:
-            origin == .thisIPhone
-        case .fromMac:
-            origin == .fromMac
-        }
-    }
-
-    func statTint(default tint: Color) -> Color {
-        switch self {
-        case .all:
-            tint
-        case .thisIPhone:
-            MuesliTheme.accent
-        case .fromMac:
-            MuesliTheme.success
         }
     }
 }

--- a/Muesli/DictationView.swift
+++ b/Muesli/DictationView.swift
@@ -560,7 +560,7 @@ struct DictationView: View {
                 }
             }
 
-            if !timeline.isEmpty {
+            if sourceFilter != .all || !timeline.isEmpty {
                 DictationSourceFilterPicker(selection: $sourceFilter)
             }
         }

--- a/Muesli/LongVoiceNoteView.swift
+++ b/Muesli/LongVoiceNoteView.swift
@@ -111,11 +111,17 @@ struct LongVoiceNoteView: View {
                         .foregroundStyle(statusColor)
                 }
 
-                Text(elapsedTimeCopy)
+                if isActivelyRecording {
+                    LongVoiceNoteElapsedText(liveState: coordinator.voiceNoteLiveState)
+                } else {
+                    Text(VoiceNoteDurationFormatter.padded(
+                        max(Int((session?.duration ?? 0).rounded(.down)), 0)
+                    ))
                     .font(.system(.title3, design: .monospaced, weight: .medium))
                     .monospacedDigit()
                     .foregroundStyle(MuesliTheme.textSecondary)
                     .padding(.top, MuesliTheme.spacing4)
+                }
             }
 
             Spacer()
@@ -150,10 +156,10 @@ struct LongVoiceNoteView: View {
 
     private var activeWaveform: some View {
         VStack(spacing: MuesliTheme.spacing12) {
-            MuesliInlineWaveformView(
+            VoiceNoteWaveformLeaf(
+                liveState: coordinator.voiceNoteLiveState,
                 mode: .level,
                 color: MuesliTheme.accent,
-                level: coordinator.inputLevel,
                 isActive: true,
                 barCount: 44
             )
@@ -382,14 +388,6 @@ struct LongVoiceNoteView: View {
             return MuesliTheme.success
         }
         return MuesliTheme.accent
-    }
-
-    private var elapsedTimeCopy: String {
-        let duration = isActivelyRecording
-            ? coordinator.recordingElapsedTime
-            : session?.duration ?? 0
-        let totalSeconds = max(Int(duration.rounded(.down)), 0)
-        return String(format: "%02d:%02d", totalSeconds / 60, totalSeconds % 60)
     }
 
     private var fallbackSession: RecordingSession {

--- a/Muesli/MeetingsView.swift
+++ b/Muesli/MeetingsView.swift
@@ -110,7 +110,7 @@ struct MeetingsView: View {
                         canStopRecording: coordinator.canStopMeetingCapture(sessionID: session.id),
                         isRecoveryNeeded: coordinator.meetingNeedsRecovery(sessionID: session.id),
                         isProcessingCurrentMeeting: session.phase == .transcribing,
-                        inputLevel: coordinator.inputLevel,
+                        liveState: coordinator.voiceNoteLiveState,
                         statusText: coordinator.activeMeetingSessionID == session.id ? coordinator.effectiveMeetingStatusText : session.phase.title,
                         actionStatusText: coordinator.clipboardStatusText,
                         onTranscribe: { coordinator.transcribeSession(session) },
@@ -932,7 +932,7 @@ private struct MeetingSessionDetailView: View {
     let canStopRecording: Bool
     let isRecoveryNeeded: Bool
     let isProcessingCurrentMeeting: Bool
-    let inputLevel: Double
+    let liveState: VoiceNoteLiveState
     let statusText: String
     let actionStatusText: String?
     let onTranscribe: () -> Void
@@ -1182,10 +1182,10 @@ private struct MeetingSessionDetailView: View {
                     }
 
                     if !isRecoveryNeeded {
-                        MuesliInlineWaveformView(
+                        VoiceNoteWaveformLeaf(
+                            liveState: liveState,
                             mode: isActiveRecording ? .level : .waiting,
                             color: captureTint,
-                            level: isActiveRecording ? inputLevel : nil,
                             isActive: isActiveRecording || isProcessingCurrentMeeting,
                             barCount: 34
                         )

--- a/Muesli/PrivacyInfo.xcprivacy
+++ b/Muesli/PrivacyInfo.xcprivacy
@@ -16,6 +16,19 @@
 				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
 			</array>
 		</dict>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeOtherDiagnosticData</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+			</array>
+		</dict>
 	</array>
 	<key>NSPrivacyTracking</key>
 	<false/>

--- a/Muesli/RootView.swift
+++ b/Muesli/RootView.swift
@@ -139,7 +139,10 @@ struct RootView: View {
     private func sectionView(for section: AppSection, isActive: Bool) -> some View {
         switch section {
         case .dictations:
-            DictationView(coordinator: coordinator, isActive: isActive)
+            DictationView(
+                coordinator: coordinator,
+                isActive: isActive && coordinator.presentedLongVoiceNoteSessionID == nil
+            )
         case .meetings:
             MeetingsView(coordinator: coordinator, isActive: isActive)
         case .settings:
@@ -231,10 +234,11 @@ private struct KeyboardHandoffOverlay: View {
                 Spacer(minLength: MuesliTheme.spacing32)
 
                 VStack(spacing: MuesliTheme.spacing16) {
-                    MuesliInlineWaveformView(
+                    VoiceNoteWaveformLeaf(
+                        liveState: coordinator.voiceNoteLiveState,
                         mode: coordinator.isRecording ? .level : .waiting,
                         color: coordinator.isRecording ? MuesliTheme.recording : MuesliTheme.transcribing,
-                        level: coordinator.isRecording ? coordinator.inputLevel : nil,
+                        isActive: true,
                         barCount: 32
                     )
                     .frame(width: 220, height: 56)

--- a/Muesli/VoiceNoteLiveState.swift
+++ b/Muesli/VoiceNoteLiveState.swift
@@ -1,0 +1,59 @@
+import Foundation
+import Observation
+
+/// High-frequency presentation state for an active voice-note capture.
+///
+/// Keeping this state separate from `DictationCoordinator` prevents metering,
+/// timer, and streaming-transcript updates from invalidating unrelated screens.
+@MainActor
+@Observable
+final class VoiceNoteLiveState {
+    private(set) var inputLevel = 0.0
+    private(set) var elapsedSeconds = 0
+    private(set) var transcript = ""
+
+    func setInputLevel(_ value: Double) {
+        guard value.isFinite else {
+            inputLevel = 0
+            return
+        }
+        inputLevel = min(max(value, 0), 1)
+    }
+
+    func setElapsedTime(_ value: TimeInterval) {
+        elapsedSeconds = VoiceNoteElapsedClock.publishedSeconds(elapsed: value)
+    }
+
+    func setTranscript(_ value: String) {
+        transcript = value
+    }
+
+    func resetInputLevel() {
+        inputLevel = 0
+    }
+
+    func resetElapsedTime() {
+        elapsedSeconds = 0
+    }
+
+    func resetTranscript() {
+        transcript = ""
+    }
+}
+
+enum VoiceNoteElapsedClock {
+    static func exactElapsed(
+        startedAt: Date?,
+        now: Date = .now,
+        fallback: TimeInterval = 0
+    ) -> TimeInterval {
+        let elapsed = startedAt.map { now.timeIntervalSince($0) } ?? fallback
+        guard elapsed.isFinite else { return 0 }
+        return max(0, elapsed)
+    }
+
+    static func publishedSeconds(elapsed: TimeInterval) -> Int {
+        guard elapsed.isFinite else { return 0 }
+        return max(0, Int(elapsed.rounded(.down)))
+    }
+}

--- a/Muesli/VoiceNoteRecordingViews.swift
+++ b/Muesli/VoiceNoteRecordingViews.swift
@@ -1,0 +1,144 @@
+import SwiftUI
+
+struct VoiceNoteWaveformLeaf: View {
+    let liveState: VoiceNoteLiveState
+    let mode: MuesliFloatingWaveformMode
+    let color: Color
+    let isActive: Bool
+    var barCount = 32
+    var usesPreviewSignal = false
+
+    @State private var previewInputLevel = 0.0
+
+    var body: some View {
+        MuesliInlineWaveformView(
+            mode: mode,
+            color: color,
+            level: displayedLevel,
+            isActive: isActive,
+            barCount: barCount,
+            refreshDriver: .inputLevel
+        )
+        .task(id: previewTaskIsActive) {
+            guard previewTaskIsActive else { return }
+            await runPreviewWaveform()
+        }
+    }
+
+    private var displayedLevel: Double? {
+        guard isActive, mode == .level else { return nil }
+        return usesPreviewSignal ? previewInputLevel : liveState.inputLevel
+    }
+
+    private var previewTaskIsActive: Bool {
+        usesPreviewSignal && isActive
+    }
+
+    private func runPreviewWaveform() async {
+        var tick = 0.0
+        while !Task.isCancelled {
+            let phrase = (sin(tick * 0.82) + 1) * 0.28
+            let syllable = (sin(tick * 2.7) + 1) * 0.18
+            let transient = (sin(tick * 7.1) + 1) * 0.08
+            if sin(tick * 0.31) > 0.72 {
+                previewInputLevel = 0.02
+            } else {
+                previewInputLevel = min(0.95, max(0.02, 0.08 + phrase + syllable + transient))
+            }
+            tick += 0.18
+            try? await Task.sleep(for: .milliseconds(55))
+        }
+    }
+}
+
+struct VoiceNoteElapsedBadge: View {
+    let liveState: VoiceNoteLiveState
+    let color: Color
+    var isActive = true
+
+    @ViewBuilder
+    var body: some View {
+        if isActive {
+            let value = VoiceNoteDurationFormatter.standard(liveState.elapsedSeconds)
+            Text(value)
+                .font(MuesliTheme.captionMedium())
+                .monospacedDigit()
+                .foregroundStyle(color)
+                .padding(.horizontal, MuesliTheme.spacing8)
+                .padding(.vertical, MuesliTheme.spacing4)
+                .background(color.opacity(0.13))
+                .clipShape(Capsule())
+                .accessibilityLabel("Recording elapsed time")
+                .accessibilityValue(value)
+        }
+    }
+}
+
+struct LongVoiceNoteElapsedText: View {
+    let liveState: VoiceNoteLiveState
+
+    var body: some View {
+        Text(VoiceNoteDurationFormatter.padded(liveState.elapsedSeconds))
+            .font(.system(.title3, design: .monospaced, weight: .medium))
+            .monospacedDigit()
+            .foregroundStyle(MuesliTheme.textSecondary)
+            .padding(.top, MuesliTheme.spacing4)
+            .accessibilityLabel("Recording elapsed time")
+    }
+}
+
+struct VoiceNoteLiveTranscriptRegion: View {
+    let liveState: VoiceNoteLiveState
+
+    var body: some View {
+        let preview = VoiceNoteTranscriptPreview.text(from: liveState.transcript)
+        VStack(alignment: .leading, spacing: MuesliTheme.spacing8) {
+            HStack(spacing: MuesliTheme.spacing8) {
+                Image(systemName: "text.bubble")
+                Text("Live Transcript")
+            }
+            .font(MuesliTheme.captionMedium())
+            .foregroundStyle(MuesliTheme.accent)
+
+            Text(preview.isEmpty ? "Listening for speech…" : preview)
+                .font(MuesliTheme.body())
+                .foregroundStyle(preview.isEmpty ? MuesliTheme.textTertiary : MuesliTheme.textPrimary)
+                .lineLimit(4, reservesSpace: true)
+                .truncationMode(.head)
+                .frame(maxWidth: .infinity, alignment: .topLeading)
+                .contentTransition(.identity)
+        }
+        .padding(MuesliTheme.spacing12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .muesliGlassSurface(cornerRadius: MuesliTheme.cornerMedium, tint: MuesliTheme.accent)
+        .accessibilityElement(children: .combine)
+        .accessibilityValue(liveState.transcript)
+    }
+}
+
+enum VoiceNoteDurationFormatter {
+    static func standard(_ totalSeconds: Int) -> String {
+        let seconds = max(0, totalSeconds)
+        return String(format: "%d:%02d", seconds / 60, seconds % 60)
+    }
+
+    static func padded(_ totalSeconds: Int) -> String {
+        let seconds = max(0, totalSeconds)
+        return String(format: "%02d:%02d", seconds / 60, seconds % 60)
+    }
+}
+
+enum VoiceNoteTranscriptPreview {
+    static let maximumCharacters = 600
+
+    static func text(from transcript: String) -> String {
+        let trimmed = transcript.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.count > maximumCharacters else { return trimmed }
+
+        let start = trimmed.index(trimmed.endIndex, offsetBy: -maximumCharacters)
+        let suffix = trimmed[start...]
+        let wordBoundary = suffix.firstIndex(where: { $0.isWhitespace })
+        let bounded = wordBoundary.map { suffix[suffix.index(after: $0)...] } ?? suffix[...]
+        return "…" + bounded.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}

--- a/Muesli/VoiceNoteRecordingViews.swift
+++ b/Muesli/VoiceNoteRecordingViews.swift
@@ -78,12 +78,14 @@ struct LongVoiceNoteElapsedText: View {
     let liveState: VoiceNoteLiveState
 
     var body: some View {
-        Text(VoiceNoteDurationFormatter.padded(liveState.elapsedSeconds))
+        let value = VoiceNoteDurationFormatter.padded(liveState.elapsedSeconds)
+        Text(value)
             .font(.system(.title3, design: .monospaced, weight: .medium))
             .monospacedDigit()
             .foregroundStyle(MuesliTheme.textSecondary)
             .padding(.top, MuesliTheme.spacing4)
             .accessibilityLabel("Recording elapsed time")
+            .accessibilityValue(value)
     }
 }
 

--- a/Muesli/VoiceNoteTimeline.swift
+++ b/Muesli/VoiceNoteTimeline.swift
@@ -1,0 +1,135 @@
+import Foundation
+import SwiftUI
+
+enum DictationSourceFilter: String, CaseIterable, Identifiable, Equatable {
+    case all
+    case thisIPhone
+    case fromMac
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .all:
+            "All"
+        case .thisIPhone:
+            "This iPhone"
+        case .fromMac:
+            "From Mac"
+        }
+    }
+
+    func includes(_ origin: SyncOrigin) -> Bool {
+        switch self {
+        case .all:
+            true
+        case .thisIPhone:
+            origin == .thisIPhone
+        case .fromMac:
+            origin == .fromMac
+        }
+    }
+
+    func statTint(default tint: Color) -> Color {
+        switch self {
+        case .all:
+            tint
+        case .thisIPhone:
+            MuesliTheme.accent
+        case .fromMac:
+            MuesliTheme.success
+        }
+    }
+}
+
+enum VoiceNoteTimelineItem: Identifiable, Equatable {
+    case completed(DictationResult, RecordingSession?)
+    case recoverable(RecordingSession)
+
+    var id: String {
+        switch self {
+        case .completed(let result, _): "result-\(result.id.uuidString)"
+        case .recoverable(let session): "session-\(session.id.uuidString)"
+        }
+    }
+
+    var createdAt: Date {
+        switch self {
+        case .completed(let result, _): result.createdAt
+        case .recoverable(let session): session.createdAt
+        }
+    }
+}
+
+struct VoiceNoteTimelineInput: Equatable {
+    let history: [DictationResult]
+    let sessions: [RecordingSession]
+    let sourceFilter: DictationSourceFilter
+}
+
+enum VoiceNoteTimelineBuilder {
+    static func build(from input: VoiceNoteTimelineInput) -> [VoiceNoteTimelineItem] {
+        let sessionsByID = Dictionary(
+            uniqueKeysWithValues: input.sessions.map { ($0.id, $0) }
+        )
+        let completed = input.history.compactMap { result -> VoiceNoteTimelineItem? in
+            guard input.sourceFilter.includes(result.syncOrigin) else { return nil }
+            return .completed(
+                result,
+                result.sessionID.flatMap { sessionsByID[$0] }
+            )
+        }
+        let recoverable = input.sessions.compactMap { session -> VoiceNoteTimelineItem? in
+            guard input.sourceFilter.includes(session.syncOrigin),
+                  session.kind != .meeting,
+                  session.isLongForm,
+                  [.recording, .transcriptionQueued, .transcribing, .failed].contains(session.phase)
+            else { return nil }
+            return .recoverable(session)
+        }
+        return mergeNewestFirst(completed, recoverable)
+    }
+
+    private static func mergeNewestFirst(
+        _ completed: [VoiceNoteTimelineItem],
+        _ recoverable: [VoiceNoteTimelineItem]
+    ) -> [VoiceNoteTimelineItem] {
+        var completedIndex = 0
+        var recoverableIndex = 0
+        var merged: [VoiceNoteTimelineItem] = []
+        merged.reserveCapacity(completed.count + recoverable.count)
+
+        while completedIndex < completed.count || recoverableIndex < recoverable.count {
+            if completedIndex == completed.count {
+                merged.append(recoverable[recoverableIndex])
+                recoverableIndex += 1
+            } else if recoverableIndex == recoverable.count
+                        || completed[completedIndex].createdAt >= recoverable[recoverableIndex].createdAt {
+                merged.append(completed[completedIndex])
+                completedIndex += 1
+            } else {
+                merged.append(recoverable[recoverableIndex])
+                recoverableIndex += 1
+            }
+        }
+        return merged
+    }
+}
+
+/// A view-owned memoizer. Array values are copy-on-write, so retaining the last
+/// exact input is cheap and avoids rebuilding a large timeline for unrelated UI
+/// changes such as sync or clipboard status updates.
+@MainActor
+final class VoiceNoteTimelineCache {
+    private var cachedInput: VoiceNoteTimelineInput?
+    private var cachedItems: [VoiceNoteTimelineItem] = []
+    private(set) var rebuildCount = 0
+
+    func items(for input: VoiceNoteTimelineInput) -> [VoiceNoteTimelineItem] {
+        guard cachedInput != input else { return cachedItems }
+        cachedInput = input
+        cachedItems = VoiceNoteTimelineBuilder.build(from: input)
+        rebuildCount += 1
+        return cachedItems
+    }
+}

--- a/MuesliKeyboard/Info.plist
+++ b/MuesliKeyboard/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
-	<string>Muesli Keyboard</string>
+	<string>Muesli</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>

--- a/MuesliKeyboard/KeyboardController.swift
+++ b/MuesliKeyboard/KeyboardController.swift
@@ -32,6 +32,7 @@ final class KeyboardController {
     var keyboardDismisser: (@MainActor () -> Void)?
     var liveTranscript = ""
     var inputLevel = 0.0
+    var isLaunchSettled = false
     private var lastInsertedCharacterCount = 0
     private var canUseRuntimeStart = false
 
@@ -377,6 +378,11 @@ final class KeyboardController {
     private func hasPendingCancelCommand() -> Bool {
         guard let command = try? store.pendingCommand(), command.action == .cancel else { return false }
         return cancelledRequestIDs.contains(command.requestID)
+    }
+
+    func prepareInitialPresentationState() {
+        refreshLatestDictation()
+        prepareLaunchRequestIfNeeded()
     }
 
     func startObservingSharedState() {

--- a/MuesliKeyboard/KeyboardRootView.swift
+++ b/MuesliKeyboard/KeyboardRootView.swift
@@ -167,7 +167,8 @@ struct KeyboardRootView: View {
                     level: controller.waveformLevel,
                     barCount: Self.activeWaveformBarCount,
                     spacing: 2.2,
-                    framesPerSecond: 18
+                    framesPerSecond: 18,
+                    refreshDriver: .timeline
                 )
                 .frame(height: 24)
                 .shadow(color: activeStatusColor.opacity(0.28), radius: 8)

--- a/MuesliKeyboard/KeyboardRootView.swift
+++ b/MuesliKeyboard/KeyboardRootView.swift
@@ -1,6 +1,8 @@
 import SwiftUI
 
 struct KeyboardRootView: View {
+    static let preferredHeight: CGFloat = 245
+
     private static let recorderBodyHeight: CGFloat = 84
     private static let activeStatusWidth: CGFloat = 84
     private static let activeControlButtonWidth: CGFloat = 120
@@ -16,6 +18,13 @@ struct KeyboardRootView: View {
         .padding(.horizontal, MuesliTheme.spacing8)
         .padding(.top, 4)
         .padding(.bottom, 5)
+        .frame(maxWidth: .infinity)
+        .frame(height: Self.preferredHeight, alignment: .bottom)
+        .transaction { transaction in
+            if !controller.isLaunchSettled {
+                transaction.animation = nil
+            }
+        }
         .background(
             LinearGradient(
                 colors: [
@@ -26,9 +35,10 @@ struct KeyboardRootView: View {
                 endPoint: .bottom
             )
         )
-        .onAppear {
-            controller.prepareLaunchRequestIfNeeded()
-        }
+        // iOS temporarily hosts third-party keyboards at full-screen and at
+        // an intermediate height. Keep those extra host regions transparent;
+        // only the final keyboard envelope should paint Muesli's surface.
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottom)
     }
 
     private var keyboardDeck: some View {

--- a/MuesliKeyboard/KeyboardViewController.swift
+++ b/MuesliKeyboard/KeyboardViewController.swift
@@ -4,9 +4,37 @@ import UIKit
 final class KeyboardViewController: UIInputViewController {
     private let controller = KeyboardController()
     private var hostingController: UIHostingController<KeyboardRootView>?
+    private let launchSnapshotView = UIImageView()
+    private var keyboardHeightConstraint: NSLayoutConstraint?
+    private var hasEnteredAppearance = false
+    private var isKeyboardPresented = false
+    private var hasActivatedKeyboardRuntime = false
+    private var stableGeometryFrameCount = 0
+    private var launchSnapshotWidth: CGFloat = 0
+    private var launchGeometryDisplayLink: CADisplayLink?
+    private var launchFallbackWorkItem: DispatchWorkItem?
 
     override func viewDidLoad() {
         super.viewDidLoad()
+
+        // Keep UIKit's system-created input view, but declare the keyboard's
+        // settled height before its first presentation. The host temporarily
+        // supplies full-screen and intermediate required heights on iOS 26;
+        // this 999-priority request declares the final envelope without
+        // fighting those required constraints. The launch snapshot masks the
+        // transient negotiation until both model and presentation settle.
+        inputView?.allowsSelfSizing = false
+        inputView?.backgroundColor = .clear
+        inputView?.isOpaque = false
+        view.backgroundColor = .clear
+        view.isOpaque = false
+        if let inputView {
+            let heightConstraint = inputView.heightAnchor.constraint(
+                equalToConstant: KeyboardRootView.preferredHeight
+            )
+            heightConstraint.priority = UILayoutPriority(999)
+            keyboardHeightConstraint = heightConstraint
+        }
 
         controller.textInserter = { [weak self] text in
             self?.textDocumentProxy.insertText(text)
@@ -23,8 +51,14 @@ final class KeyboardViewController: UIInputViewController {
         controller.keyboardDismisser = { [weak self] in
             self?.dismissKeyboard()
         }
-        let rootView = KeyboardRootView(controller: controller)
-        let hostingController = UIHostingController(rootView: rootView)
+        controller.prepareInitialPresentationState()
+
+        let hostingController = UIHostingController(
+            rootView: KeyboardRootView(controller: controller)
+        )
+        hostingController.sizingOptions = []
+        hostingController.view.backgroundColor = .clear
+        hostingController.view.isOpaque = false
         self.hostingController = hostingController
 
         addChild(hostingController)
@@ -34,25 +68,181 @@ final class KeyboardViewController: UIInputViewController {
             hostingController.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             hostingController.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             hostingController.view.topAnchor.constraint(equalTo: view.topAnchor),
-            hostingController.view.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-            view.heightAnchor.constraint(greaterThanOrEqualToConstant: 246)
+            hostingController.view.bottomAnchor.constraint(equalTo: view.bottomAnchor)
         ])
         hostingController.didMove(toParent: self)
-    }
 
-    override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
-        controller.markKeyboardVisible()
-        controller.startObservingSharedState()
+        launchSnapshotView.translatesAutoresizingMaskIntoConstraints = false
+        launchSnapshotView.backgroundColor = .clear
+        launchSnapshotView.contentMode = .scaleToFill
+        launchSnapshotView.clipsToBounds = true
+        launchSnapshotView.isUserInteractionEnabled = false
+        launchSnapshotView.accessibilityElementsHidden = true
+        view.addSubview(launchSnapshotView)
+        NSLayoutConstraint.activate([
+            launchSnapshotView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            launchSnapshotView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            launchSnapshotView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            launchSnapshotView.heightAnchor.constraint(equalToConstant: KeyboardRootView.preferredHeight)
+        ])
+        refreshLaunchSnapshot()
     }
 
     override func viewWillAppear(_ animated: Bool) {
+        controller.isLaunchSettled = false
+        controller.prepareInitialPresentationState()
+        refreshLaunchSnapshot()
+        launchSnapshotView.isHidden = false
+
         super.viewWillAppear(animated)
-        controller.startObservingSharedState()
+
+        isKeyboardPresented = true
+        hasEnteredAppearance = true
+        hasActivatedKeyboardRuntime = false
+        stableGeometryFrameCount = 0
+        view.setNeedsUpdateConstraints()
+        inputView?.setNeedsUpdateConstraints()
+        startLaunchGeometryGate()
+    }
+
+    override func updateViewConstraints() {
+        super.updateViewConstraints()
+
+        guard hasEnteredAppearance, let keyboardHeightConstraint else { return }
+        keyboardHeightConstraint.constant = KeyboardRootView.preferredHeight
+        if !keyboardHeightConstraint.isActive {
+            keyboardHeightConstraint.isActive = true
+        }
+    }
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+
+        let laidOutWidth = view.bounds.width
+        guard isKeyboardPresented,
+              !hasActivatedKeyboardRuntime,
+              !launchSnapshotView.isHidden,
+              laidOutWidth > 0,
+              abs(laidOutWidth - launchSnapshotWidth) > 1 else { return }
+        refreshLaunchSnapshot()
     }
 
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
+
+        isKeyboardPresented = false
+        hasEnteredAppearance = false
+        stopLaunchGeometryGate()
+        controller.isLaunchSettled = false
+        launchSnapshotView.isHidden = false
+
         controller.stopObservingSharedState()
+    }
+}
+
+private extension KeyboardViewController {
+    static let settledHeightTolerance: CGFloat = 1
+    static let requiredStableGeometryFrames = 2
+
+    func startLaunchGeometryGate() {
+        stopLaunchGeometryGate()
+
+        let displayLink = CADisplayLink(target: self, selector: #selector(evaluateLaunchGeometry))
+        displayLink.preferredFrameRateRange = CAFrameRateRange(minimum: 60, maximum: 120, preferred: 120)
+        displayLink.add(to: .main, forMode: .common)
+        launchGeometryDisplayLink = displayLink
+
+        let fallback = DispatchWorkItem { [weak self] in
+            self?.activateKeyboardRuntimeIfNeeded()
+        }
+        launchFallbackWorkItem = fallback
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.75, execute: fallback)
+    }
+
+    func stopLaunchGeometryGate() {
+        launchGeometryDisplayLink?.invalidate()
+        launchGeometryDisplayLink = nil
+        launchFallbackWorkItem?.cancel()
+        launchFallbackWorkItem = nil
+        stableGeometryFrameCount = 0
+    }
+
+    @objc
+    func evaluateLaunchGeometry() {
+        let targetHeight = KeyboardRootView.preferredHeight
+        let modelHeight = inputView?.bounds.height ?? view.bounds.height
+        let presentationHeight = inputView?.layer.presentation()?.bounds.height
+            ?? view.layer.presentation()?.bounds.height
+            ?? modelHeight
+        let modelIsSettled = abs(modelHeight - targetHeight) <= Self.settledHeightTolerance
+        let presentationIsSettled = abs(presentationHeight - targetHeight) <= Self.settledHeightTolerance
+
+        if modelIsSettled && presentationIsSettled {
+            stableGeometryFrameCount += 1
+        } else {
+            stableGeometryFrameCount = 0
+        }
+
+        guard stableGeometryFrameCount >= Self.requiredStableGeometryFrames else { return }
+        activateKeyboardRuntimeIfNeeded()
+    }
+
+    func activateKeyboardRuntimeIfNeeded() {
+        guard isKeyboardPresented, !hasActivatedKeyboardRuntime else { return }
+        hasActivatedKeyboardRuntime = true
+        stopLaunchGeometryGate()
+        revealLiveKeyboardSurface()
+
+        // Start App Group reads and observable updates on the next run-loop
+        // turn, after the settled geometry has already been presented. Keep
+        // launch animations disabled while the observer performs its first
+        // reconciliation so presentation state cannot visibly cross-fade.
+        DispatchQueue.main.async { [weak self] in
+            guard let self, self.isKeyboardPresented, self.hasActivatedKeyboardRuntime else { return }
+            self.controller.startObservingSharedState()
+
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
+                guard let self, self.isKeyboardPresented, self.hasActivatedKeyboardRuntime else { return }
+                self.controller.isLaunchSettled = true
+            }
+        }
+    }
+
+    func refreshLaunchSnapshot() {
+        let width = view.bounds.width
+        guard width > 0 else { return }
+        launchSnapshotWidth = width
+
+        let snapshotHost = UIHostingController(
+            rootView: KeyboardRootView(controller: controller)
+        )
+        snapshotHost.sizingOptions = []
+        snapshotHost.view.backgroundColor = .clear
+        snapshotHost.view.isOpaque = false
+        snapshotHost.view.frame = CGRect(
+            x: 0,
+            y: 0,
+            width: width,
+            height: KeyboardRootView.preferredHeight
+        )
+        snapshotHost.view.setNeedsLayout()
+        snapshotHost.view.layoutIfNeeded()
+
+        let format = UIGraphicsImageRendererFormat()
+        format.opaque = false
+        format.scale = max(view.traitCollection.displayScale, 1)
+        let renderer = UIGraphicsImageRenderer(
+            size: snapshotHost.view.bounds.size,
+            format: format
+        )
+        launchSnapshotView.image = renderer.image { context in
+            snapshotHost.view.layer.render(in: context.cgContext)
+        }
+    }
+
+    func revealLiveKeyboardSurface() {
+        UIView.performWithoutAnimation {
+            launchSnapshotView.isHidden = true
+        }
     }
 }

--- a/MuesliKeyboard/KeyboardViewController.swift
+++ b/MuesliKeyboard/KeyboardViewController.swift
@@ -9,6 +9,7 @@ final class KeyboardViewController: UIInputViewController {
     private var hasEnteredAppearance = false
     private var isKeyboardPresented = false
     private var hasActivatedKeyboardRuntime = false
+    private var appearanceGuard = MuesliKeyboardAppearanceGuard()
     private var stableGeometryFrameCount = 0
     private var launchSnapshotWidth: CGFloat = 0
     private var launchGeometryDisplayLink: CADisplayLink?
@@ -89,6 +90,7 @@ final class KeyboardViewController: UIInputViewController {
     }
 
     override func viewWillAppear(_ animated: Bool) {
+        appearanceGuard.beginAppearance()
         controller.isLaunchSettled = false
         controller.prepareInitialPresentationState()
         refreshLaunchSnapshot()
@@ -128,6 +130,7 @@ final class KeyboardViewController: UIInputViewController {
     }
 
     override func viewWillDisappear(_ animated: Bool) {
+        appearanceGuard.endAppearance()
         super.viewWillDisappear(animated)
 
         isKeyboardPresented = false
@@ -189,6 +192,7 @@ private extension KeyboardViewController {
 
     func activateKeyboardRuntimeIfNeeded() {
         guard isKeyboardPresented, !hasActivatedKeyboardRuntime else { return }
+        let generation = appearanceGuard.generation
         hasActivatedKeyboardRuntime = true
         stopLaunchGeometryGate()
         revealLiveKeyboardSurface()
@@ -198,11 +202,21 @@ private extension KeyboardViewController {
         // launch animations disabled while the observer performs its first
         // reconciliation so presentation state cannot visibly cross-fade.
         DispatchQueue.main.async { [weak self] in
-            guard let self, self.isKeyboardPresented, self.hasActivatedKeyboardRuntime else { return }
+            guard let self,
+                  self.appearanceGuard.acceptsDeferredWork(
+                    from: generation,
+                    isPresented: self.isKeyboardPresented,
+                    hasActivatedRuntime: self.hasActivatedKeyboardRuntime
+                  ) else { return }
             self.controller.startObservingSharedState()
 
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
-                guard let self, self.isKeyboardPresented, self.hasActivatedKeyboardRuntime else { return }
+                guard let self,
+                      self.appearanceGuard.acceptsDeferredWork(
+                        from: generation,
+                        isPresented: self.isKeyboardPresented,
+                        hasActivatedRuntime: self.hasActivatedKeyboardRuntime
+                      ) else { return }
                 self.controller.isLaunchSettled = true
             }
         }

--- a/Shared/MuesliKeyboardAppearanceGuard.swift
+++ b/Shared/MuesliKeyboardAppearanceGuard.swift
@@ -1,0 +1,26 @@
+/// Invalidates deferred presentation work when a keyboard appearance ends.
+struct MuesliKeyboardAppearanceGuard: Equatable {
+    typealias Generation = UInt
+
+    private(set) var generation: Generation = 0
+
+    @discardableResult
+    mutating func beginAppearance() -> Generation {
+        generation &+= 1
+        return generation
+    }
+
+    mutating func endAppearance() {
+        generation &+= 1
+    }
+
+    func acceptsDeferredWork(
+        from capturedGeneration: Generation,
+        isPresented: Bool,
+        hasActivatedRuntime: Bool
+    ) -> Bool {
+        capturedGeneration == generation
+            && isPresented
+            && hasActivatedRuntime
+    }
+}

--- a/Shared/MuesliWaveformView.swift
+++ b/Shared/MuesliWaveformView.swift
@@ -63,6 +63,18 @@ enum MuesliFloatingWaveformMode: Equatable {
     case waiting
 }
 
+enum MuesliInlineWaveformRefreshDriver: Equatable {
+    /// Redraw only when a new metered input level arrives.
+    case inputLevel
+    /// Animate independently of level publication, used by the keyboard where
+    /// cross-process meter values are intentionally throttled.
+    case timeline
+
+    func usesTimeline(for mode: MuesliFloatingWaveformMode) -> Bool {
+        mode == .waiting || self == .timeline
+    }
+}
+
 enum MuesliKeyboardWaveformPresentation {
     static func mode(for phase: DictationPhase) -> MuesliFloatingWaveformMode {
         phase == .recording ? .level : .waiting
@@ -104,9 +116,7 @@ struct MuesliInlineWaveformView: View {
     var barCount: Int = 24
     var spacing: CGFloat = 3
     var framesPerSecond: Double = 24
-
-    @State private var liveSamples: [CGFloat] = []
-    @State private var sampleSequence = 0
+    var refreshDriver: MuesliInlineWaveformRefreshDriver = .inputLevel
 
     private let basePattern: [CGFloat] = [
         0.18, 0.26, 0.42, 0.58, 0.76, 0.92,
@@ -117,28 +127,16 @@ struct MuesliInlineWaveformView: View {
 
     var body: some View {
         Group {
-            if isActive {
+            if isActive && refreshDriver.usesTimeline(for: mode) {
                 TimelineView(.animation(minimumInterval: 1.0 / max(framesPerSecond, 1.0))) { timeline in
                     let elapsed = timeline.date.timeIntervalSinceReferenceDate
                     waveformCanvas(elapsed: elapsed)
                 }
             } else {
-                waveformCanvas(elapsed: 0)
+                waveformCanvas(
+                    elapsed: isActive ? Date.now.timeIntervalSinceReferenceDate : 0
+                )
             }
-        }
-        .onAppear {
-            seedLiveSamplesIfNeeded()
-        }
-        .onChange(of: level ?? 0) { _, newValue in
-            guard isActive else { return }
-            appendLiveSample(newValue)
-        }
-        .onChange(of: mode) { _, _ in
-            seedLiveSamplesIfNeeded(force: true)
-        }
-        .onChange(of: isActive) { _, active in
-            guard active else { return }
-            seedLiveSamplesIfNeeded(force: true)
         }
     }
 
@@ -196,7 +194,7 @@ struct MuesliInlineWaveformView: View {
     }
 
     private func liveLevelSamples(count: Int, elapsed: TimeInterval) -> [CGFloat] {
-        var samples = paddedLiveSamples(count: count)
+        var samples = Array(repeating: CGFloat.zero, count: count)
         guard let level else { return samples }
 
         let normalized = CGFloat(min(max(level, 0), 1))
@@ -220,19 +218,6 @@ struct MuesliInlineWaveformView: View {
         return samples
     }
 
-    private func paddedLiveSamples(count: Int) -> [CGFloat] {
-        guard !liveSamples.isEmpty else {
-            return Array(repeating: 0, count: count)
-        }
-
-        let suffix = liveSamples.suffix(count)
-        if suffix.count == count {
-            return Array(suffix)
-        }
-
-        return Array(repeating: 0, count: count - suffix.count) + suffix
-    }
-
     private func waitingSamples(count: Int, elapsed: TimeInterval) -> [CGFloat] {
         (0..<count).map { index in
             let base = basePattern[index % basePattern.count]
@@ -244,29 +229,6 @@ struct MuesliInlineWaveformView: View {
     private func waitingOpacity(index: Int, elapsed: TimeInterval) -> Double {
         let phase = CGFloat(elapsed) * 5.8 + CGFloat(index) * 0.72
         return Double(0.48 + (sin(phase) + 1) * 0.16)
-    }
-
-    private func seedLiveSamplesIfNeeded(force: Bool = false) {
-        guard force || liveSamples.isEmpty else { return }
-
-        liveSamples = Array(repeating: 0, count: sampleCount)
-    }
-
-    private func appendLiveSample(_ rawLevel: Double) {
-        guard mode == .level else { return }
-
-        let normalized = CGFloat(min(max(rawLevel, 0), 1))
-        let gatedLevel = gatedLevel(for: normalized)
-        let shaped = pow(gatedLevel, 0.72)
-        let texture = CGFloat(0.90 + 0.16 * sin(Double(sampleSequence) * 1.73))
-        let sample = gatedLevel <= 0.02 ? 0 : min(0.98, max(0.01, shaped * 0.92 * texture))
-        let maxSamples = sampleCount * 3
-
-        sampleSequence += 1
-        liveSamples.append(sample)
-        if liveSamples.count > maxSamples {
-            liveSamples.removeFirst(liveSamples.count - maxSamples)
-        }
     }
 
     private func gatedLevel(for normalized: CGFloat) -> CGFloat {

--- a/Shared/MuesliWaveformView.swift
+++ b/Shared/MuesliWaveformView.swift
@@ -200,7 +200,7 @@ struct MuesliInlineWaveformView: View {
         let normalized = CGFloat(min(max(level, 0), 1))
         let gatedLevel = gatedLevel(for: normalized)
         guard gatedLevel > 0.02 else {
-            return samples.map { min($0, 0.02) }
+            return samples
         }
 
         let shaped = pow(gatedLevel, 0.72)

--- a/Tests/MuesliTests/KeyboardWaveformTests.swift
+++ b/Tests/MuesliTests/KeyboardWaveformTests.swift
@@ -34,4 +34,16 @@ final class KeyboardWaveformTests: XCTestCase {
         XCTAssertEqual(throttle.valueToPublish(-1, at: start), 0)
         XCTAssertEqual(throttle.valueToPublish(2, at: start.addingTimeInterval(0.17)), 1)
     }
+
+    func testInAppWaveformUsesInputAsItsOnlyLiveClock() {
+        XCTAssertFalse(
+            MuesliInlineWaveformRefreshDriver.inputLevel.usesTimeline(for: .level)
+        )
+        XCTAssertTrue(
+            MuesliInlineWaveformRefreshDriver.inputLevel.usesTimeline(for: .waiting)
+        )
+        XCTAssertTrue(
+            MuesliInlineWaveformRefreshDriver.timeline.usesTimeline(for: .level)
+        )
+    }
 }

--- a/Tests/MuesliTests/KeyboardWaveformTests.swift
+++ b/Tests/MuesliTests/KeyboardWaveformTests.swift
@@ -2,6 +2,47 @@ import XCTest
 @testable import Muesli
 
 final class KeyboardWaveformTests: XCTestCase {
+    func testStaleAppearanceCannotSettleANewerKeyboardPresentation() {
+        var appearanceGuard = MuesliKeyboardAppearanceGuard()
+        let firstAppearance = appearanceGuard.beginAppearance()
+
+        XCTAssertTrue(appearanceGuard.acceptsDeferredWork(
+            from: firstAppearance,
+            isPresented: true,
+            hasActivatedRuntime: true
+        ))
+
+        appearanceGuard.endAppearance()
+        let secondAppearance = appearanceGuard.beginAppearance()
+
+        XCTAssertFalse(appearanceGuard.acceptsDeferredWork(
+            from: firstAppearance,
+            isPresented: true,
+            hasActivatedRuntime: true
+        ))
+        XCTAssertTrue(appearanceGuard.acceptsDeferredWork(
+            from: secondAppearance,
+            isPresented: true,
+            hasActivatedRuntime: true
+        ))
+    }
+
+    func testCurrentAppearanceStillRequiresPresentationAndRuntimeActivation() {
+        var appearanceGuard = MuesliKeyboardAppearanceGuard()
+        let appearance = appearanceGuard.beginAppearance()
+
+        XCTAssertFalse(appearanceGuard.acceptsDeferredWork(
+            from: appearance,
+            isPresented: false,
+            hasActivatedRuntime: true
+        ))
+        XCTAssertFalse(appearanceGuard.acceptsDeferredWork(
+            from: appearance,
+            isPresented: true,
+            hasActivatedRuntime: false
+        ))
+    }
+
     func testKeyboardWaveformUsesMeteredLevelOnlyWhileRecording() {
         XCTAssertEqual(MuesliKeyboardWaveformPresentation.mode(for: .recording), .level)
         XCTAssertEqual(

--- a/Tests/MuesliTests/VoiceNotePresentationPerformanceTests.swift
+++ b/Tests/MuesliTests/VoiceNotePresentationPerformanceTests.swift
@@ -1,0 +1,151 @@
+import XCTest
+import Observation
+@testable import Muesli
+
+final class VoiceNotePresentationPerformanceTests: XCTestCase {
+    func testElapsedClockKeepsExactLifecycleTimeAndPublishesWholeSeconds() {
+        let start = Date(timeIntervalSinceReferenceDate: 1_000)
+
+        let beforeThreshold = VoiceNoteElapsedClock.exactElapsed(
+            startedAt: start,
+            now: start.addingTimeInterval(29.999)
+        )
+        XCTAssertEqual(VoiceNoteElapsedClock.publishedSeconds(elapsed: beforeThreshold), 29)
+
+        let atThreshold = VoiceNoteElapsedClock.exactElapsed(
+            startedAt: start,
+            now: start.addingTimeInterval(30)
+        )
+        XCTAssertEqual(atThreshold, 30, accuracy: 0.000_1)
+        XCTAssertEqual(VoiceNoteElapsedClock.publishedSeconds(elapsed: atThreshold), 30)
+
+        let afterThreshold = VoiceNoteElapsedClock.exactElapsed(
+            startedAt: start,
+            now: start.addingTimeInterval(30.1)
+        )
+        XCTAssertGreaterThan(afterThreshold, 30)
+        XCTAssertEqual(VoiceNoteElapsedClock.publishedSeconds(elapsed: afterThreshold), 30)
+    }
+
+    func testElapsedClockClampsInvalidAndNegativeValues() {
+        XCTAssertEqual(
+            VoiceNoteElapsedClock.exactElapsed(startedAt: nil, fallback: -.infinity),
+            0
+        )
+        XCTAssertEqual(VoiceNoteElapsedClock.publishedSeconds(elapsed: -.infinity), 0)
+        XCTAssertEqual(VoiceNoteElapsedClock.publishedSeconds(elapsed: -5), 0)
+    }
+
+    @MainActor
+    func testTimelineCacheRebuildsOnlyForExactInputChanges() {
+        let requestID = UUID()
+        let sessionID = UUID()
+        let result = Muesli.DictationResult(
+            requestID: requestID,
+            sessionID: sessionID,
+            text: "A local note",
+            createdAt: Date(timeIntervalSinceReferenceDate: 200),
+            engineIdentifier: "parakeet",
+            source: "ios"
+        )
+        let session = Muesli.RecordingSession(
+            id: sessionID,
+            requestID: requestID,
+            kind: .quickDictation,
+            createdAt: Date(timeIntervalSinceReferenceDate: 200),
+            phase: .completed,
+            source: "ios"
+        )
+        let input = VoiceNoteTimelineInput(
+            history: [result],
+            sessions: [session],
+            sourceFilter: .all
+        )
+        let cache = VoiceNoteTimelineCache()
+
+        XCTAssertEqual(cache.items(for: input).count, 1)
+        XCTAssertEqual(cache.rebuildCount, 1)
+        XCTAssertEqual(cache.items(for: input).count, 1)
+        XCTAssertEqual(cache.rebuildCount, 1)
+
+        let filteredInput = VoiceNoteTimelineInput(
+            history: [result],
+            sessions: [session],
+            sourceFilter: .fromMac
+        )
+        XCTAssertTrue(cache.items(for: filteredInput).isEmpty)
+        XCTAssertEqual(cache.rebuildCount, 2)
+    }
+
+    func testTimelineBuilderMergesRecoverableNotesByCreationDate() {
+        let completed = Muesli.DictationResult(
+            requestID: UUID(),
+            text: "Completed",
+            createdAt: Date(timeIntervalSinceReferenceDate: 100),
+            engineIdentifier: "parakeet",
+            source: "ios"
+        )
+        let recoverable = Muesli.RecordingSession(
+            kind: .quickDictation,
+            createdAt: Date(timeIntervalSinceReferenceDate: 200),
+            phase: .failed,
+            source: "ios",
+            isLongForm: true
+        )
+
+        let items = VoiceNoteTimelineBuilder.build(
+            from: VoiceNoteTimelineInput(
+                history: [completed],
+                sessions: [recoverable],
+                sourceFilter: .all
+            )
+        )
+
+        XCTAssertEqual(items.count, 2)
+        guard case .recoverable(let first) = items.first else {
+            return XCTFail("The newest recoverable session should lead the timeline")
+        }
+        XCTAssertEqual(first.id, recoverable.id)
+    }
+
+    func testTranscriptPreviewIsBoundedAndPreservesTheNewestText() {
+        let ending = "this is the newest live transcript phrase"
+        let transcript = String(repeating: "older words ", count: 100) + ending
+        let preview = VoiceNoteTranscriptPreview.text(from: transcript)
+
+        XCTAssertLessThanOrEqual(preview.count, VoiceNoteTranscriptPreview.maximumCharacters + 1)
+        XCTAssertTrue(preview.hasSuffix(ending))
+        XCTAssertTrue(preview.hasPrefix("…"))
+        XCTAssertEqual(VoiceNoteTranscriptPreview.text(from: "   \n"), "")
+    }
+
+    @MainActor
+    func testLiveStateMutationsDoNotInvalidateItsOwner() {
+        let owner = VoiceNoteObservationOwner()
+        let ownerInvalidation = expectation(description: "Parent observation remains stable")
+        ownerInvalidation.isInverted = true
+
+        withObservationTracking {
+            _ = owner.historyRevision
+            _ = owner.liveState
+        } onChange: {
+            ownerInvalidation.fulfill()
+        }
+
+        owner.liveState.setInputLevel(0.72)
+        owner.liveState.setElapsedTime(18.4)
+        owner.liveState.setTranscript("A partial transcript")
+
+        wait(for: [ownerInvalidation], timeout: 0.01)
+        XCTAssertEqual(owner.liveState.inputLevel, 0.72, accuracy: 0.000_1)
+        XCTAssertEqual(owner.liveState.elapsedSeconds, 18)
+        XCTAssertEqual(owner.liveState.transcript, "A partial transcript")
+    }
+}
+
+@MainActor
+@Observable
+private final class VoiceNoteObservationOwner {
+    let liveState = VoiceNoteLiveState()
+    var historyRevision = 0
+}


### PR DESCRIPTION
## Summary

- mask iOS keyboard height negotiation with a fixed-height launch snapshot, then reveal the live SwiftUI surface atomically after geometry settles
- preload the keyboard presentation state and suppress launch-time animations without changing the validated runtime behavior
- keep the extension at a stable height across repeated keyboard switches and avoid unused snapshot rasterization during iPad resizing
- rename the keyboard extension display name from `Muesli Keyboard — Muesli` to `Muesli`
- remove the temporary geometry tracing, exporter, and render-timing diagnostics used to isolate the transition bug
- align the embedded privacy manifest with App Store Connect by declaring Other Diagnostic Data for Analytics and App Functionality, unlinked and not used for tracking
- isolate live voice-note metering, timer, transcript, and timeline updates from the parent scroll hierarchy to remove recording-time scroll jitter
- invalidate stale keyboard appearance callbacks without changing the fixed-height snapshot/reveal path, and keep empty source filters recoverable with complete elapsed-time accessibility

## Validation

- [x] repeated physical-device keyboard switching on Picophone; transition flash confirmed fixed
- [x] signed Release build for generic iOS device
- [x] source privacy manifest passes `plutil -lint`
- [x] compiled Release app contains Product Interaction and Other Diagnostic Data with the expected purposes and flags
- [x] source and compiled Release bundle contain none of the removed tracing/export symbols
- [x] 173 unit/integration tests pass
- [x] stale keyboard appearance regression covers disappear/reappear generations
- [x] 12 UI tests pass
- [x] final independent diff review found no remaining actionable issues

## Release note

This resolves the binary-level privacy mismatch identified for build 0.1.2 (8) before the next GA submission.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli-ios/pr/24"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786859664&installation_id=136549638&pr_number=24&repository=Muesli-HQ%2Fmuesli-ios&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli-ios%2Fpull%2F24&signature=e87973ca8902bb22bd1def9014b860b9c983496203849743b6eaf959dafa3c4d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved keyboard startup to reduce flicker and transient visual artifacts, with smoother launch geometry handling.
  - Refreshed voice-note live UI timing/state so elapsed time, metering, and waveform updates stay consistent.
  - Updated waveform refresh behavior to improve responsiveness across different recording phases.
- **New Features**
  - Enhanced voice-note recording visuals, including improved elapsed-time badge and live transcript presentation.
- **Privacy**
  - Updated privacy disclosures to include unlinked, non-tracking diagnostic data used for analytics and app functionality.
- **Style**
  - Updated the keyboard’s displayed name to **“Muesli.”**
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
