### PR TITLE
Harden keyboard dictation across lock-screen suspension

### DIFF
--- a/Muesli/AudioInputRouteManager.swift
+++ b/Muesli/AudioInputRouteManager.swift
@@ -56,7 +56,12 @@ enum AudioInputRouteManager {
         do {
             try session.setCategory(
                 .playAndRecord,
-                mode: .spokenAudio,
+                // `.spokenAudio` is a playback-only mode. Pairing it with
+                // `.playAndRecord` causes AVAudioSession to fall back to its
+                // default behavior, which makes lock/route recovery depend on
+                // an implicit configuration. Use the supported recording mode
+                // explicitly so the active session survives background capture.
+                mode: .default,
                 options: recordingCategoryOptions
             )
             try session.setActive(true)
@@ -65,7 +70,7 @@ enum AudioInputRouteManager {
                 try? session.setActive(false, options: .notifyOthersOnDeactivation)
                 try session.setCategory(
                     .playAndRecord,
-                    mode: .spokenAudio,
+                    mode: .default,
                     options: recordingCategoryOptions
                 )
                 try session.setActive(true)

--- a/Muesli/AudioRecorder.swift
+++ b/Muesli/AudioRecorder.swift
@@ -38,6 +38,7 @@ final class AudioRecorder {
         let recorder: AVAudioRecorder
         do {
             recorder = try AVAudioRecorder(url: url, settings: settings)
+            try SharedFileProtection.protectAudio(at: url)
         } catch {
             throw RecordingError.recorderSetupFailed(stage: "create", underlying: error)
         }
@@ -55,6 +56,10 @@ final class AudioRecorder {
         guard let recorder, recorder.isRecording else { return -160 }
         recorder.updateMeters()
         return recorder.averagePower(forChannel: 0)
+    }
+
+    var isCapturingAudio: Bool {
+        recorder?.isRecording == true
     }
 
     @discardableResult

--- a/Muesli/CheckpointingAudioWriter.swift
+++ b/Muesli/CheckpointingAudioWriter.swift
@@ -43,27 +43,29 @@ final class CheckpointingAudioWriter: @unchecked Sendable {
         self.checkpointDirectory = checkpointDirectory
         self.format = format
         if let continuousAudioURL {
-            try FileManager.default.createDirectory(
-                at: continuousAudioURL.deletingLastPathComponent(),
-                withIntermediateDirectories: true
+            try SharedFileProtection.prepareMetadataDirectory(
+                at: continuousAudioURL.deletingLastPathComponent()
             )
         }
-        try FileManager.default.createDirectory(at: checkpointDirectory, withIntermediateDirectories: true)
+        try SharedFileProtection.prepareMetadataDirectory(at: checkpointDirectory)
         let checkpointURL = Self.checkpointURL(directory: checkpointDirectory, index: 0)
         state = State(
             continuousFile: try continuousAudioURL.map {
-                try AVAudioFile(forWriting: $0, settings: format.settings)
+                try Self.makeProtectedAudioFile(at: $0, format: format)
             },
             continuousURL: continuousAudioURL,
-            checkpointFile: try AVAudioFile(forWriting: checkpointURL, settings: format.settings),
+            checkpointFile: try Self.makeProtectedAudioFile(at: checkpointURL, format: format),
             checkpointURL: checkpointURL
         )
     }
 
-    func append(_ buffer: AVAudioPCMBuffer) {
+    func append(
+        _ buffer: AVAudioPCMBuffer,
+        onAccepted: (@Sendable () -> Void)? = nil
+    ) {
         guard let copy = Self.copyBuffer(buffer), copy.frameLength > 0 else { return }
         queue.async { [weak self] in
-            self?.write(copy)
+            self?.write(copy, onAccepted: onAccepted)
         }
     }
 
@@ -85,7 +87,7 @@ final class CheckpointingAudioWriter: @unchecked Sendable {
             let nextIndex = state.checkpointIndex + 1
             let nextURL = Self.checkpointURL(directory: checkpointDirectory, index: nextIndex)
             do {
-                state.checkpointFile = try AVAudioFile(forWriting: nextURL, settings: format.settings)
+                state.checkpointFile = try Self.makeProtectedAudioFile(at: nextURL, format: format)
                 state.checkpointURL = nextURL
                 state.checkpointIndex = nextIndex
                 state.checkpointStartFrame = state.totalFrames
@@ -147,7 +149,10 @@ final class CheckpointingAudioWriter: @unchecked Sendable {
         }
     }
 
-    private func write(_ buffer: AVAudioPCMBuffer) {
+    private func write(
+        _ buffer: AVAudioPCMBuffer,
+        onAccepted: (@Sendable () -> Void)?
+    ) {
         guard !state.isClosed else { return }
         let frameCount = AVAudioFramePosition(buffer.frameLength)
         guard frameCount > 0 else { return }
@@ -175,6 +180,7 @@ final class CheckpointingAudioWriter: @unchecked Sendable {
         }
         if wroteFrames {
             state.totalFrames += frameCount
+            onAccepted?()
         }
     }
 
@@ -189,6 +195,17 @@ final class CheckpointingAudioWriter: @unchecked Sendable {
         directory
             .appendingPathComponent("chunk-\(String(format: "%04d", index))")
             .appendingPathExtension("wav")
+    }
+
+    private static func makeProtectedAudioFile(at url: URL, format: AVAudioFormat) throws -> AVAudioFile {
+        do {
+            let file = try AVAudioFile(forWriting: url, settings: format.settings)
+            try SharedFileProtection.protectAudio(at: url)
+            return file
+        } catch {
+            try? FileManager.default.removeItem(at: url)
+            throw error
+        }
     }
 
     private static func copyBuffer(_ buffer: AVAudioPCMBuffer) -> AVAudioPCMBuffer? {

--- a/Muesli/DictationCoordinator.swift
+++ b/Muesli/DictationCoordinator.swift
@@ -98,6 +98,37 @@ private enum KeyboardSessionStopReason: Equatable {
     }
 }
 
+private enum TranscriptionBackgroundTaskOwner: Equatable {
+    case voiceNote(UUID)
+    case meeting(UUID)
+}
+
+enum VoiceNoteAudioInterruptionPolicy {
+    static func captureReason(
+        interruptionReason: AVAudioSession.InterruptionReason?,
+        rawReason: UInt?
+    ) -> VoiceNoteCaptureInterruptionReason {
+        if rawReason == 1 {
+            return .appSuspended
+        }
+        if interruptionReason == .routeDisconnected {
+            return .routeDisconnected
+        }
+        if interruptionReason == .builtInMicMuted {
+            return .microphoneMuted
+        }
+        return .system
+    }
+
+    static func captureReason(
+        routeChangeReason: AVAudioSession.RouteChangeReason?
+    ) -> VoiceNoteCaptureInterruptionReason {
+        routeChangeReason == .oldDeviceUnavailable
+            ? .routeDisconnected
+            : .engineConfigurationChanged
+    }
+}
+
 private enum KeyboardSessionReducer {
     static func reduce(_ state: KeyboardSessionState, event: KeyboardSessionEvent) -> KeyboardSessionState {
         switch event {
@@ -129,6 +160,18 @@ private enum KeyboardSessionReducer {
     }
 }
 
+private struct RealtimeDictationCallbackContext: Equatable {
+    let id: UUID
+    let sessionID: UUID
+    let requestID: UUID
+
+    init(id: UUID = UUID(), sessionID: UUID, requestID: UUID) {
+        self.id = id
+        self.sessionID = sessionID
+        self.requestID = requestID
+    }
+}
+
 @MainActor
 @Observable
 final class DictationCoordinator {
@@ -136,6 +179,13 @@ final class DictationCoordinator {
     private static let userNameKey = "muesli.onboarding.userName"
     private static let useCaseKey = "muesli.onboarding.useCase"
     private static let offlineTranscriptionNoProgressTimeout: TimeInterval = 90
+    private static let voiceNoteResumeRetryDelays: [Duration] = [
+        .zero,
+        .milliseconds(250),
+        .milliseconds(750),
+        .seconds(1.5),
+        .seconds(3),
+    ]
 
     private let store: SharedStore
     private let eventBus: any CrossProcessEventStreaming
@@ -149,6 +199,7 @@ final class DictationCoordinator {
     private var realtimeDictationChunksDirectory: URL?
     private var isRealtimeDictationSessionActive = false
     private var realtimeDictationCommittedText = ""
+    private var realtimeDictationCallbackContext: RealtimeDictationCallbackContext?
     private var meetingVadController: StreamingVadController?
     private let keyboardSessionKeeper = KeyboardSessionKeeper()
     private let liveActivityController = MuesliLiveActivityController()
@@ -158,15 +209,19 @@ final class DictationCoordinator {
     private var recordingTimerTask: Task<Void, Never>?
     @ObservationIgnored private var recordingTimerStartedAt: Date?
     @ObservationIgnored nonisolated(unsafe) private var sharedEventObservationTask: Task<Void, Never>?
+    @ObservationIgnored nonisolated(unsafe) private var keyboardCommandReconciliationTask: Task<Void, Never>?
     @ObservationIgnored nonisolated(unsafe) private var longVoiceNoteRecoveryTask: Task<Void, Never>?
+    @ObservationIgnored private var longVoiceNoteRecoveryNeedsAnotherPass = false
+    @ObservationIgnored private var voiceNoteCaptureResumeTask: Task<Void, Never>?
+    @ObservationIgnored private var voiceNoteCaptureHealthCheckTask: Task<Void, Never>?
     private var keyboardCommandProcessingInProgress = false
     private var keyboardSessionRetryTask: Task<Void, Never>?
+    @ObservationIgnored private var keyboardStandbyRecoveryTask: Task<Void, Never>?
     private var keyboardSessionRetryAttempt = 0
     private var keyboardWaveformLevelThrottle = MuesliWaveformLevelThrottle()
-    private let keyboardRuntimeStatusQueue = DispatchQueue(
-        label: "com.phequals7.muesli.keyboard-runtime-status",
-        qos: .utility
-    )
+    private var keyboardCrossProcessSmoothedLevel = 0.0
+    private var keyboardStandbyHeartbeatLastPublishedAt = Date.distantPast
+    @ObservationIgnored private let keyboardRuntimeStatusWriter: KeyboardRuntimeStatusProjectionWriter
     private var keyboardSessionLiveActivityRequestIDs = Set<UUID>()
     private var iCloudSyncTask: Task<Void, Never>?
     private var iCloudSyncDebounceTask: Task<Void, Never>?
@@ -175,15 +230,24 @@ final class DictationCoordinator {
     private var meetingChunkTasks: [Task<MeetingChunkTranscription?, Never>] = []
     private var meetingChunkTranscriptions: [MeetingChunkTranscription] = []
     private var meetingChunksDirectory: URL?
+    @ObservationIgnored private var meetingCaptureGraphRecoveryTask: Task<Void, Never>?
+    @ObservationIgnored private var meetingCaptureGraphRecoveryID: UUID?
+    @ObservationIgnored private var meetingCaptureHealthCheckTask: Task<Void, Never>?
+    @ObservationIgnored private var meetingCaptureHealthCheckID: UUID?
     private var meetingLifecycleState = MeetingLifecycleState()
     private var meetingLifecycleRunner: MeetingLifecycleRunner?
     private var voiceNoteLifecycleState = VoiceNoteLifecycleState()
     private var voiceNoteLifecycleRunner: VoiceNoteLifecycleRunner?
+    private var voiceNoteDraftLastPersistedAt = Date.distantPast
     private let meetingVadQueue = DispatchQueue(label: "com.phequals7.muesli.meeting-vad")
     private var transcriptionBackgroundTask: UIBackgroundTaskIdentifier = .invalid
-    nonisolated(unsafe) private var audioRouteObserver: NSObjectProtocol?
-    nonisolated(unsafe) private var audioInterruptionObserver: NSObjectProtocol?
-    nonisolated(unsafe) private var mediaServicesResetObserver: NSObjectProtocol?
+    private var transcriptionBackgroundTaskOwner: TranscriptionBackgroundTaskOwner?
+    private var transcriptionBackgroundTaskLeaseID: UUID?
+    @ObservationIgnored nonisolated(unsafe) private var audioRouteObserver: NSObjectProtocol?
+    @ObservationIgnored nonisolated(unsafe) private var audioInterruptionObserver: NSObjectProtocol?
+    @ObservationIgnored nonisolated(unsafe) private var mediaServicesResetObserver: NSObjectProtocol?
+    @ObservationIgnored nonisolated(unsafe) private var audioEngineConfigurationObserver: NSObjectProtocol?
+    @ObservationIgnored nonisolated(unsafe) private var protectedDataObserver: NSObjectProtocol?
 
     private var activeRequest: DictationRequest?
     private var activeSession: RecordingSession?
@@ -336,9 +400,15 @@ final class DictationCoordinator {
 
     var recoverableVoiceNoteSessions: [RecordingSession] {
         recordingSessions.filter { session in
-            session.kind != .meeting
-                && session.isLongForm
-                && [.recording, .transcriptionQueued, .transcribing, .failed].contains(session.phase)
+            let hasDraft = !(session.draftTranscriptText?
+                .trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ?? true)
+            return session.kind != .meeting
+                && (session.audioFileName != nil
+                    || session.protectedAudioUntilTranscriptCompletes
+                    || session.hasDurableAudioCheckpoint
+                    || hasDraft)
+                && [.recording, .interrupted, .transcriptionQueued, .transcribing, .failed]
+                    .contains(session.phase)
         }
     }
 
@@ -411,6 +481,7 @@ final class DictationCoordinator {
         self.store = store
         self.eventBus = eventBus
         voiceNoteCheckpointStore = VoiceNoteCheckpointStore(store: store)
+        keyboardRuntimeStatusWriter = KeyboardRuntimeStatusProjectionWriter(store: store)
         ModelBackgroundDownloadService.shared.delegate = self
 
         #if DEBUG
@@ -428,9 +499,28 @@ final class DictationCoordinator {
             forName: AVAudioSession.routeChangeNotification,
             object: AVAudioSession.sharedInstance(),
             queue: .main
-        ) { [weak self] _ in
+        ) { [weak self] notification in
+            let rawReason = notification.userInfo?[AVAudioSessionRouteChangeReasonKey] as? UInt
+            let routeReason = rawReason.flatMap(AVAudioSession.RouteChangeReason.init(rawValue:))
+            let captureReason = VoiceNoteAudioInterruptionPolicy.captureReason(
+                routeChangeReason: routeReason
+            )
             Task { @MainActor in
-                self?.refreshAudioInputRoute()
+                guard let self else { return }
+                self.refreshAudioInputRoute()
+                if self.meetingLifecycleState.isRecording,
+                   self.meetingRecorder != nil {
+                    self.scheduleMeetingCaptureGraphRecovery(reason: "route_change")
+                } else if self.isRecording {
+                    self.scheduleVoiceNoteCaptureHealthCheck(
+                        reason: captureReason,
+                        rebuildGraph: true
+                    )
+                } else if self.isKeyboardSessionArmed {
+                    // Standby has no writer, but it still must prove that its input
+                    // tap survived the route change before accepting the next Start.
+                    self.keyboardSessionKeeper.resetInputHealthEvidence()
+                }
             }
         }
         audioInterruptionObserver = NotificationCenter.default.addObserver(
@@ -444,11 +534,20 @@ final class DictationCoordinator {
             let reason = rawReason.flatMap(AVAudioSession.InterruptionReason.init(rawValue:))
             let rawOptions = notification.userInfo?[AVAudioSessionInterruptionOptionKey] as? UInt ?? 0
             let shouldResume = AVAudioSession.InterruptionOptions(rawValue: rawOptions).contains(.shouldResume)
+            // Raw reason 1 is the legacy app-suspension value. Referencing the old
+            // SDK symbol/key directly is deprecated, but accepting its raw value keeps
+            // recovery compatible with older OS deliveries.
+            let wasSuspended = rawReason == 1
             Task { @MainActor in
                 self?.handleAudioSessionInterruption(
                     type: type,
                     cause: Self.meetingInterruptionCause(for: reason),
-                    shouldResume: shouldResume
+                    voiceNoteReason: VoiceNoteAudioInterruptionPolicy.captureReason(
+                        interruptionReason: reason,
+                        rawReason: rawReason
+                    ),
+                    shouldResume: shouldResume,
+                    wasSuspended: wasSuspended
                 )
             }
         }
@@ -461,9 +560,39 @@ final class DictationCoordinator {
                 self?.handleAudioServicesReset()
             }
         }
-        keyboardSessionKeeper.onRecordingFailure = { [weak self] failure in
+        audioEngineConfigurationObserver = NotificationCenter.default.addObserver(
+            forName: .AVAudioEngineConfigurationChange,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
             Task { @MainActor in
-                self?.handleVoiceNoteWriterFailure(failure)
+                self?.handleAudioEngineConfigurationChange()
+            }
+        }
+        protectedDataObserver = NotificationCenter.default.addObserver(
+            forName: UIApplication.protectedDataDidBecomeAvailableNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor in
+                self?.recoverLongVoiceNotesIfNeeded()
+            }
+        }
+        keyboardSessionKeeper.onRecordingFailure = { [weak self] failure, segmentID in
+            Task { @MainActor in
+                guard let self,
+                      self.keyboardSessionKeeper.isActiveSegment(segmentID)
+                else { return }
+                self.handleVoiceNoteWriterFailure(failure)
+            }
+        }
+        keyboardSessionKeeper.setInputActivityHandler { [weak self] powerDB, isCapturing, segmentID in
+            Task { @MainActor in
+                self?.handleKeyboardInputActivity(
+                    powerDB: powerDB,
+                    isCapturing: isCapturing,
+                    segmentID: segmentID
+                )
             }
         }
         startSharedEventObservation()
@@ -491,7 +620,13 @@ final class DictationCoordinator {
 
     deinit {
         sharedEventObservationTask?.cancel()
+        keyboardCommandReconciliationTask?.cancel()
         longVoiceNoteRecoveryTask?.cancel()
+        voiceNoteCaptureResumeTask?.cancel()
+        voiceNoteCaptureHealthCheckTask?.cancel()
+        meetingCaptureGraphRecoveryTask?.cancel()
+        meetingCaptureHealthCheckTask?.cancel()
+        keyboardStandbyRecoveryTask?.cancel()
         if let audioRouteObserver {
             NotificationCenter.default.removeObserver(audioRouteObserver)
         }
@@ -500,6 +635,12 @@ final class DictationCoordinator {
         }
         if let mediaServicesResetObserver {
             NotificationCenter.default.removeObserver(mediaServicesResetObserver)
+        }
+        if let audioEngineConfigurationObserver {
+            NotificationCenter.default.removeObserver(audioEngineConfigurationObserver)
+        }
+        if let protectedDataObserver {
+            NotificationCenter.default.removeObserver(protectedDataObserver)
         }
     }
 
@@ -586,6 +727,10 @@ final class DictationCoordinator {
                     return
                 }
                 guard !Task.isCancelled, let self else { return }
+                if !self.voiceNoteLifecycleState.isRecording {
+                    try? await Task.sleep(for: .milliseconds(250))
+                    continue
+                }
                 for event in schedule.consumeNextDeadline() {
                     guard !Task.isCancelled,
                           self.voiceNoteLifecycleRunner?.sessionID == sessionID,
@@ -608,6 +753,10 @@ final class DictationCoordinator {
         guard voiceNoteLifecycleRunner?.sessionID == sessionID else { return }
         voiceNoteLifecycleRunner?.recordingScheduleTask?.cancel()
         voiceNoteLifecycleRunner?.recordingScheduleTask = nil
+        voiceNoteCaptureResumeTask?.cancel()
+        voiceNoteCaptureResumeTask = nil
+        voiceNoteCaptureHealthCheckTask?.cancel()
+        voiceNoteCaptureHealthCheckTask = nil
     }
 
     private func finishVoiceNoteLifecycle(sessionID: UUID) {
@@ -659,9 +808,7 @@ final class DictationCoordinator {
             ? "Finish the active meeting first"
             : "Finish the active voice note first"
         saveKeyboardHandoff(requestID: requestID, phase: .failed, message: message)
-        if let pendingRequest = try? store.pendingRequest(), pendingRequest.id == requestID {
-            try? store.clearPendingRequest()
-        }
+        _ = try? store.clearPendingRequest(id: requestID)
         saveKeyboardRuntimeStatus(
             isActive: false,
             activeRequestID: nil,
@@ -707,19 +854,21 @@ final class DictationCoordinator {
         message: String,
         unavailableAudioMessage: String? = nil
     ) async -> RecordingSession {
-        let audioIsRecoverable = session.isLongForm
-            ? await hasRecoverableAudio(for: session)
-            : false
-        let resolvedMessage = session.isLongForm && !audioIsRecoverable
+        let audioIsRecoverable = await hasRecoverableAudio(for: session)
+        let resolvedMessage = !audioIsRecoverable
             ? unavailableAudioMessage ?? message
             : message
-        var failedSession = VoiceNoteFailureSessionPolicy.prepare(
+        let failedSession = VoiceNoteFailureSessionPolicy.prepare(
             session,
             reason: reason,
             message: resolvedMessage,
             hasRecoverableAudio: audioIsRecoverable
         )
-        cleanupNonRetainedAudio(for: &failedSession)
+        // A transient read failure is not proof that the file is disposable (the
+        // device may still be locked, a WAV header may need repair, or the writer
+        // may be finalizing). Preserve every named audio artifact on a retryable
+        // failure; only successful completion, explicit cancellation, or an
+        // explicit user delete may remove captured speech.
         try? store.saveSession(failedSession)
         settleVoiceNoteLifecycleAfterFailure(failedSession)
         return failedSession
@@ -821,7 +970,11 @@ final class DictationCoordinator {
         switch voiceNoteLifecycleState.phase {
         case .recordingShort(let activeID) where activeID == sessionID:
             guard transitionVoiceNoteLifecycle(.longFormActivated(sessionID)) else { return nil }
+        case .interruptedShort(let activeID) where activeID == sessionID:
+            guard transitionVoiceNoteLifecycle(.longFormActivated(sessionID)) else { return nil }
         case .recordingLongProtected(let activeID) where activeID == sessionID:
+            break
+        case .interruptedLongProtected(let activeID) where activeID == sessionID:
             break
         default:
             return nil
@@ -879,8 +1032,17 @@ final class DictationCoordinator {
         return session
     }
 
-    private func handleVoiceNoteWriterFailure(_ failure: CheckpointingAudioWriterFailure) {
+    private func handleVoiceNoteWriterFailure(
+        _ failure: CheckpointingAudioWriterFailure,
+        expectedSessionID: UUID? = nil,
+        expectedRequestID: UUID? = nil
+    ) {
         guard isRecording, var session = activeSession, session.kind != .meeting else { return }
+        if let expectedSessionID, session.id != expectedSessionID { return }
+        if let expectedRequestID,
+           session.requestID != expectedRequestID || activeRequest?.id != expectedRequestID {
+            return
+        }
         if failure == .continuousWrite {
             longVoiceNoteAudioIsSecured = session.hasDurableAudioCheckpoint
         } else {
@@ -908,18 +1070,21 @@ final class DictationCoordinator {
     private static func meetingInterruptionCause(
         for reason: AVAudioSession.InterruptionReason?
     ) -> MeetingAudioInterruptionCause {
-        switch reason {
-        case .routeDisconnected: .routeDisconnected
-        case .builtInMicMuted: .microphoneMuted
-        case .none, .default, .appWasSuspended: .system
-        @unknown default: .system
+        if reason == .routeDisconnected {
+            return .routeDisconnected
         }
+        if reason == .builtInMicMuted {
+            return .microphoneMuted
+        }
+        return .system
     }
 
     private func handleAudioSessionInterruption(
         type: AVAudioSession.InterruptionType,
         cause: MeetingAudioInterruptionCause,
-        shouldResume: Bool
+        voiceNoteReason: VoiceNoteCaptureInterruptionReason,
+        shouldResume: Bool,
+        wasSuspended: Bool
     ) {
         if meetingLifecycleState.isRecordingVisible || meetingRecorder != nil {
             if type == .ended {
@@ -931,6 +1096,8 @@ final class DictationCoordinator {
             }
             switch MeetingAudioInterruptionPolicy.disposition(for: cause) {
             case .keepCaptureAlive:
+                cancelMeetingCaptureRecoveryTasks()
+                meetingRecorder?.invalidateInputHealth()
                 AppTelemetry.signal(
                     "meeting_audio_interruption_began",
                     parameters: ["cause": cause.rawValue]
@@ -943,11 +1110,30 @@ final class DictationCoordinator {
             }
             return
         }
-        guard type == .began else { return }
-        handleVoiceNoteRecordingInterruption(
-            message: "Recording was interrupted by the system",
-            cause: .interrupted
-        )
+        if !isRecording, isKeyboardSessionArmed {
+            if type == .began {
+                keyboardSessionKeeper.invalidateInputHealth()
+            } else {
+                recoverKeyboardStandbyIfNeeded(recreateEngine: false)
+            }
+            return
+        }
+        if type == .began {
+            handleVoiceNoteCaptureInterruption(reason: voiceNoteReason)
+            if wasSuspended, UIApplication.shared.applicationState == .active {
+                scheduleVoiceNoteCaptureResume(
+                    reason: voiceNoteReason,
+                    shouldResume: shouldResume,
+                    rebuildGraph: true
+                )
+            }
+        } else {
+            scheduleVoiceNoteCaptureResume(
+                reason: voiceNoteReason,
+                shouldResume: shouldResume,
+                rebuildGraph: true
+            )
+        }
     }
 
     private func handleAudioServicesReset() {
@@ -958,9 +1144,34 @@ final class DictationCoordinator {
             )
             return
         }
-        handleVoiceNoteRecordingInterruption(
-            message: "Audio services restarted",
-            cause: .interrupted
+        if !isRecording, isKeyboardSessionArmed {
+            keyboardSessionKeeper.invalidateInputHealth()
+            recoverKeyboardStandbyIfNeeded(recreateEngine: true)
+            return
+        }
+        handleVoiceNoteCaptureInterruption(reason: .mediaServicesReset)
+        scheduleVoiceNoteCaptureResume(
+            reason: .mediaServicesReset,
+            shouldResume: true,
+            rebuildGraph: true
+        )
+    }
+
+    private func handleAudioEngineConfigurationChange() {
+        if meetingLifecycleState.isRecording, meetingRecorder != nil {
+            scheduleMeetingCaptureGraphRecovery(reason: "engine_configuration_change")
+            return
+        }
+        guard isRecording else {
+            if isKeyboardSessionArmed {
+                keyboardSessionKeeper.resetInputHealthEvidence()
+            }
+            return
+        }
+        guard activeSession?.kind != .meeting else { return }
+        scheduleVoiceNoteCaptureHealthCheck(
+            reason: .engineConfigurationChanged,
+            rebuildGraph: true
         )
     }
 
@@ -996,12 +1207,25 @@ final class DictationCoordinator {
         guard meetingLifecycleState.isRecording,
               let meetingRecorder
         else { return }
+        cancelMeetingCaptureRecoveryTasks()
         do {
-            let didResume = try meetingRecorder.resumeIfNeeded()
+            let didResume = try meetingRecorder.resumeIfNeeded(rebuildGraph: true)
             guard didResume else {
                 stopMeetingRecording(queueForTranscription: false)
                 return
             }
+            guard let sessionID = meetingLifecycleState.activeSessionID,
+                  let operationID = meetingLifecycleRunner?.id
+            else {
+                stopMeetingRecording(queueForTranscription: false)
+                return
+            }
+            scheduleMeetingCaptureHealthProof(
+                recorder: meetingRecorder,
+                sessionID: sessionID,
+                operationID: operationID,
+                reason: "interruption_resume"
+            )
             AppTelemetry.signal(
                 "meeting_recording_resumed_after_interruption",
                 parameters: [
@@ -1043,11 +1267,428 @@ final class DictationCoordinator {
         stopRecording(requestID: requestID)
     }
 
+    private func handleVoiceNoteCaptureInterruption(
+        reason: VoiceNoteCaptureInterruptionReason
+    ) {
+        guard isRecording,
+              let session = activeSession,
+              session.kind != .meeting,
+              let requestID = session.requestID,
+              voiceNoteLifecycleRunner?.requestID == requestID
+        else { return }
+
+        voiceNoteCaptureResumeTask?.cancel()
+        voiceNoteCaptureResumeTask = nil
+        invalidateVoiceNoteInputHealth()
+        let draft = liveDictationTranscript.trimmingCharacters(in: .whitespacesAndNewlines)
+        sealActiveVoiceNoteCheckpointForInterruption(sessionID: session.id)
+
+        let interruptedAt = Date()
+        guard let persisted = try? store.transitionVoiceNoteSession(
+            id: session.id,
+            expectedPhases: [.recording, .interrupted],
+            update: { persisted in
+                persisted.phase = .interrupted
+                persisted.captureInterruptionReason = reason
+                persisted.captureInterruptedAt = interruptedAt
+                persisted.errorMessage = nil
+                if !draft.isEmpty {
+                    persisted.draftTranscriptText = draft
+                    persisted.draftTranscriptUpdatedAt = interruptedAt
+                }
+            }
+        ) else {
+            if let current = try? store.activeRecordingSession(id: session.id) {
+                activeSession = current
+            }
+            AppTelemetry.failure(
+                "voice_note_interruption_persistence_conflict",
+                domain: .stateMachine,
+                stage: "capture_interruption",
+                reason: "phase_compare_and_set_failed"
+            )
+            return
+        }
+        guard transitionVoiceNoteLifecycle(.captureInterrupted(session.id)) else { return }
+        activeSession = persisted
+        if !draft.isEmpty {
+            voiceNoteDraftLastPersistedAt = interruptedAt
+        }
+        statusText = "Recording paused — resuming"
+        if session.kind == .keyboardDictation {
+            saveKeyboardRuntimeStatus(
+                isActive: true,
+                activeRequestID: requestID,
+                phase: .recording,
+                message: "Recording paused — resuming",
+                supportsBackgroundStart: false,
+                isRecoveringCapture: true
+            )
+        }
+        AppTelemetry.signal(
+            "voice_note_capture_interrupted",
+            parameters: ["reason": reason.rawValue]
+        )
+    }
+
+    private func sealActiveVoiceNoteCheckpointForInterruption(sessionID: UUID) {
+        guard let runner = voiceNoteLifecycleRunner,
+              runner.sessionID == sessionID
+        else { return }
+        let runnerID = runner.id
+        let requestID = runner.requestID
+        let checkpoint = keyboardSessionKeeper.rotateSegmentCheckpoint()
+            ?? realtimeDictationRecorder?.rotateChunk()
+        guard let checkpoint else { return }
+
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            do {
+                let manifest = try await voiceNoteCheckpointStore.record(
+                    checkpoint,
+                    sessionID: sessionID
+                )
+                guard isCurrentVoiceNoteLifecycle(
+                    sessionID: sessionID,
+                    requestID: requestID,
+                    runnerID: runnerID
+                ) else { return }
+                let checkpointIsDurable = !manifest.entries.isEmpty
+                guard let persisted = try store.transitionVoiceNoteSession(
+                    id: sessionID,
+                    expectedPhases: [.recording, .interrupted],
+                    update: { session in
+                        session.hasDurableAudioCheckpoint = checkpointIsDurable
+                            || session.hasDurableAudioCheckpoint
+                        session.protectedAudioUntilTranscriptCompletes = checkpointIsDurable
+                            || session.protectedAudioUntilTranscriptCompletes
+                    }
+                ) else { return }
+                if activeSession?.id == sessionID {
+                    activeSession = persisted
+                }
+            } catch {
+                AppTelemetry.failure(
+                    "voice_note_interruption_checkpoint_failed",
+                    domain: .audio,
+                    stage: "interruption_checkpoint",
+                    error: error
+                )
+            }
+        }
+    }
+
+    func reconcileVoiceNoteRuntime(reason: String) {
+        guard isRecording,
+              let session = activeSession,
+              session.kind != .meeting
+        else { return }
+
+        if !isVoiceNoteCaptureReceivingAudio || session.phase == .interrupted {
+            let interruptionReason = session.captureInterruptionReason ?? .appSuspended
+            if voiceNoteLifecycleState.isRecording {
+                handleVoiceNoteCaptureInterruption(reason: interruptionReason)
+            }
+            scheduleVoiceNoteCaptureResume(
+                reason: interruptionReason,
+                shouldResume: true,
+                rebuildGraph: true
+            )
+        }
+        AppTelemetry.signal(
+            "voice_note_runtime_reconciled",
+            parameters: ["reason": reason]
+        )
+    }
+
+    /// Configuration and route notifications can arrive while AVAudioEngine still
+    /// reports `isRunning`. Delay the decision until the rebuilt graph has had time
+    /// to deliver a real input buffer, then recover only if capture is genuinely
+    /// silent. This avoids both phantom-running capture and notification/rebuild
+    /// loops.
+    private func scheduleVoiceNoteCaptureHealthCheck(
+        reason: VoiceNoteCaptureInterruptionReason,
+        rebuildGraph: Bool
+    ) {
+        guard isRecording,
+              let session = activeSession,
+              session.kind != .meeting,
+              let requestID = session.requestID,
+              let runnerID = voiceNoteLifecycleRunner?.id,
+              voiceNoteCaptureResumeTask == nil
+        else { return }
+
+        // Forget pre-event liveness without disabling the current tap. A valid
+        // post-event buffer can prove the graph survived; an in-flight callback
+        // from before the event is excluded by the recorder's health epoch.
+        resetVoiceNoteInputHealthEvidence()
+        voiceNoteCaptureHealthCheckTask?.cancel()
+        voiceNoteCaptureHealthCheckTask = Task { @MainActor [weak self] in
+            do {
+                // The input taps use 2,048/4,096-frame buffers. 600 ms covers at
+                // least one callback at their supported sample rates without
+                // making a real interruption feel sticky.
+                try await Task.sleep(for: .milliseconds(600))
+            } catch {
+                return
+            }
+            guard let self,
+                  !Task.isCancelled,
+                  self.voiceNoteCaptureResumeTask == nil,
+                  self.isCurrentVoiceNoteLifecycle(
+                      sessionID: session.id,
+                      requestID: requestID,
+                      runnerID: runnerID
+                  ),
+                  self.isRecording,
+                  self.activeSession?.id == session.id
+            else { return }
+
+            self.voiceNoteCaptureHealthCheckTask = nil
+            guard !self.isVoiceNoteCaptureReceivingAudio else { return }
+            self.handleVoiceNoteCaptureInterruption(reason: reason)
+            self.scheduleVoiceNoteCaptureResume(
+                reason: reason,
+                shouldResume: true,
+                rebuildGraph: rebuildGraph
+            )
+        }
+    }
+
+    private var isVoiceNoteCaptureReceivingAudio: Bool {
+        guard let requestID = activeRequest?.id else { return false }
+        if usesKeyboardSessionLiveActivity(for: requestID) {
+            return keyboardSessionKeeper.isReceivingAudio(maximumAge: 1.5)
+        }
+        if let realtimeDictationRecorder {
+            return realtimeDictationRecorder.isReceivingAudio(maximumAge: 1.5)
+        }
+        // Voice-note sessions are exclusively engine-backed. The remaining
+        // AVAudioRecorder instance is scoped to the foreground onboarding test and
+        // must never be treated as the authority for a persisted voice-note session.
+        return false
+    }
+
+    private func invalidateVoiceNoteInputHealth() {
+        guard let requestID = activeRequest?.id else { return }
+        if usesKeyboardSessionLiveActivity(for: requestID) {
+            keyboardSessionKeeper.invalidateInputHealth()
+        } else {
+            realtimeDictationRecorder?.invalidateInputHealth()
+        }
+    }
+
+    private func resetVoiceNoteInputHealthEvidence() {
+        guard let requestID = activeRequest?.id else { return }
+        if usesKeyboardSessionLiveActivity(for: requestID) {
+            keyboardSessionKeeper.resetInputHealthEvidence()
+        } else {
+            realtimeDictationRecorder?.resetInputHealthEvidence()
+        }
+    }
+
+    private func scheduleVoiceNoteCaptureResume(
+        reason: VoiceNoteCaptureInterruptionReason,
+        shouldResume: Bool,
+        rebuildGraph: Bool = false
+    ) {
+        voiceNoteCaptureResumeTask?.cancel()
+        voiceNoteCaptureResumeTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            var requiresGraphRebuild = rebuildGraph
+            for (attempt, delay) in Self.voiceNoteResumeRetryDelays.enumerated() {
+                if delay != .zero {
+                    do {
+                        try await Task.sleep(for: delay)
+                    } catch {
+                        return
+                    }
+                }
+                guard !Task.isCancelled else { return }
+                if attemptVoiceNoteCaptureResume(
+                    reason: reason,
+                    rebuildGraph: requiresGraphRebuild,
+                    attempt: attempt + 1
+                ) {
+                    do {
+                        // A running engine is only a provisional success. Wait for
+                        // a real input callback (or AVAudioRecorder time progress)
+                        // before publishing `.recording` to either state authority.
+                        try await Task.sleep(for: .milliseconds(600))
+                    } catch {
+                        return
+                    }
+                    guard !Task.isCancelled else { return }
+                    if isVoiceNoteCaptureReceivingAudio,
+                       completeVoiceNoteCaptureResume(
+                           reason: reason,
+                           shouldResume: shouldResume
+                       ) {
+                        voiceNoteCaptureResumeTask = nil
+                        return
+                    }
+                    requiresGraphRebuild = true
+                }
+            }
+            voiceNoteCaptureResumeTask = nil
+            guard isRecording, activeSession?.kind != .meeting else { return }
+            statusText = "Recording paused — unlock or open Muesli to resume"
+        }
+    }
+
+    @discardableResult
+    private func attemptVoiceNoteCaptureResume(
+        reason: VoiceNoteCaptureInterruptionReason,
+        rebuildGraph: Bool,
+        attempt: Int
+    ) -> Bool {
+        guard isRecording,
+              var session = activeSession,
+              session.kind != .meeting,
+              let requestID = session.requestID,
+              activeRequest?.id == requestID
+        else { return true }
+
+        do {
+            let didResume: Bool
+            let recreateEngine = reason == .mediaServicesReset
+            if usesKeyboardSessionLiveActivity(for: requestID) {
+                didResume = try keyboardSessionKeeper.resumeCaptureIfNeeded(
+                    rebuildGraph: rebuildGraph,
+                    recreateEngine: recreateEngine
+                )
+            } else if let realtimeDictationRecorder {
+                didResume = try realtimeDictationRecorder.resumeIfNeeded(
+                    routeStage: "voice note interruption recovery",
+                    rebuildGraph: rebuildGraph,
+                    recreateEngine: recreateEngine
+                )
+            } else {
+                throw AudioRecorder.RecordingError.startFailed(
+                    stage: "missing engine-backed voice note recorder"
+                )
+            }
+            guard didResume else {
+                throw AudioRecorder.RecordingError.startFailed(stage: "interruption recovery")
+            }
+            return true
+        } catch {
+            if voiceNoteLifecycleState.isRecording {
+                _ = transitionVoiceNoteLifecycle(.captureInterrupted(session.id))
+            }
+            let persisted = try? store.transitionVoiceNoteSession(
+                id: session.id,
+                expectedPhases: [.recording, .interrupted],
+                update: { persisted in
+                    persisted.phase = .interrupted
+                    persisted.captureInterruptionReason = reason
+                    persisted.captureInterruptedAt = persisted.captureInterruptedAt ?? .now
+                    persisted.lastTranscriptionFailureReason = .interrupted
+                    persisted.errorMessage = "Recording is paused. Muesli kept everything captured so far."
+                }
+            )
+            if let persisted {
+                session = persisted
+                activeSession = persisted
+            }
+            AppTelemetry.failure(
+                "voice_note_capture_resume_failed",
+                domain: .audio,
+                stage: "interruption_resume",
+                error: error,
+                reason: reason.rawValue,
+                parameters: ["attempt": "\(attempt)"]
+            )
+            return false
+        }
+    }
+
+    @discardableResult
+    private func completeVoiceNoteCaptureResume(
+        reason: VoiceNoteCaptureInterruptionReason,
+        shouldResume: Bool
+    ) -> Bool {
+        guard isRecording,
+              let session = activeSession,
+              session.kind != .meeting,
+              let requestID = session.requestID,
+              activeRequest?.id == requestID
+        else { return false }
+
+        let lifecycleWasInterrupted: Bool
+        switch voiceNoteLifecycleState.phase {
+        case .interruptedShort(let id), .interruptedLongProtected(let id):
+            lifecycleWasInterrupted = id == session.id
+        default:
+            lifecycleWasInterrupted = false
+        }
+        guard lifecycleWasInterrupted else { return false }
+
+        do {
+            guard let persisted = try store.transitionVoiceNoteSession(
+                id: session.id,
+                expectedPhases: [.interrupted],
+                update: { stored in
+                    stored.phase = .recording
+                    stored.captureInterruptionReason = nil
+                    stored.captureInterruptedAt = nil
+                    stored.errorMessage = nil
+                }
+            ) else { return false }
+
+            guard transitionVoiceNoteLifecycle(.captureResumed(session.id)) else {
+                _ = try? store.transitionVoiceNoteSession(
+                    id: session.id,
+                    expectedPhases: [.recording],
+                    update: { stored in
+                        stored.phase = .interrupted
+                        stored.captureInterruptionReason = reason
+                        stored.captureInterruptedAt = stored.captureInterruptedAt ?? .now
+                    }
+                )
+                return false
+            }
+
+            activeSession = persisted
+            statusText = "Recording"
+            saveKeyboardRuntimeStatus(
+                isActive: true,
+                activeRequestID: requestID,
+                phase: .recording,
+                message: "Listening",
+                supportsBackgroundStart: false
+            )
+            AppTelemetry.signal(
+                "voice_note_capture_resumed",
+                parameters: [
+                    "reason": reason.rawValue,
+                    "system_should_resume": shouldResume ? "true" : "false",
+                ]
+            )
+            return true
+        } catch {
+            AppTelemetry.failure(
+                "voice_note_capture_resume_persistence_failed",
+                domain: .persistence,
+                stage: "interruption_resume_commit",
+                error: error,
+                reason: reason.rawValue
+            )
+            return false
+        }
+    }
+
     func recoverLongVoiceNotesIfNeeded() {
-        guard longVoiceNoteRecoveryTask == nil else { return }
+        guard longVoiceNoteRecoveryTask == nil else {
+            longVoiceNoteRecoveryNeedsAnotherPass = true
+            return
+        }
         longVoiceNoteRecoveryTask = Task { @MainActor [weak self] in
             guard let self else { return }
-            await recoverLongVoiceNotesOnLaunch()
+            repeat {
+                longVoiceNoteRecoveryNeedsAnotherPass = false
+                await recoverLongVoiceNotesOnLaunch()
+            } while longVoiceNoteRecoveryNeedsAnotherPass && !Task.isCancelled
             longVoiceNoteRecoveryTask = nil
         }
     }
@@ -1058,7 +1699,7 @@ final class DictationCoordinator {
     }
 
     func openLongVoiceNote(_ session: RecordingSession) {
-        guard session.kind != .meeting, session.isLongForm else { return }
+        guard session.kind != .meeting else { return }
         presentedLongVoiceNoteSessionID = session.id
     }
 
@@ -1068,6 +1709,13 @@ final class DictationCoordinator {
     }
 
     private func recoverLongVoiceNotesOnLaunch() async {
+        guard UIApplication.shared.isProtectedDataAvailable else {
+            AppTelemetry.signal(
+                "voice_note_recovery_deferred",
+                parameters: ["reason": "protected_data_unavailable"]
+            )
+            return
+        }
         let inventoryResult = VoiceNoteRecoveryInventory.load {
             try store.recordingSessions()
         }
@@ -1098,31 +1746,35 @@ final class DictationCoordinator {
 
         var didChange = false
         for original in sessions where original.kind != .meeting {
-            if original.audioFileName == nil,
-               !original.protectedAudioUntilTranscriptCompletes {
-                continue
-            }
-            let isCheckpointArmedRecording = original.phase == .recording
-                && original.longFormThresholdSeconds != nil
-            guard original.isLongForm || isCheckpointArmedRecording else { continue }
-            guard [.recording, .transcriptionQueued, .transcribing, .failed].contains(original.phase),
-                  voiceNoteLifecycleRunner?.sessionID != original.id,
-                  original.phase != .failed || original.longFormRecoveryValidatedAt == nil
+            let hasDraft = !(original.draftTranscriptText?
+                .trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ?? true)
+            let hasRecoveryEvidence = original.audioFileName != nil
+                || original.protectedAudioUntilTranscriptCompletes
+                || original.hasDurableAudioCheckpoint
+                || hasDraft
+            guard hasRecoveryEvidence,
+                  [.recording, .interrupted, .transcriptionQueued, .transcribing, .failed]
+                    .contains(original.phase),
+                  voiceNoteLifecycleRunner?.sessionID != original.id
             else { continue }
 
             var session = original
-            if isCheckpointArmedRecording {
-                session.isLongForm = true
-                session.longFormActivatedAt = session.longFormActivatedAt ?? .now
-            }
+            let recoveryObservedAt = Date()
             let recoveredManifest = try? await voiceNoteCheckpointStore.salvageTrailingCheckpoint(
                 sessionID: session.id
             )
-            session.hasDurableAudioCheckpoint = !(recoveredManifest?.entries.isEmpty ?? true)
-            if session.phase == .recording || session.phase == .transcribing {
+            session.hasDurableAudioCheckpoint = session.hasDurableAudioCheckpoint
+                || !(recoveredManifest?.entries.isEmpty ?? true)
+            if [.recording, .interrupted, .transcriptionQueued, .transcribing]
+                .contains(session.phase) {
+                session.endedAt = session.endedAt
+                    ?? session.captureInterruptedAt
+                    ?? recoveryObservedAt
                 session.phase = .failed
                 session.lastTranscriptionFailureReason = .interrupted
-                session.errorMessage = "Your audio is safe. Transcription needs to be retried."
+                session.errorMessage = "Recording was interrupted. Recovering everything captured so far."
+            } else if session.phase == .failed, session.endedAt == nil {
+                session.endedAt = session.captureInterruptedAt ?? recoveryObservedAt
             }
 
             var hasAudio = false
@@ -1141,22 +1793,52 @@ final class DictationCoordinator {
             if hasAudio {
                 session.phase = .failed
                 session.protectedAudioUntilTranscriptCompletes = true
+                session.captureInterruptionReason = nil
                 session.errorMessage = "Your audio is safe. We couldn't finish transcribing this note."
-                AppTelemetry.contextualSignal(
-                    "long_voice_note_recovered_on_launch",
-                    parameters: voiceNoteTelemetryParameters(session: session)
-                )
             } else {
                 session.phase = .failed
                 session.protectedAudioUntilTranscriptCompletes = false
-                session.hasDurableAudioCheckpoint = false
                 session.lastTranscriptionFailureReason = .audioUnavailable
-                session.errorMessage = "The saved audio is unavailable."
-                session.audioFileName = nil
-                try? await voiceNoteCheckpointStore.delete(sessionID: session.id)
+                session.errorMessage = hasDraft
+                    ? "A partial transcript was recovered. The audio still needs recovery."
+                    : "The saved audio could not be opened yet. It has not been deleted."
             }
             session.longFormRecoveryValidatedAt = .now
-            try? store.saveSession(session)
+
+            // Recovery performs file I/O across suspension points. A retry may
+            // claim the same row while that work is in flight, so never write the
+            // stale snapshot back wholesale. Merge only recovery-owned fields if
+            // both phase and audio identity are still the ones we inspected.
+            guard voiceNoteLifecycleRunner?.sessionID != original.id,
+                  activeSession?.id != original.id
+            else { continue }
+            var didApplyRecovery = false
+            let recovered = try? store.transitionVoiceNoteSession(
+                id: original.id,
+                expectedPhases: [original.phase],
+                update: { stored in
+                    guard stored.audioFileName == original.audioFileName else { return }
+                    didApplyRecovery = true
+                    stored.phase = session.phase
+                    stored.endedAt = stored.endedAt ?? session.endedAt
+                    stored.hasDurableAudioCheckpoint = stored.hasDurableAudioCheckpoint
+                        || session.hasDurableAudioCheckpoint
+                    stored.protectedAudioUntilTranscriptCompletes =
+                        session.protectedAudioUntilTranscriptCompletes
+                    stored.lastTranscriptionFailureReason = session.lastTranscriptionFailureReason
+                    stored.captureInterruptionReason = session.captureInterruptionReason
+                    stored.captureInterruptedAt = session.captureInterruptedAt
+                    stored.errorMessage = session.errorMessage
+                    stored.longFormRecoveryValidatedAt = session.longFormRecoveryValidatedAt
+                }
+            )
+            guard didApplyRecovery, let recovered else { continue }
+            if hasAudio {
+                AppTelemetry.contextualSignal(
+                    "voice_note_recovered_on_launch",
+                    parameters: voiceNoteTelemetryParameters(session: recovered)
+                )
+            }
             didChange = true
         }
         if didChange {
@@ -1223,6 +1905,7 @@ final class DictationCoordinator {
         operationID: UUID = UUID()
     ) -> Bool {
         guard transitionMeetingLifecycle(event) else { return false }
+        cancelMeetingCaptureRecoveryTasks()
         meetingLifecycleRunner?.cancelAll()
         meetingLifecycleRunner = MeetingLifecycleRunner(id: operationID, sessionID: sessionID)
         return true
@@ -1260,6 +1943,7 @@ final class DictationCoordinator {
             return false
         }
         guard transitionMeetingLifecycle(.finished(sessionID)) else { return false }
+        cancelMeetingCaptureRecoveryTasks()
         meetingLifecycleRunner?.cancelAll()
         meetingLifecycleRunner = nil
         if activeSession?.kind == .meeting, activeSession?.id == sessionID {
@@ -1309,7 +1993,7 @@ final class DictationCoordinator {
             ?? MuesliAppConstants.startAction
         if action == MuesliAppConstants.cancelAction {
             guard !rejectConflictingKeyboardCommand(requestID: requestID, action: .cancel) else {
-                try? store.clearPendingCommand()
+                clearPendingKeyboardCommand(requestID: requestID, action: .cancel)
                 return
             }
             saveKeyboardHandoff(
@@ -1318,12 +2002,12 @@ final class DictationCoordinator {
                 message: "Cancelled"
             )
             cancelRecording(requestID: requestID)
-            try? store.clearPendingCommand()
+            clearPendingKeyboardCommand(requestID: requestID, action: .cancel)
             return
         }
         if action == MuesliAppConstants.stopAction {
             guard !rejectConflictingKeyboardCommand(requestID: requestID, action: .stop) else {
-                try? store.clearPendingCommand()
+                clearPendingKeyboardCommand(requestID: requestID, action: .stop)
                 return
             }
             saveKeyboardHandoff(
@@ -1332,15 +2016,15 @@ final class DictationCoordinator {
                 message: "Stopping"
             )
             stopRecording(requestID: requestID)
-            try? store.clearPendingCommand()
+            clearPendingKeyboardCommand(requestID: requestID, action: .stop)
             return
         }
 
         guard !rejectConflictingKeyboardCommand(requestID: requestID, action: .start) else {
-            try? store.clearPendingCommand()
+            clearPendingKeyboardCommand(requestID: requestID, action: .start)
             return
         }
-        defer { try? store.clearPendingCommand() }
+        defer { clearPendingKeyboardCommand(requestID: requestID, action: .start) }
 
         let pendingRequest = try? store.pendingRequest()
         let request = pendingRequest?.id == requestID
@@ -1437,7 +2121,7 @@ final class DictationCoordinator {
             return false
         }
 
-        guard let session = try? store.recordingSession(requestID: request.id),
+        guard var session = try? store.recordingSession(requestID: request.id),
               let audioFileName = session.audioFileName,
               let audioURL = try? store.audioFileURL(fileName: audioFileName),
               FileManager.default.fileExists(atPath: audioURL.path)
@@ -1463,6 +2147,19 @@ final class DictationCoordinator {
             requestID: request.id
         )
         guard let lifecycleRunnerID = voiceNoteLifecycleRunner?.id,
+              let persisted = try? store.transitionVoiceNoteSession(
+                  id: session.id,
+                  expectedPhases: [.recording, .interrupted, .transcriptionQueued, .transcribing, .failed],
+                  update: { recovered in
+                      recovered.phase = .transcribing
+                      recovered.endedAt = recovered.endedAt
+                          ?? recovered.captureInterruptedAt
+                          ?? .now
+                      recovered.protectedAudioUntilTranscriptCompletes = true
+                      recovered.lastTranscriptionAttemptAt = .now
+                      recovered.errorMessage = nil
+                  }
+              ),
               transitionVoiceNoteLifecycle(.retryRequested(session.id)),
               transitionVoiceNoteLifecycle(.transcriptionStarted(session.id))
         else {
@@ -1471,6 +2168,8 @@ final class DictationCoordinator {
             activeSession = nil
             return true
         }
+        session = persisted
+        activeSession = persisted
         statusText = "Transcribing"
         try? store.saveStatus(.init(requestID: request.id, phase: .transcribing, message: "Recovering transcription"))
         saveKeyboardHandoff(
@@ -1889,7 +2588,7 @@ final class DictationCoordinator {
             }
             for session in persistedSessions where session.kind == .meeting {
                 switch session.phase {
-                case .recording, .transcribing:
+                case .recording, .interrupted, .transcribing:
                     recoverPersistedMeeting(session, reason: "orphaned_\(session.phase.rawValue)")
                 case .transcriptionQueued, .completed, .failed, .cancelled:
                     break
@@ -1937,9 +2636,20 @@ final class DictationCoordinator {
             return
         }
 
-        if reason == "foreground", !meetingRecorder.isCapturingAudio {
+        if reason == "foreground", !meetingRecorder.isReceivingAudio(maximumAge: 1.5) {
             do {
-                _ = try meetingRecorder.resumeIfNeeded(routeStage: "meeting foreground recovery")
+                _ = try meetingRecorder.resumeIfNeeded(
+                    routeStage: "meeting foreground recovery",
+                    rebuildGraph: true
+                )
+                if let operationID = meetingLifecycleRunner?.id {
+                    scheduleMeetingCaptureHealthProof(
+                        recorder: meetingRecorder,
+                        sessionID: persistedSession.id,
+                        operationID: operationID,
+                        reason: "foreground_resume"
+                    )
+                }
             } catch {
                 recoverPersistedMeeting(persistedSession, reason: "foreground_resume_failed")
                 finishMeetingLifecycle(sessionID: sessionID)
@@ -1983,6 +2693,7 @@ final class DictationCoordinator {
     }
 
     private func stopOrphanedMeetingCapture() {
+        cancelMeetingCaptureRecoveryTasks()
         meetingVadController?.stop()
         meetingRecorder?.cancel()
         meetingRecorder = nil
@@ -1990,6 +2701,136 @@ final class DictationCoordinator {
         stopMetering()
         cleanupMeetingChunks(cancelTasks: true)
         meetingStatusText = "Meeting recording recovered"
+    }
+
+    private func cancelMeetingCaptureRecoveryTasks() {
+        meetingCaptureGraphRecoveryID = nil
+        meetingCaptureGraphRecoveryTask?.cancel()
+        meetingCaptureGraphRecoveryTask = nil
+        meetingCaptureHealthCheckID = nil
+        meetingCaptureHealthCheckTask?.cancel()
+        meetingCaptureHealthCheckTask = nil
+    }
+
+    private func scheduleMeetingCaptureGraphRecovery(reason: String) {
+        guard meetingCaptureGraphRecoveryTask == nil,
+              meetingCaptureHealthCheckTask == nil,
+              let recorder = meetingRecorder,
+              let sessionID = meetingLifecycleState.activeSessionID,
+              let operationID = meetingLifecycleRunner?.id
+        else { return }
+
+        recorder.invalidateInputHealth()
+        meetingCaptureHealthCheckID = nil
+        meetingCaptureHealthCheckTask?.cancel()
+        meetingCaptureHealthCheckTask = nil
+        let recoveryID = UUID()
+        meetingCaptureGraphRecoveryID = recoveryID
+        meetingCaptureGraphRecoveryTask = Task { @MainActor [weak self, weak recorder] in
+            guard let self else { return }
+            defer {
+                if self.meetingCaptureGraphRecoveryID == recoveryID {
+                    self.meetingCaptureGraphRecoveryID = nil
+                    self.meetingCaptureGraphRecoveryTask = nil
+                }
+            }
+            guard let recorder else { return }
+
+            let retryDelays: [Duration] = [.zero, .milliseconds(250), .milliseconds(750)]
+            var lastError: Error?
+            for delay in retryDelays {
+                do {
+                    if delay != .zero {
+                        try await Task.sleep(for: delay)
+                    } else {
+                        await Task.yield()
+                    }
+                    guard self.meetingRecorder === recorder,
+                          self.isCurrentMeetingLifecycle(
+                            sessionID: sessionID,
+                            operationID: operationID
+                          ),
+                          self.meetingLifecycleState.isRecording
+                    else { return }
+
+                    if try recorder.resumeIfNeeded(
+                        routeStage: "meeting \(reason) recovery",
+                        rebuildGraph: true
+                    ) {
+                        self.scheduleMeetingCaptureHealthProof(
+                            recorder: recorder,
+                            sessionID: sessionID,
+                            operationID: operationID,
+                            reason: reason
+                        )
+                        return
+                    }
+                } catch is CancellationError {
+                    return
+                } catch {
+                    lastError = error
+                }
+            }
+
+            AppTelemetry.failure(
+                "meeting_capture_graph_recovery_failed",
+                domain: .audio,
+                stage: reason,
+                error: lastError,
+                reason: "recorder_did_not_resume"
+            )
+            self.handleMeetingRecordingInterruption(
+                message: "Meeting audio could not resume after an input change",
+                cause: .system
+            )
+        }
+    }
+
+    private func scheduleMeetingCaptureHealthProof(
+        recorder: StreamingMeetingRecorder,
+        sessionID: UUID,
+        operationID: UUID,
+        reason: String
+    ) {
+        meetingCaptureHealthCheckID = nil
+        meetingCaptureHealthCheckTask?.cancel()
+        meetingCaptureHealthCheckTask = nil
+        let healthCheckID = UUID()
+        meetingCaptureHealthCheckID = healthCheckID
+        meetingCaptureHealthCheckTask = Task { @MainActor [weak self, weak recorder] in
+            guard let self else { return }
+            defer {
+                if self.meetingCaptureHealthCheckID == healthCheckID {
+                    self.meetingCaptureHealthCheckID = nil
+                    self.meetingCaptureHealthCheckTask = nil
+                }
+            }
+            do {
+                try await Task.sleep(for: .seconds(2))
+            } catch {
+                return
+            }
+            guard let recorder,
+                  self.meetingRecorder === recorder,
+                  self.isCurrentMeetingLifecycle(
+                    sessionID: sessionID,
+                    operationID: operationID
+                  ),
+                  self.meetingLifecycleState.isRecording
+            else { return }
+            guard !recorder.isReceivingAudio(maximumAge: 1.5) else { return }
+
+            AppTelemetry.failure(
+                "meeting_capture_health_proof_failed",
+                domain: .audio,
+                stage: reason,
+                reason: "no_recent_durable_input"
+            )
+            self.handleMeetingRecordingInterruption(
+                message: "Meeting audio did not resume after interruption",
+                cause: .system
+            )
+        }
     }
 
     private func transcriptsBySessionID(_ transcripts: [Transcript]) -> [UUID: Transcript] {
@@ -2204,6 +3045,29 @@ final class DictationCoordinator {
         session.lastTranscriptionAttemptAt = .now
         session.errorMessage = nil
         try? store.saveSession(session)
+        if session.isKeyboardOwnedVoiceNote {
+            let current = try? store.keyboardHandoffState()
+            let retryAttempt = max(
+                session.transcriptionRetryCount,
+                (current?.recoveryAttemptCount ?? 0) + 1
+            )
+            let retrying = if let current, current.requestID == requestID {
+                current.advanced(
+                    to: .transcribingStarted,
+                    message: "Retrying transcription",
+                    recoveryAttemptCount: retryAttempt
+                )
+            } else {
+                KeyboardHandoffState(
+                    requestID: requestID,
+                    phase: .transcribingStarted,
+                    message: "Retrying transcription",
+                    recoveryAttemptCount: retryAttempt,
+                    createdAt: session.createdAt
+                )
+            }
+            _ = try? store.saveKeyboardHandoffState(retrying)
+        }
         activeSession = session
         statusText = "Preparing audio"
         AppTelemetry.contextualSignal(
@@ -2213,8 +3077,8 @@ final class DictationCoordinator {
 
         let task = Task { @MainActor [weak self] in
             guard let self else { return }
-            beginTranscriptionBackgroundTask()
-            defer { endTranscriptionBackgroundTask() }
+            let backgroundLeaseID = beginTranscriptionBackgroundTask(owner: .voiceNote(sessionID))
+            defer { endTranscriptionBackgroundTask(leaseID: backgroundLeaseID) }
             var session = session
             do {
                 var usableURL = audioURL
@@ -2276,9 +3140,6 @@ final class DictationCoordinator {
                     createdAt: existingTranscript?.createdAt ?? .now,
                     engineIdentifier: engine.identifier
                 )
-                try store.saveTranscript(transcript)
-                cacheTranscript(transcript)
-
                 session.phase = .completed
                 session.endedAt = session.endedAt ?? .now
                 session.transcriptID = transcript.id
@@ -2287,9 +3148,10 @@ final class DictationCoordinator {
                 session.protectedAudioUntilTranscriptCompletes = false
                 session.hasDurableAudioCheckpoint = false
                 session.lastTranscriptionFailureReason = nil
-                cleanupNonRetainedAudio(for: &session)
-                try store.saveSession(session)
-                try? await voiceNoteCheckpointStore.delete(sessionID: sessionID)
+                session.captureInterruptionReason = nil
+                session.captureInterruptedAt = nil
+                session.draftTranscriptText = nil
+                session.draftTranscriptUpdatedAt = nil
 
                 let existingResult = try? store.result(for: requestID)
                 let result = DictationResult(
@@ -2301,12 +3163,36 @@ final class DictationCoordinator {
                     engineIdentifier: engine.identifier,
                     source: session.source
                 )
-                try store.saveResult(result)
+                guard try store.completeVoiceNoteSession(
+                    session,
+                    transcript: transcript,
+                    result: result,
+                    expectedPhase: .transcribing,
+                    keyboardHandoffState: session.isKeyboardOwnedVoiceNote
+                        ? makeKeyboardHandoffState(
+                            requestID: requestID,
+                            phase: .resultReady,
+                            message: "Ready to insert"
+                        )
+                        : nil
+                ) else {
+                    throw VoiceNoteCaptureFailure.invalidLifecycleTransition
+                }
+                cacheTranscript(transcript)
+                refreshHistory()
+
+                // The transcript, session, and result are now durably committed.
+                // Audio/checkpoint cleanup is deliberately best-effort so a crash
+                // cannot remove the only recovery evidence before completion lands.
+                if let committedSession = try? store.recordingSession(id: sessionID) {
+                    session = committedSession
+                    cleanupCommittedVoiceNoteAudio(for: &session)
+                }
+                try? await voiceNoteCheckpointStore.delete(sessionID: sessionID)
                 scheduleICloudSyncAfterLocalChange(reason: "long_voice_note_recovered")
                 activeSession = nil
                 statusText = "Ready"
                 finishVoiceNoteLifecycle(sessionID: sessionID)
-                refreshHistory()
             } catch is CancellationError {
                 guard isCurrentVoiceNoteLifecycle(
                     sessionID: sessionID,
@@ -2798,6 +3684,8 @@ final class DictationCoordinator {
 
     private func stopKeyboardSessionMode(reason: KeyboardSessionStopReason = .stopped) {
         stopKeyboardSessionAfterCurrentRequest = false
+        keyboardStandbyRecoveryTask?.cancel()
+        keyboardStandbyRecoveryTask = nil
         keyboardSessionRetryTask?.cancel()
         keyboardSessionRetryTask = nil
         keyboardSessionRetryAttempt = 0
@@ -3335,23 +4223,35 @@ final class DictationCoordinator {
     private func startCheckpointingDictationRecorder(
         audioURL: URL,
         sessionID: UUID,
+        requestID: UUID,
         enablesRealtimeTranscription: Bool,
         usesDurableCheckpoints: Bool
     ) async throws {
         realtimeDictationCommittedText = ""
         liveDictationTranscript = ""
         clearKeyboardLiveTranscript()
+        let callbackContext = RealtimeDictationCallbackContext(
+            sessionID: sessionID,
+            requestID: requestID
+        )
+        realtimeDictationCallbackContext = callbackContext
         if enablesRealtimeTranscription {
             await engine.selectModel(selectedTranscriptionModel)
             try await engine.startRealtimeSession(
-                partialTranscript: { [weak self] partial in
+                partialTranscript: { [weak self, callbackContext] partial in
                     Task { @MainActor in
-                        self?.updateRealtimeDictationPartial(partial)
+                        self?.updateRealtimeDictationPartial(
+                            partial,
+                            context: callbackContext
+                        )
                     }
                 },
-                endOfUtterance: { [weak self] utterance in
+                endOfUtterance: { [weak self, callbackContext] utterance in
                     Task { @MainActor in
-                        self?.commitRealtimeDictationUtterance(utterance)
+                        self?.commitRealtimeDictationUtterance(
+                            utterance,
+                            context: callbackContext
+                        )
                     }
                 }
             )
@@ -3367,9 +4267,17 @@ final class DictationCoordinator {
         }
 
         let streamingRecorder = StreamingMeetingRecorder()
-        streamingRecorder.onRecordingFailure = { [weak self] failure in
+        streamingRecorder.onRecordingFailure = {
+            [weak self, weak streamingRecorder, sessionID, requestID] failure, captureID in
             Task { @MainActor in
-                self?.handleVoiceNoteWriterFailure(failure)
+                guard let self,
+                      streamingRecorder?.isActiveCapture(captureID) == true
+                else { return }
+                self.handleVoiceNoteWriterFailure(
+                    failure,
+                    expectedSessionID: sessionID,
+                    expectedRequestID: requestID
+                )
             }
         }
         if enablesRealtimeTranscription {
@@ -3383,8 +4291,18 @@ final class DictationCoordinator {
                     do {
                         try await engine.processRealtimeAudioBuffer(audioBuffer.buffer)
                     } catch is CancellationError {
+                        guard !Task.isCancelled else { return }
+                        pipe.markLossy()
+                        AppTelemetry.failure(
+                            "realtime_dictation_buffer_cancelled",
+                            domain: .transcription,
+                            stage: "streaming_buffer",
+                            reason: "engine_cancelled_without_task_cancellation",
+                            parameters: ["surface": "dictation"]
+                        )
                         return
                     } catch {
+                        pipe.markLossy()
                         AppTelemetry.failure(
                             "realtime_dictation_buffer_failed",
                             domain: .transcription,
@@ -3407,7 +4325,11 @@ final class DictationCoordinator {
         isRealtimeDictationSessionActive = enablesRealtimeTranscription
     }
 
-    private func updateRealtimeDictationPartial(_ partial: String) {
+    private func updateRealtimeDictationPartial(
+        _ partial: String,
+        context: RealtimeDictationCallbackContext
+    ) {
+        guard acceptsRealtimeDictationCallback(context) else { return }
         let partial = partial.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !partial.isEmpty else { return }
 
@@ -3420,7 +4342,11 @@ final class DictationCoordinator {
         saveKeyboardLiveTranscript(text: liveDictationTranscript, isFinal: false)
     }
 
-    private func commitRealtimeDictationUtterance(_ utterance: String) {
+    private func commitRealtimeDictationUtterance(
+        _ utterance: String,
+        context: RealtimeDictationCallbackContext
+    ) {
+        guard acceptsRealtimeDictationCallback(context) else { return }
         let utterance = utterance.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !utterance.isEmpty else { return }
 
@@ -3431,7 +4357,29 @@ final class DictationCoordinator {
             realtimeDictationCommittedText = "\(committed) \(utterance)"
         }
         liveDictationTranscript = realtimeDictationCommittedText
-        saveKeyboardLiveTranscript(text: liveDictationTranscript, isFinal: false)
+        saveKeyboardLiveTranscript(
+            text: liveDictationTranscript,
+            isFinal: false,
+            forceDraftPersistence: true
+        )
+    }
+
+    private func acceptsRealtimeDictationCallback(
+        _ context: RealtimeDictationCallbackContext
+    ) -> Bool {
+        guard realtimeDictationCallbackContext == context,
+              isRecording,
+              activeRequest?.id == context.requestID,
+              activeSession?.id == context.sessionID,
+              activeSession?.requestID == context.requestID,
+              let runner = voiceNoteLifecycleRunner
+        else { return false }
+
+        return isCurrentVoiceNoteLifecycle(
+            sessionID: context.sessionID,
+            requestID: context.requestID,
+            runnerID: runner.id
+        ) && voiceNoteLifecycleState.isRecording
     }
 
     private func startRecording(for request: DictationRequest, source: String) {
@@ -3464,9 +4412,14 @@ final class DictationCoordinator {
         }
         activeRequest = request
         let usesKeyboardSessionLiveActivity = source == "keyboard" && isKeyboardSessionArmed
+        if source == "keyboard" {
+            keyboardCrossProcessSmoothedLevel = 0
+            keyboardWaveformLevelThrottle = MuesliWaveformLevelThrottle()
+        }
         setUsesKeyboardSessionLiveActivity(usesKeyboardSessionLiveActivity, for: request.id)
         liveDictationTranscript = ""
         realtimeDictationCommittedText = ""
+        voiceNoteDraftLastPersistedAt = .distantPast
         clearKeyboardLiveTranscript()
         let kind: RecordingSessionKind = source == "keyboard" ? .keyboardDictation : .quickDictation
         let longModeThreshold = configuredLongVoiceNoteThreshold()
@@ -3495,42 +4448,48 @@ final class DictationCoordinator {
                 if !usesKeyboardSessionLiveActivity, keyboardSessionKeeper.isRunning {
                     keyboardSessionKeeper.stop(deactivateSession: true)
                     transitionKeyboardSession(.requestFinished)
-                    try? store.clearKeyboardRuntimeStatus()
+                    keyboardRuntimeStatusWriter.clear()
                     try? await Task.sleep(for: .milliseconds(150))
                 }
                 if usesKeyboardSessionLiveActivity {
-                    if !keyboardSessionKeeper.canAcceptStartCommand {
-                        if !keyboardSessionKeeper.isRunning {
-                            try await keyboardSessionKeeper.start()
-                        }
-                        guard await keyboardSessionKeeper.waitUntilCanAcceptStartCommand() else {
-                            throw AudioRecorder.RecordingError.startFailed(stage: "keyboard session input")
-                        }
-                        transitionKeyboardSession(.startSucceeded)
+                    // Prepare storage before the final readiness check. No async
+                    // suspension may sit between proving the standby tap is alive
+                    // and atomically attaching its writer.
+                    let checkpointDirectory = try await voiceNoteCheckpointStore.prepare(
+                        sessionID: session.id,
+                        startedAt: session.startedAt ?? session.createdAt
+                    )
+                    keyboardStandbyRecoveryTask?.cancel()
+                    keyboardStandbyRecoveryTask = nil
+                    // `isRunning` is not a readiness signal: a stale standby graph
+                    // can remain running after lock/route changes while its tap is
+                    // dead. Reconcile it and require a fresh converted input buffer
+                    // before opening the recording segment.
+                    guard await ensureKeyboardSessionKeeperRunning(publishReady: false) else {
+                        throw AudioRecorder.RecordingError.startFailed(stage: "keyboard session input")
                     }
-                    let checkpointDirectory: URL?
-                    if longModeThreshold != nil {
-                        checkpointDirectory = try await voiceNoteCheckpointStore.prepare(
-                            sessionID: session.id,
-                            startedAt: session.startedAt ?? session.createdAt
-                        )
-                    } else {
-                        checkpointDirectory = nil
-                    }
+                    // The keeper rechecks liveness while holding its graph lock, so
+                    // a route/config event cannot slip between this check and writer
+                    // attachment. Checkpointing begins at the first captured frame.
                     try keyboardSessionKeeper.beginSegment(
                         outputURL: audioURL,
                         checkpointDirectory: checkpointDirectory
                     )
                     transitionKeyboardSession(.recordingStarted(request.id))
-                } else if selectedTranscriptionModel.supportsRealtimeStreaming || longModeThreshold != nil {
+                } else {
+                    // Voice-note capture always uses the engine-backed writer. Keeping a
+                    // second AVAudioRecorder path made interruption recovery depend on an
+                    // object that can remain `isRecording == true` after its input has
+                    // died and cannot be recreated without splitting/truncating the WAV.
+                    // One recorder architecture gives every voice note the same
+                    // checkpoint, graph-rebuild, and media-services-reset guarantees.
                     try await startCheckpointingDictationRecorder(
                         audioURL: audioURL,
                         sessionID: session.id,
+                        requestID: request.id,
                         enablesRealtimeTranscription: selectedTranscriptionModel.supportsRealtimeStreaming,
-                        usesDurableCheckpoints: longModeThreshold != nil
+                        usesDurableCheckpoints: true
                     )
-                } else {
-                    try recorder.start(outputURL: audioURL)
                 }
                 refreshAudioInputRoute()
                 activeSession = session
@@ -3563,7 +4522,7 @@ final class DictationCoordinator {
                 startMetering { [weak self] level in
                     guard let self else { return }
                     self.inputLevel = level
-                    if source == "keyboard" {
+                    if source == "keyboard", !usesKeyboardSessionLiveActivity {
                         self.publishKeyboardRuntimeLevel(level, requestID: request.id)
                     }
                 }
@@ -3595,9 +4554,7 @@ final class DictationCoordinator {
                 cleanupNonRetainedAudio(for: &session)
                 try? store.saveSession(session)
                 cleanupRealtimeDictationRecorder()
-                if session.longFormThresholdSeconds != nil {
-                    try? await voiceNoteCheckpointStore.delete(sessionID: session.id)
-                }
+                try? await voiceNoteCheckpointStore.delete(sessionID: session.id)
                 finishVoiceNoteLifecycle(sessionID: session.id)
                 activeSession = nil
                 activeRequest = nil
@@ -3623,9 +4580,7 @@ final class DictationCoordinator {
                 )
                 try? store.saveStatus(.init(requestID: request.id, phase: .failed, message: error.localizedDescription))
                 if source == "keyboard" {
-                    if let command = try? store.pendingCommand(), command.requestID == request.id {
-                        try? store.clearPendingCommand()
-                    }
+                    clearPendingKeyboardCommand(requestID: request.id)
                     saveKeyboardHandoff(
                         requestID: request.id,
                         phase: .failed,
@@ -3647,24 +4602,32 @@ final class DictationCoordinator {
         audioURL: URL,
         lifecycleRunnerID: UUID
     ) {
-        beginTranscriptionBackgroundTask()
+        let backgroundLeaseID = beginTranscriptionBackgroundTask(owner: .voiceNote(session.id))
         let task = Task {
-            defer { endTranscriptionBackgroundTask() }
+            defer { endTranscriptionBackgroundTask(leaseID: backgroundLeaseID) }
 
             do {
+                var usableAudioURL = audioURL
+                if !(await voiceNoteCheckpointStore.isReadableAudio(at: usableAudioURL)) {
+                    usableAudioURL = try await voiceNoteCheckpointStore.reconstructAudio(
+                        sessionID: session.id,
+                        destinationURL: audioURL
+                    )
+                }
                 await engine.selectModel(selectedTranscriptionModel)
                 guard isCurrentVoiceNoteLifecycle(
                     sessionID: session.id,
                     requestID: request.id,
                     runnerID: lifecycleRunnerID
                 ) else { return }
+                let transcriptionURL = usableAudioURL
                 saveKeyboardHandoff(
                     requestID: request.id,
                     phase: .transcribingStarted,
                     message: "Recovering transcription"
                 )
                 let outcome = try await runOfflineTranscriptionJob(
-                    audioURL: audioURL,
+                    audioURL: transcriptionURL,
                     onProgress: { [weak self] update in
                         guard let self,
                               self.isCurrentVoiceNoteLifecycle(
@@ -3687,7 +4650,7 @@ final class DictationCoordinator {
                     },
                     onTimeout: {}
                 ) { [engine] progress in
-                    try await engine.transcribe(audioURL: audioURL, progress: progress)
+                    try await engine.transcribe(audioURL: transcriptionURL, progress: progress)
                 }
                 guard case .completed(let rawText) = outcome else {
                     throw VoiceNoteRetryError.timeout
@@ -3703,9 +4666,6 @@ final class DictationCoordinator {
                     text: text,
                     engineIdentifier: engine.identifier
                 )
-                try store.saveTranscript(savedTranscript)
-                cacheTranscript(savedTranscript)
-
                 var completedSession = session
                 completedSession.phase = .completed
                 completedSession.endedAt = completedSession.endedAt ?? .now
@@ -3715,13 +4675,10 @@ final class DictationCoordinator {
                 completedSession.protectedAudioUntilTranscriptCompletes = false
                 completedSession.hasDurableAudioCheckpoint = false
                 completedSession.lastTranscriptionFailureReason = nil
-                cleanupNonRetainedAudio(for: &completedSession)
-                try store.saveSession(completedSession)
-                if completedSession.longFormThresholdSeconds != nil {
-                    try? await voiceNoteCheckpointStore.delete(sessionID: completedSession.id)
-                }
-                finishVoiceNoteLifecycle(sessionID: completedSession.id)
-                exportRetainedAudioIfNeeded(for: completedSession)
+                completedSession.captureInterruptionReason = nil
+                completedSession.captureInterruptedAt = nil
+                completedSession.draftTranscriptText = nil
+                completedSession.draftTranscriptUpdatedAt = nil
 
                 let existingResult = try? store.result(for: request.id)
                 let result = DictationResult(
@@ -3733,17 +4690,42 @@ final class DictationCoordinator {
                     engineIdentifier: engine.identifier,
                     source: completedSession.source
                 )
-                try store.saveResult(result)
+                guard try store.completeVoiceNoteSession(
+                    completedSession,
+                    transcript: savedTranscript,
+                    result: result,
+                    expectedPhase: .transcribing,
+                    keyboardHandoffState: completedSession.isKeyboardOwnedVoiceNote
+                        ? makeKeyboardHandoffState(
+                            requestID: request.id,
+                            phase: .resultReady,
+                            message: "Ready to insert"
+                        )
+                        : nil
+                ) else {
+                    throw VoiceNoteCaptureFailure.invalidLifecycleTransition
+                }
+                cacheTranscript(savedTranscript)
+                refreshHistory()
+
+                // Completion is atomic; retained evidence is only removed after
+                // the result is visible and is safe to retry if cleanup is cut short.
+                if let committed = try? store.recordingSession(id: completedSession.id) {
+                    completedSession = committed
+                    cleanupCommittedVoiceNoteAudio(for: &completedSession)
+                }
+                try? await voiceNoteCheckpointStore.delete(sessionID: completedSession.id)
+                finishVoiceNoteLifecycle(sessionID: completedSession.id)
+                exportRetainedAudioIfNeeded(for: completedSession)
                 scheduleICloudSyncAfterLocalChange(reason: "dictation_completed")
                 saveKeyboardLiveTranscript(text: text, isFinal: true)
-                saveKeyboardHandoff(requestID: request.id, phase: .resultReady, message: "Ready to insert")
-                try store.clearPendingRequest()
+                _ = try? store.clearPendingRequest(id: request.id)
+                clearPendingKeyboardCommand(requestID: request.id)
                 activeRequest = nil
                 activeSession = nil
                 let completedDeferredStop = completeDeferredKeyboardSessionStopIfNeeded()
                 transitionKeyboardSession(.requestFinished)
                 statusText = "Ready"
-                refreshHistory()
                 if !completedDeferredStop {
                     saveKeyboardRuntimeStatus(
                         isActive: canStartKeyboardRequestsInBackground,
@@ -3785,8 +4767,8 @@ final class DictationCoordinator {
                 )
                 activeRequest = nil
                 activeSession = nil
-                try? store.clearPendingRequest()
-                try? store.clearPendingCommand()
+                _ = try? store.clearPendingRequest(id: request.id)
+                clearPendingKeyboardCommand(requestID: request.id)
                 let completedDeferredStop = completeDeferredKeyboardSessionStopIfNeeded()
                 transitionKeyboardSession(.requestFinished)
                 statusText = error.localizedDescription
@@ -3870,6 +4852,11 @@ final class DictationCoordinator {
             lifecycleRunnerID = nil
         }
         isRecording = false
+        // Audio finalization may flush engine callbacks after Stop. They belong
+        // to the completed capture, not to the mutable live presentation (and
+        // especially not to a subsequent request), so revoke their generation
+        // before crossing the first suspension point in finalization.
+        realtimeDictationCallbackContext = nil
         stopMetering()
         stopRecordingTimer()
         statusText = "Saving audio"
@@ -3892,9 +4879,16 @@ final class DictationCoordinator {
             )
         }
         if var session {
-            session.phase = .transcriptionQueued
             session.endedAt = .now
-            try? store.saveSession(session)
+            if let persisted = try? store.transitionVoiceNoteSession(
+                id: session.id,
+                expectedPhases: [.recording, .interrupted],
+                update: { persisted in
+                    persisted.endedAt = session.endedAt
+                }
+            ) {
+                session = persisted
+            }
             activeSession = session
             Task {
                 if usesKeyboardSessionLiveActivity {
@@ -3912,10 +4906,12 @@ final class DictationCoordinator {
             }
         }
 
-        beginTranscriptionBackgroundTask()
+        let backgroundLeaseID = beginTranscriptionBackgroundTask(
+            owner: .voiceNote(session?.id ?? request.id)
+        )
         let transcriptionTask = Task {
             defer {
-                endTranscriptionBackgroundTask()
+                endTranscriptionBackgroundTask(leaseID: backgroundLeaseID)
             }
             let startedFromKeyboard = isKeyboardHandoffActive
 
@@ -3926,6 +4922,7 @@ final class DictationCoordinator {
                 var finalCheckpoint: MeetingAudioChunk?
                 var finalWriterFailure: CheckpointingAudioWriterFailure?
                 var realtimeText = ""
+                var realtimeAudioWasLossy = false
 
                 if usesKeyboardSessionLiveActivity {
                     let segment = try keyboardSessionKeeper.finishSegment()
@@ -3938,8 +4935,10 @@ final class DictationCoordinator {
                     finalCheckpoint = stoppedAudio?.finalChunk
                     finalWriterFailure = stoppedAudio?.writerFailure
                     if usesRealtimeStreaming {
-                        realtimeDictationBufferPipe?.finish()
+                        let bufferPipe = realtimeDictationBufferPipe
+                        bufferPipe?.finish()
                         await realtimeDictationProcessingTask?.value
+                        realtimeAudioWasLossy = bufferPipe?.hasDroppedBuffers == true
                     }
                     realtimeDictationProcessingTask = nil
                     realtimeDictationBufferPipe = nil
@@ -3949,14 +4948,39 @@ final class DictationCoordinator {
                     }
                     audioURL = retainedAudioURL
                     if usesRealtimeStreaming {
-                        realtimeText = postProcessTranscript(try await engine.finishRealtimeSession())
+                        do {
+                            let completedRealtimeText = postProcessTranscript(
+                                try await engine.finishRealtimeSession()
+                            )
+                            // Realtime UI is best-effort; the retained recording
+                            // is the complete authority. If backpressure dropped
+                            // or failed even one buffer while suspended, use the
+                            // durable audio for the final transcript.
+                            realtimeText = realtimeAudioWasLossy ? "" : completedRealtimeText
+                        } catch {
+                            realtimeText = ""
+                            AppTelemetry.failure(
+                                "realtime_dictation_finish_failed",
+                                domain: .transcription,
+                                stage: "streaming_finish",
+                                error: error,
+                                parameters: ["fallback": "retained_audio"]
+                            )
+                        }
                     }
                 } else {
                     audioURL = try recorder.stop()
                 }
 
-                if let currentSession = activeSession ?? session,
-                   currentSession.longFormThresholdSeconds != nil {
+                if var currentSession = activeSession ?? session {
+                    currentSession.audioFileName = audioURL.lastPathComponent
+                    // From this point onward the audio evidence, not the UI duration
+                    // threshold, controls retention until transcription succeeds.
+                    currentSession.protectedAudioUntilTranscriptCompletes = true
+                    activeSession = currentSession
+                }
+
+                if let currentSession = activeSession ?? session {
                     let manifest = try await voiceNoteCheckpointStore.finalize(
                         sessionID: currentSession.id,
                         finalCheckpoint: finalCheckpoint
@@ -3975,17 +4999,7 @@ final class DictationCoordinator {
                         && !checkpointFinalizationFailed
                     var finalizedSession = activeSession ?? currentSession
                     finalizedSession.hasDurableAudioCheckpoint = longVoiceNoteAudioIsSecured
-                    if finalizedSession.isLongForm {
-                        finalizedSession.protectedAudioUntilTranscriptCompletes =
-                            longVoiceNoteAudioIsSecured
-                    }
                     activeSession = finalizedSession
-                    try? store.saveSession(finalizedSession)
-                    guard transitionVoiceNoteLifecycle(.audioFinalized(currentSession.id)),
-                          transitionVoiceNoteLifecycle(.transcriptionQueued(currentSession.id))
-                    else {
-                        throw VoiceNoteCaptureFailure.invalidLifecycleTransition
-                    }
                     if currentSession.isLongForm, !manifest.entries.isEmpty {
                         var checkpointParameters = voiceNoteTelemetryParameters(
                             session: currentSession,
@@ -4021,10 +5035,44 @@ final class DictationCoordinator {
                               runnerID: lifecycleRunnerID
                           )
                     else { return }
-                    currentSession.phase = .transcribing
+                    guard let queuedSession = try store.transitionVoiceNoteSession(
+                        id: currentSession.id,
+                        expectedPhases: [.recording, .interrupted],
+                        update: { persisted in
+                            persisted.phase = .transcriptionQueued
+                            persisted.endedAt = currentSession.endedAt ?? .now
+                            persisted.audioFileName = audioURL.lastPathComponent
+                            persisted.hasDurableAudioCheckpoint = currentSession.hasDurableAudioCheckpoint
+                            persisted.protectedAudioUntilTranscriptCompletes = true
+                            persisted.captureInterruptionReason = currentSession.captureInterruptionReason
+                            persisted.captureInterruptedAt = currentSession.captureInterruptedAt
+                            persisted.draftTranscriptText = currentSession.draftTranscriptText
+                            persisted.draftTranscriptUpdatedAt = currentSession.draftTranscriptUpdatedAt
+                        }
+                    ) else {
+                        throw VoiceNoteCaptureFailure.invalidLifecycleTransition
+                    }
+                    currentSession = queuedSession
+                    activeSession = currentSession
+                    guard transitionVoiceNoteLifecycle(.audioFinalized(currentSession.id)),
+                          transitionVoiceNoteLifecycle(.transcriptionQueued(currentSession.id))
+                    else {
+                        throw VoiceNoteCaptureFailure.invalidLifecycleTransition
+                    }
+
+                    guard let transcribingSession = try store.transitionVoiceNoteSession(
+                        id: currentSession.id,
+                        expectedPhases: [.transcriptionQueued],
+                        update: { persisted in
+                            persisted.phase = .transcribing
+                            persisted.lastTranscriptionAttemptAt = .now
+                        }
+                    ) else {
+                        throw VoiceNoteCaptureFailure.invalidLifecycleTransition
+                    }
+                    currentSession = transcribingSession
                     currentSession.lastTranscriptionAttemptAt = .now
                     activeSession = currentSession
-                    try? store.saveSession(currentSession)
                     guard transitionVoiceNoteLifecycle(.transcriptionStarted(currentSession.id)) else {
                         throw VoiceNoteCaptureFailure.invalidLifecycleTransition
                     }
@@ -4074,7 +5122,8 @@ final class DictationCoordinator {
                         )
                     }
                     clearKeyboardSessionLiveActivityRoute(for: request.id)
-                    try? store.clearPendingRequest()
+                    _ = try? store.clearPendingRequest(id: request.id)
+                    clearPendingKeyboardCommand(requestID: request.id)
                     try? store.saveStatus(.idle)
                     return
                 }
@@ -4082,17 +5131,12 @@ final class DictationCoordinator {
                     transitionKeyboardSession(.transcribing(request.id))
                 }
                 let completedSession = activeSession ?? session
-                let transcript: Transcript?
-                let resultCreatedAt: Date
                 if var completedSession {
-                    resultCreatedAt = completedSession.createdAt
                     let savedTranscript = Transcript(
                         sessionID: completedSession.id,
                         text: text,
                         engineIdentifier: engine.identifier
                     )
-                    try store.saveTranscript(savedTranscript)
-                    cacheTranscript(savedTranscript)
                     completedSession.phase = .completed
                     completedSession.audioFileName = completedSession.audioFileName ?? audioURL.lastPathComponent
                     completedSession.transcriptID = savedTranscript.id
@@ -4101,34 +5145,69 @@ final class DictationCoordinator {
                     completedSession.protectedAudioUntilTranscriptCompletes = false
                     completedSession.hasDurableAudioCheckpoint = false
                     completedSession.lastTranscriptionFailureReason = nil
-                    cleanupNonRetainedAudio(for: &completedSession)
-                    try store.saveSession(completedSession)
-                    if completedSession.longFormThresholdSeconds != nil {
-                        try? await voiceNoteCheckpointStore.delete(sessionID: completedSession.id)
-                        realtimeDictationChunksDirectory = nil
+                    completedSession.captureInterruptionReason = nil
+                    completedSession.captureInterruptedAt = nil
+                    completedSession.draftTranscriptText = nil
+                    completedSession.draftTranscriptUpdatedAt = nil
+
+                    let existingResult = try? store.result(for: request.id)
+                    let result = DictationResult(
+                        id: existingResult?.id ?? UUID(),
+                        requestID: request.id,
+                        sessionID: savedTranscript.sessionID,
+                        text: text,
+                        createdAt: completedSession.createdAt,
+                        engineIdentifier: engine.identifier,
+                        source: completedSession.source
+                    )
+                    guard try store.completeVoiceNoteSession(
+                        completedSession,
+                        transcript: savedTranscript,
+                        result: result,
+                        expectedPhase: .transcribing,
+                        keyboardHandoffState: startedFromKeyboard
+                            ? makeKeyboardHandoffState(
+                                requestID: request.id,
+                                phase: .resultReady,
+                                message: "Ready to insert"
+                            )
+                            : nil
+                    ) else {
+                        throw VoiceNoteCaptureFailure.invalidLifecycleTransition
                     }
+                    cacheTranscript(savedTranscript)
+                    refreshHistory()
+
+                    // Cleanup follows the atomic result commit. If the process is
+                    // suspended here, recovery evidence may leak temporarily but
+                    // the completed voice note cannot disappear from history.
+                    if let committed = try? store.recordingSession(id: completedSession.id) {
+                        completedSession = committed
+                        cleanupCommittedVoiceNoteAudio(for: &completedSession)
+                    }
+                    try? await voiceNoteCheckpointStore.delete(sessionID: completedSession.id)
+                    realtimeDictationChunksDirectory = nil
                     exportRetainedAudioIfNeeded(for: completedSession)
-                    transcript = savedTranscript
                 } else {
-                    resultCreatedAt = request.createdAt
-                    transcript = nil
+                    // Preserve the legacy request path that predates persisted
+                    // recording sessions; there is no session row to atomically CAS.
+                    let result = DictationResult(
+                        requestID: request.id,
+                        sessionID: nil,
+                        text: text,
+                        createdAt: request.createdAt,
+                        engineIdentifier: engine.identifier,
+                        source: nil
+                    )
+                    try store.saveResult(result)
+                    refreshHistory()
                 }
-                let result = DictationResult(
-                    requestID: request.id,
-                    sessionID: transcript?.sessionID,
-                    text: text,
-                    createdAt: resultCreatedAt,
-                    engineIdentifier: engine.identifier,
-                    source: completedSession?.source
-                )
-                try store.saveResult(result)
                 scheduleICloudSyncAfterLocalChange(reason: "dictation_completed")
                 if startedFromKeyboard {
                     saveKeyboardLiveTranscript(text: text, isFinal: true)
-                    saveKeyboardHandoff(requestID: request.id, phase: .resultReady, message: "Ready to insert")
                 }
-                try store.clearPendingRequest()
-                refreshHistory()
+                _ = try? store.clearPendingRequest(id: request.id)
+                clearPendingKeyboardCommand(requestID: request.id)
                 lastTranscript = text
                 activeRequest = nil
                 activeSession = nil
@@ -4219,8 +5298,8 @@ final class DictationCoordinator {
                 }
                 activeRequest = nil
                 activeSession = nil
-                try? store.clearPendingRequest()
-                try? store.clearPendingCommand()
+                _ = try? store.clearPendingRequest(id: request.id)
+                clearPendingKeyboardCommand(requestID: request.id)
                 let completedDeferredStop = completeDeferredKeyboardSessionStopIfNeeded()
                 if !completedDeferredStop {
                     saveKeyboardRuntimeStatus(
@@ -4371,7 +5450,7 @@ final class DictationCoordinator {
             if keyboardSessionKeeper.isRunning {
                 keyboardSessionKeeper.stop(deactivateSession: true)
                 transitionKeyboardSession(.requestFinished)
-                try? store.clearKeyboardRuntimeStatus()
+                keyboardRuntimeStatusWriter.clear()
                 try? await Task.sleep(for: .milliseconds(150))
             }
 
@@ -4383,9 +5462,17 @@ final class DictationCoordinator {
 
             let vadController = StreamingVadController(vadManager: vadManager)
             let streamingRecorder = StreamingMeetingRecorder()
-            streamingRecorder.onRecordingFailure = { [weak self] failure in
+            streamingRecorder.onRecordingFailure = {
+                [weak self, weak streamingRecorder, sessionID = session.id, operationID] failure, captureID in
                 Task { @MainActor in
-                    self?.handleMeetingRecordingWriterFailure(failure)
+                    guard let self,
+                          streamingRecorder?.isActiveCapture(captureID) == true
+                    else { return }
+                    self.handleMeetingRecordingWriterFailure(
+                        failure,
+                        expectedSessionID: sessionID,
+                        expectedOperationID: operationID
+                    )
                 }
             }
             vadController.onChunkBoundary = { [weak self] in
@@ -4753,8 +5840,16 @@ final class DictationCoordinator {
         }
     }
 
-    private func handleMeetingRecordingWriterFailure(_ failure: CheckpointingAudioWriterFailure) {
-        guard isMeetingRecording else { return }
+    private func handleMeetingRecordingWriterFailure(
+        _ failure: CheckpointingAudioWriterFailure,
+        expectedSessionID: UUID,
+        expectedOperationID: UUID
+    ) {
+        guard isMeetingRecording,
+              activeSession?.id == expectedSessionID,
+              meetingLifecycleRunner?.id == expectedOperationID,
+              meetingLifecycleRunner?.sessionID == expectedSessionID
+        else { return }
         meetingStatusText = "Audio could not be saved reliably. Finishing the meeting."
         AppTelemetry.failure(
             "meeting_recording_writer_failed",
@@ -4833,11 +5928,11 @@ final class DictationCoordinator {
     }
 
     private func finalizeStreamingMeeting(_ initialSession: RecordingSession, operationID: UUID) {
-        beginTranscriptionBackgroundTask()
+        let backgroundLeaseID = beginTranscriptionBackgroundTask(owner: .meeting(initialSession.id))
         let task = Task { @MainActor [weak self] in
             guard let self else { return }
             defer {
-                endTranscriptionBackgroundTask()
+                endTranscriptionBackgroundTask(leaseID: backgroundLeaseID)
             }
 
             var session = initialSession
@@ -5010,11 +6105,11 @@ final class DictationCoordinator {
             return
         }
 
-        beginTranscriptionBackgroundTask()
+        let backgroundLeaseID = beginTranscriptionBackgroundTask(owner: .meeting(session.id))
         let task = Task { @MainActor [weak self] in
             guard let self else { return }
             defer {
-                endTranscriptionBackgroundTask()
+                endTranscriptionBackgroundTask(leaseID: backgroundLeaseID)
             }
 
             do {
@@ -5496,6 +6591,35 @@ final class DictationCoordinator {
         session.audioFileName = nil
     }
 
+    private func cleanupCommittedVoiceNoteAudio(for session: inout RecordingSession) {
+        guard session.phase == .completed,
+              !session.protectedAudioUntilTranscriptCompletes,
+              !session.keepsAudioRecording,
+              let audioFileName = session.audioFileName
+        else { return }
+
+        do {
+            try store.deleteAudioFile(fileName: audioFileName)
+        } catch {
+            // Completion already succeeded. Retaining an orphaned audio file is
+            // safer than turning a post-commit housekeeping failure into data loss.
+            return
+        }
+
+        session.audioFileName = nil
+        let cleanedAudioFileName = session.audioFileName
+        let persisted = try? store.transitionVoiceNoteSession(
+            id: session.id,
+            expectedPhases: [.completed],
+            update: { stored in
+                stored.audioFileName = cleanedAudioFileName
+            }
+        )
+        if persisted != nil {
+            refreshHistory()
+        }
+    }
+
     private func clearMissingRetainedAudioReference(for session: inout RecordingSession) {
         guard session.keepsAudioRecording,
               let audioFileName = session.audioFileName,
@@ -5542,12 +6666,76 @@ final class DictationCoordinator {
     private func startSharedEventObservation() {
         sharedEventObservationTask?.cancel()
         sharedEventObservationTask = Task { @MainActor [weak self, eventBus] in
+            await self?.processPendingKeyboardCommand()
             for await event in eventBus.events() {
                 guard !Task.isCancelled, let self else { return }
                 guard event == .commandChanged else { continue }
                 await self.processPendingKeyboardCommand()
             }
         }
+
+        // Darwin notifications are lossy across process suspension. Commands are
+        // durable SQLite rows, so drain them independently while the keyboard hot
+        // mic is armed. This keeps Stop/Cancel responsive after a lock even if the
+        // one notification edge was delivered while the container was suspended.
+        keyboardCommandReconciliationTask?.cancel()
+        keyboardCommandReconciliationTask = Task { @MainActor [weak self] in
+            while !Task.isCancelled {
+                guard let self else { return }
+                if self.isKeyboardSessionArmed || self.activeRequest != nil {
+                    await self.processPendingKeyboardCommand()
+                }
+                let hasActiveRequest = self.activeRequest != nil
+                do {
+                    try await Task.sleep(for: .milliseconds(
+                        hasActiveRequest ? 350 : 2_000
+                    ))
+                } catch {
+                    return
+                }
+            }
+        }
+    }
+
+    private func handleKeyboardInputActivity(
+        powerDB: Float,
+        isCapturing: Bool,
+        segmentID: UUID?,
+        now: Date = .now
+    ) {
+        if isCapturing,
+           let segmentID,
+           keyboardSessionKeeper.isActiveSegment(segmentID),
+           isRecording,
+           let requestID = activeRequest?.id,
+           usesKeyboardSessionLiveActivity(for: requestID) {
+            let normalized = min(max((Double(powerDB) + 50) / 50, 0), 1)
+            keyboardCrossProcessSmoothedLevel = (0.48 * normalized)
+                + (0.52 * keyboardCrossProcessSmoothedLevel)
+            publishKeyboardRuntimeLevel(
+                keyboardCrossProcessSmoothedLevel,
+                requestID: requestID
+            )
+            return
+        }
+
+        guard !isCapturing,
+              isKeyboardSessionArmed,
+              activeRequest == nil,
+              !isRecording,
+              keyboardSessionKeeper.canAcceptStartCommand,
+              now.timeIntervalSince(keyboardStandbyHeartbeatLastPublishedAt) >= 0.75
+        else { return }
+
+        keyboardStandbyHeartbeatLastPublishedAt = now
+        saveKeyboardRuntimeStatus(
+            isActive: true,
+            activeRequestID: nil,
+            phase: .idle,
+            message: "Keyboard session ready",
+            supportsBackgroundStart: true,
+            inputLevel: 0
+        )
     }
 
     private func processPendingKeyboardCommand() async {
@@ -5560,7 +6748,50 @@ final class DictationCoordinator {
             requestID: command.requestID,
             action: command.action
         ) else {
-            try? store.clearPendingCommand()
+            _ = try? store.clearPendingCommand(id: command.id)
+            return
+        }
+
+        let persistedSession = try? store.recordingSession(requestID: command.requestID)
+        if keyboardIntentIsDurablySatisfied(command, session: persistedSession) {
+            _ = try? store.clearPendingCommand(id: command.id)
+            return
+        }
+
+        if command.action != .start,
+           activeRequest == nil,
+           activeSession == nil,
+           !isRecording {
+            if let persistedSession,
+               [.recording, .interrupted].contains(persistedSession.phase) {
+                // The container restarted after capture became durable. Keep the
+                // level-triggered terminal intent until launch recovery seals the
+                // evidence; the next reconciliation pass will clear it once the
+                // row becomes queued/failed/terminal.
+                recoverLongVoiceNotesIfNeeded()
+                return
+            }
+
+            let terminal = makeKeyboardHandoffState(
+                requestID: command.requestID,
+                phase: .cancelled,
+                message: command.action == .cancel
+                    ? "Cancelled"
+                    : "Stopped before recording began"
+            )
+            guard (try? store.resolveKeyboardIntent(
+                commandID: command.id,
+                requestID: command.requestID,
+                handoffState: terminal,
+                clearsPendingRequest: true
+            )) == true else { return }
+            saveKeyboardRuntimeStatus(
+                isActive: canStartKeyboardRequestsInBackground,
+                activeRequestID: nil,
+                phase: .idle,
+                message: isKeyboardSessionArmed ? "Keyboard session ready" : "Ready",
+                supportsBackgroundStart: canStartKeyboardRequestsInBackground
+            )
             return
         }
         if KeyboardCommandArbitration.shouldDeferUntilRecorderStarts(
@@ -5577,22 +6808,14 @@ final class DictationCoordinator {
         case .start:
             break
         case .stop:
-            saveKeyboardHandoff(
-                requestID: command.requestID,
-                phase: .stopAcknowledged,
-                message: "Stopping"
-            )
+            // Stop is a desired state, not a one-shot edge. Keep it durable until
+            // the session reaches transcriptionQueued/transcribing so a process
+            // death between initiating Stop and sealing audio can replay safely.
             stopRecording(requestID: command.requestID)
-            try? store.clearPendingCommand()
             return
         case .cancel:
-            saveKeyboardHandoff(
-                requestID: command.requestID,
-                phase: .cancelled,
-                message: "Cancelled"
-            )
             cancelRecording(requestID: command.requestID)
-            try? store.clearPendingCommand()
+            _ = try? store.clearPendingCommand(id: command.id)
             return
         }
 
@@ -5602,6 +6825,7 @@ final class DictationCoordinator {
             : DictationRequest(id: command.requestID)
 
         if refreshActiveKeyboardRequestIfNeeded(request) {
+            _ = try? store.clearPendingCommand(id: command.id)
             return
         }
 
@@ -5616,13 +6840,41 @@ final class DictationCoordinator {
                 phase: .failed,
                 message: "Muesli is busy"
             ))
-            try? store.clearPendingCommand()
+            _ = try? store.clearPendingCommand(id: command.id)
             return
         }
 
+        guard (try? store.clearPendingCommand(id: command.id)) == true else { return }
         transitionKeyboardSession(.handoffStarted(request.id))
         startRecording(for: request, source: "keyboard")
-        try? store.clearPendingCommand()
+    }
+
+    private func keyboardIntentIsDurablySatisfied(
+        _ command: DictationCommand,
+        session: RecordingSession?
+    ) -> Bool {
+        guard let session else { return false }
+        switch command.action {
+        case .start:
+            return [.recording, .interrupted, .transcriptionQueued, .transcribing, .completed]
+                .contains(session.phase)
+        case .stop:
+            return [.transcriptionQueued, .transcribing, .completed, .failed, .cancelled]
+                .contains(session.phase)
+        case .cancel:
+            return [.cancelled, .completed, .failed].contains(session.phase)
+        }
+    }
+
+    private func clearPendingKeyboardCommand(
+        requestID: UUID,
+        action: DictationCommandAction? = nil
+    ) {
+        guard let command = try? store.pendingCommand(),
+              command.requestID == requestID,
+              action.map({ command.action == $0 }) ?? true
+        else { return }
+        _ = try? store.clearPendingCommand(id: command.id)
     }
 
     private func publishKeyboardSessionReadyIfAvailable() {
@@ -5634,6 +6886,58 @@ final class DictationCoordinator {
             message: "Keyboard session ready",
             supportsBackgroundStart: true
         )
+    }
+
+    private func recoverKeyboardStandbyIfNeeded(recreateEngine: Bool) {
+        guard MuesliPreferences.keyboardSessionModeEnabled,
+              isKeyboardSessionArmed,
+              !isRecording,
+              !hasMeetingRecordingInProgress,
+              activeRequest == nil
+        else { return }
+
+        keyboardStandbyRecoveryTask?.cancel()
+        keyboardStandbyRecoveryTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            do {
+                guard try self.keyboardSessionKeeper.ensureReadyForStartCommand(
+                    recreateEngine: recreateEngine
+                ),
+                await self.keyboardSessionKeeper.waitUntilCanAcceptStartCommand()
+                else {
+                    throw AudioRecorder.RecordingError.startFailed(
+                        stage: "keyboard standby input"
+                    )
+                }
+                guard !Task.isCancelled,
+                      !self.isRecording,
+                      self.activeRequest == nil,
+                      self.isKeyboardSessionArmed
+                else { return }
+
+                self.keyboardStandbyRecoveryTask = nil
+                self.transitionKeyboardSession(.startSucceeded)
+                self.publishKeyboardSessionReadyIfAvailable()
+                AppTelemetry.signal(
+                    "keyboard_standby_recovered",
+                    parameters: ["engine_recreated": recreateEngine ? "true" : "false"]
+                )
+            } catch {
+                guard !Task.isCancelled else { return }
+                self.keyboardStandbyRecoveryTask = nil
+                self.transitionKeyboardSession(
+                    .retryScheduled(message: Self.keyboardSessionRetryMessage)
+                )
+                self.scheduleKeyboardSessionRetry()
+                AppTelemetry.failure(
+                    "keyboard_standby_recovery_failed",
+                    domain: .audio,
+                    stage: "standby_recovery",
+                    error: error,
+                    parameters: ["engine_recreated": recreateEngine ? "true" : "false"]
+                )
+            }
+        }
     }
 
     @discardableResult
@@ -5713,7 +7017,8 @@ final class DictationCoordinator {
         phase: DictationPhase,
         message: String?,
         supportsBackgroundStart: Bool = false,
-        inputLevel: Double? = nil
+        inputLevel: Double? = nil,
+        isRecoveringCapture: Bool = false
     ) {
         let status = keyboardRuntimeStatus(
             isActive: isActive,
@@ -5721,14 +7026,14 @@ final class DictationCoordinator {
             phase: phase,
             message: message,
             supportsBackgroundStart: supportsBackgroundStart,
-            inputLevel: inputLevel
+            inputLevel: inputLevel,
+            isRecoveringCapture: isRecoveringCapture
         )
 
-        // Lifecycle writes stay ordered behind any queued waveform samples so a
-        // stale recording level cannot overwrite a later terminal phase.
-        keyboardRuntimeStatusQueue.sync {
-            try? store.saveKeyboardRuntimeStatus(status)
-        }
+        // The coalescing serial writer preserves ordering while keeping SQLite's
+        // cross-process busy wait off the MainActor. Lifecycle states supersede
+        // queued meter samples instead of waiting behind every 20 Hz update.
+        keyboardRuntimeStatusWriter.submit(status)
     }
 
     private func keyboardRuntimeStatus(
@@ -5737,7 +7042,8 @@ final class DictationCoordinator {
         phase: DictationPhase,
         message: String?,
         supportsBackgroundStart: Bool,
-        inputLevel: Double?
+        inputLevel: Double?,
+        isRecoveringCapture: Bool = false
     ) -> KeyboardRuntimeStatus {
         let runtimeInputLevel = inputLevel ?? (phase == .recording ? self.inputLevel : 0)
         let canAcceptStartCommand = isActive
@@ -5751,12 +7057,19 @@ final class DictationCoordinator {
             message: message,
             supportsBackgroundStart: supportsBackgroundStart,
             canAcceptStartCommand: canAcceptStartCommand,
-            inputLevel: runtimeInputLevel
+            inputLevel: runtimeInputLevel,
+            isRecoveringCapture: isRecoveringCapture
         )
     }
 
     private func publishKeyboardRuntimeLevel(_ level: Double, requestID: UUID) {
-        guard activeRequest?.id == requestID, isRecording else { return }
+        guard activeRequest?.id == requestID,
+              isRecording,
+              voiceNoteLifecycleRunner?.requestID == requestID,
+              voiceNoteLifecycleState.isRecording,
+              activeSession?.requestID == requestID,
+              activeSession?.phase == .recording
+        else { return }
         guard let publishedLevel = keyboardWaveformLevelThrottle.valueToPublish(level) else { return }
         let status = keyboardRuntimeStatus(
             isActive: true,
@@ -5766,10 +7079,7 @@ final class DictationCoordinator {
             supportsBackgroundStart: false,
             inputLevel: publishedLevel
         )
-        let store = store
-        keyboardRuntimeStatusQueue.async {
-            try? store.saveKeyboardRuntimeStatus(status)
-        }
+        keyboardRuntimeStatusWriter.submit(status)
     }
 
     private func saveKeyboardHandoff(
@@ -5777,20 +7087,39 @@ final class DictationCoordinator {
         phase: KeyboardHandoffPhase,
         message: String? = nil
     ) {
-        let previous = try? store.keyboardHandoffState()
-        let state: KeyboardHandoffState
-        if let previous, previous.requestID == requestID {
-            state = previous.advanced(to: phase, message: message)
-        } else {
-            state = KeyboardHandoffState(requestID: requestID, phase: phase, message: message)
-        }
-        try? store.saveKeyboardHandoffState(state)
+        _ = try? store.saveKeyboardHandoffState(makeKeyboardHandoffState(
+            requestID: requestID,
+            phase: phase,
+            message: message
+        ))
     }
 
-    private func saveKeyboardLiveTranscript(text: String, isFinal: Bool) {
-        guard isKeyboardHandoffActive, let requestID = activeRequest?.id else { return }
+    private func makeKeyboardHandoffState(
+        requestID: UUID,
+        phase: KeyboardHandoffPhase,
+        message: String? = nil
+    ) -> KeyboardHandoffState {
+        let previous = try? store.keyboardHandoffState()
+        if let previous, previous.requestID == requestID {
+            return previous.advanced(to: phase, message: message)
+        }
+        return KeyboardHandoffState(requestID: requestID, phase: phase, message: message)
+    }
 
+    private func saveKeyboardLiveTranscript(
+        text: String,
+        isFinal: Bool,
+        forceDraftPersistence: Bool = false
+    ) {
         let cleanedText = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !isFinal {
+            persistVoiceNoteDraftIfNeeded(
+                text: cleanedText,
+                force: forceDraftPersistence
+            )
+        }
+
+        guard isKeyboardHandoffActive, let requestID = activeRequest?.id else { return }
         guard !cleanedText.isEmpty else {
             clearKeyboardLiveTranscript()
             return
@@ -5801,6 +7130,39 @@ final class DictationCoordinator {
             text: cleanedText,
             isFinal: isFinal
         ))
+    }
+
+    private func persistVoiceNoteDraftIfNeeded(text: String, force: Bool) {
+        let cleanedText = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !cleanedText.isEmpty,
+              let session = activeSession,
+              session.kind != .meeting,
+              session.requestID == activeRequest?.id
+        else { return }
+
+        let now = Date()
+        guard force
+            || session.draftTranscriptText == nil
+            || now.timeIntervalSince(voiceNoteDraftLastPersistedAt) >= 1
+        else { return }
+
+        // Drafts are capture evidence, not a whole-row last-writer-wins update.
+        // Restrict the write to durable capture phases so a delayed realtime
+        // callback can never regress a queued/completed/failed session.
+        guard let persisted = try? store.transitionVoiceNoteSession(
+            id: session.id,
+            expectedPhases: [.recording, .interrupted],
+            update: { current in
+                current.draftTranscriptText = cleanedText
+                current.draftTranscriptUpdatedAt = now
+            }
+        ) else { return }
+
+        guard activeSession?.id == persisted.id,
+              activeRequest?.id == persisted.requestID
+        else { return }
+        activeSession = persisted
+        voiceNoteDraftLastPersistedAt = now
     }
 
     private func clearKeyboardLiveTranscript() {
@@ -5875,18 +7237,93 @@ final class DictationCoordinator {
         return true
     }
 
-    private func beginTranscriptionBackgroundTask() {
+    @discardableResult
+    private func beginTranscriptionBackgroundTask(owner: TranscriptionBackgroundTaskOwner) -> UUID {
         endTranscriptionBackgroundTask()
+        let leaseID = UUID()
+        transcriptionBackgroundTaskLeaseID = leaseID
+        transcriptionBackgroundTaskOwner = owner
         transcriptionBackgroundTask = UIApplication.shared.beginBackgroundTask(withName: "MuesliTranscription") { [weak self] in
             Task { @MainActor in
-                self?.handleTranscriptionBackgroundTaskExpiration()
+                self?.handleTranscriptionBackgroundTaskExpiration(leaseID: leaseID)
             }
+        }
+        return leaseID
+    }
+
+    private func handleTranscriptionBackgroundTaskExpiration(leaseID: UUID) {
+        guard transcriptionBackgroundTaskLeaseID == leaseID else { return }
+        defer { endTranscriptionBackgroundTask(leaseID: leaseID) }
+        guard let owner = transcriptionBackgroundTaskOwner else { return }
+        switch owner {
+        case .voiceNote(let sessionID):
+            handleVoiceNoteBackgroundTaskExpiration(sessionID: sessionID)
+        case .meeting(let sessionID):
+            handleMeetingBackgroundTaskExpiration(sessionID: sessionID)
         }
     }
 
-    private func handleTranscriptionBackgroundTaskExpiration() {
-        defer { endTranscriptionBackgroundTask() }
-        guard case .transcribing(let sessionID) = meetingLifecycleState.phase,
+    private func handleVoiceNoteBackgroundTaskExpiration(sessionID: UUID) {
+        let requestID = voiceNoteLifecycleRunner?.sessionID == sessionID
+            ? voiceNoteLifecycleRunner?.requestID
+            : (try? store.activeRecordingSession(id: sessionID))?.requestID
+        voiceNoteLifecycleRunner?.cancelAll()
+        let persisted = try? store.activeRecordingSession(id: sessionID)
+        let expectedPhases: Set<RecordingSessionPhase> = [.recording, .interrupted, .transcriptionQueued, .transcribing]
+        let recovered = try? store.transitionVoiceNoteSession(
+            id: sessionID,
+            expectedPhases: expectedPhases,
+            update: { session in
+                session.phase = .failed
+                session.endedAt = session.endedAt ?? session.captureInterruptedAt ?? .now
+                session.lastTranscriptionFailureReason = .interrupted
+                session.protectedAudioUntilTranscriptCompletes =
+                    session.protectedAudioUntilTranscriptCompletes
+                    || session.audioFileName != nil
+                    || session.hasDurableAudioCheckpoint
+                session.errorMessage = "Processing paused in the background. Muesli kept the recovery files."
+            }
+        )
+        if voiceNoteLifecycleState.activeSessionID == sessionID {
+            switch voiceNoteLifecycleState.phase {
+            case .recordingShort, .recordingLongProtected,
+                 .interruptedShort, .interruptedLongProtected:
+                _ = transitionVoiceNoteLifecycle(.stopRequested(sessionID))
+            default:
+                break
+            }
+            _ = transitionVoiceNoteLifecycle(.transcriptionFailed(sessionID))
+            finishVoiceNoteLifecycle(sessionID: sessionID)
+        }
+        isRecording = false
+        stopMetering()
+        stopRecordingTimer()
+        if activeSession?.id == sessionID {
+            activeSession = nil
+        }
+        if activeRequest?.id == requestID {
+            activeRequest = nil
+        }
+        if let requestID {
+            _ = try? store.clearPendingRequest(id: requestID)
+            clearPendingKeyboardCommand(requestID: requestID)
+            clearKeyboardSessionLiveActivityRoute(for: requestID)
+            saveKeyboardHandoff(
+                requestID: requestID,
+                phase: .failed,
+                message: recovered?.errorMessage ?? persisted?.errorMessage ?? "Voice note recovery saved"
+            )
+        }
+        statusText = recovered?.errorMessage ?? "Voice note recovery saved"
+        refreshHistory()
+        AppTelemetry.signal("voice_note_transcription_deferred", parameters: [
+            "reason": "background_time_expired",
+        ])
+    }
+
+    private func handleMeetingBackgroundTaskExpiration(sessionID: UUID) {
+        guard case .transcribing(let activeSessionID) = meetingLifecycleState.phase,
+              activeSessionID == sessionID,
               let operationID = meetingLifecycleRunner?.id
         else { return }
 
@@ -5915,7 +7352,14 @@ final class DictationCoordinator {
         ])
     }
 
-    private func endTranscriptionBackgroundTask() {
+    private func endTranscriptionBackgroundTask(leaseID: UUID? = nil) {
+        if let leaseID, transcriptionBackgroundTaskLeaseID != leaseID {
+            return
+        }
+        defer {
+            transcriptionBackgroundTaskOwner = nil
+            transcriptionBackgroundTaskLeaseID = nil
+        }
         guard transcriptionBackgroundTask != .invalid else { return }
         UIApplication.shared.endBackgroundTask(transcriptionBackgroundTask)
         transcriptionBackgroundTask = .invalid
@@ -5923,9 +7367,8 @@ final class DictationCoordinator {
 
     private func cancelRecording(requestID: UUID) {
         guard activeRequest?.id == requestID else {
-            if let pendingRequest = try? store.pendingRequest(), pendingRequest.id == requestID {
-                try? store.clearPendingRequest()
-            }
+            _ = try? store.clearPendingRequest(id: requestID)
+            clearPendingKeyboardCommand(requestID: requestID)
             clearKeyboardSessionLiveActivityRoute(for: requestID)
             if activeRequest == nil {
                 try? store.saveStatus(.idle)
@@ -5991,8 +7434,8 @@ final class DictationCoordinator {
         if completeDeferredKeyboardSessionStopIfNeeded() {
             transitionKeyboardSession(.requestFinished)
             statusText = "Ready"
-            try? store.clearPendingCommand()
-            try? store.clearPendingRequest()
+            clearPendingKeyboardCommand(requestID: requestID)
+            _ = try? store.clearPendingRequest(id: requestID)
             try? store.saveStatus(.idle)
             saveKeyboardHandoff(requestID: requestID, phase: .cancelled, message: "Cancelled")
             clearKeyboardLiveTranscript()
@@ -6008,8 +7451,8 @@ final class DictationCoordinator {
         )
         transitionKeyboardSession(.requestFinished)
         statusText = "Ready"
-        try? store.clearPendingCommand()
-        try? store.clearPendingRequest()
+        clearPendingKeyboardCommand(requestID: requestID)
+        _ = try? store.clearPendingRequest(id: requestID)
         try? store.saveStatus(.idle)
         saveKeyboardHandoff(requestID: requestID, phase: .cancelled, message: "Cancelled")
         clearKeyboardLiveTranscript()
@@ -6029,6 +7472,7 @@ final class DictationCoordinator {
     }
 
     private func cleanupRealtimeDictationRecorder() {
+        realtimeDictationCallbackContext = nil
         realtimeDictationRecorder?.cancel()
         realtimeDictationRecorder = nil
         realtimeDictationBufferPipe?.finish()
@@ -6276,14 +7720,114 @@ private struct SendableAudioBuffer: @unchecked Sendable {
     let buffer: AVAudioPCMBuffer
 }
 
+private final class KeyboardRuntimeStatusProjectionWriter: @unchecked Sendable {
+    private enum Projection {
+        case status(KeyboardRuntimeStatus)
+        case cleared
+    }
+
+    private struct PendingProjection {
+        let generation: UInt64
+        let value: Projection
+    }
+
+    private let store: SharedStore
+    private let lock = NSLock()
+    private let queue = DispatchQueue(
+        label: "com.phequals7.muesli.keyboard-runtime-status",
+        qos: .utility
+    )
+    private var pendingProjection: PendingProjection?
+    private var nextGeneration: UInt64 = 0
+    private var isDraining = false
+    private var consecutiveFailureCount = 0
+
+    init(store: SharedStore) {
+        self.store = store
+    }
+
+    func submit(_ status: KeyboardRuntimeStatus) {
+        enqueue(.status(status))
+    }
+
+    func clear() {
+        enqueue(.cleared)
+    }
+
+    private func enqueue(_ projection: Projection) {
+        lock.lock()
+        nextGeneration &+= 1
+        pendingProjection = PendingProjection(
+            generation: nextGeneration,
+            value: projection
+        )
+        let shouldStartDrain = !isDraining
+        if shouldStartDrain {
+            isDraining = true
+        }
+        lock.unlock()
+
+        guard shouldStartDrain else { return }
+        queue.async { [weak self] in
+            self?.drain()
+        }
+    }
+
+    private func drain() {
+        while true {
+            lock.lock()
+            guard let projection = pendingProjection else {
+                isDraining = false
+                lock.unlock()
+                return
+            }
+            lock.unlock()
+
+            do {
+                switch projection.value {
+                case .status(let status):
+                    try store.saveKeyboardRuntimeStatus(status)
+                case .cleared:
+                    try store.clearKeyboardRuntimeStatus()
+                }
+            } catch {
+                lock.lock()
+                consecutiveFailureCount = min(consecutiveFailureCount + 1, 5)
+                let failureCount = consecutiveFailureCount
+                lock.unlock()
+                let delay = min(2, 0.1 * pow(2, Double(failureCount - 1)))
+                queue.asyncAfter(deadline: .now() + delay) { [weak self] in
+                    self?.drain()
+                }
+                return
+            }
+
+            lock.lock()
+            consecutiveFailureCount = 0
+            if pendingProjection?.generation == projection.generation {
+                pendingProjection = nil
+            }
+            lock.unlock()
+        }
+    }
+}
+
 private final class RealtimeAudioBufferPipe: @unchecked Sendable {
     let stream: AsyncStream<SendableAudioBuffer>
     private let lock = NSLock()
     private var continuation: AsyncStream<SendableAudioBuffer>.Continuation?
+    private var droppedBufferCount = 0
+
+    var hasDroppedBuffers: Bool {
+        lock.lock()
+        let value = droppedBufferCount > 0
+        lock.unlock()
+        return value
+    }
 
     init() {
         var streamContinuation: AsyncStream<SendableAudioBuffer>.Continuation?
-        stream = AsyncStream<SendableAudioBuffer> { continuation in
+        stream = AsyncStream<SendableAudioBuffer>(bufferingPolicy: .bufferingNewest(8)) { continuation in
             streamContinuation = continuation
         }
         continuation = streamContinuation
@@ -6293,7 +7837,18 @@ private final class RealtimeAudioBufferPipe: @unchecked Sendable {
         lock.lock()
         let continuation = continuation
         lock.unlock()
-        continuation?.yield(SendableAudioBuffer(buffer: buffer))
+        guard let continuation else { return }
+        if case .dropped = continuation.yield(SendableAudioBuffer(buffer: buffer)) {
+            lock.lock()
+            droppedBufferCount += 1
+            lock.unlock()
+        }
+    }
+
+    func markLossy() {
+        lock.lock()
+        droppedBufferCount += 1
+        lock.unlock()
     }
 
     func finish() {

--- a/Muesli/DictationView.swift
+++ b/Muesli/DictationView.swift
@@ -928,6 +928,8 @@ private struct RecoverableVoiceNoteRow: View {
     let action: () -> Void
 
     var body: some View {
+        let hasDraft = !(session.draftTranscriptText?
+            .trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ?? true)
         Button(action: action) {
             HStack(spacing: MuesliTheme.spacing12) {
                 Image(systemName: session.audioFileName == nil ? "waveform.slash" : "waveform.badge.exclamationmark")
@@ -938,15 +940,18 @@ private struct RecoverableVoiceNoteRow: View {
                     .clipShape(Circle())
 
                 VStack(alignment: .leading, spacing: MuesliTheme.spacing4) {
-                    Text(session.audioFileName == nil ? "Audio unavailable" : "Needs transcription")
+                    Text(hasDraft
+                        ? "Partial transcript recovered"
+                        : (session.audioFileName == nil ? "Audio unavailable" : "Needs transcription"))
                         .font(MuesliTheme.headline())
                         .foregroundStyle(MuesliTheme.textPrimary)
                     Text(session.createdAt.formatted(date: .abbreviated, time: .shortened))
                         .font(MuesliTheme.caption())
                         .foregroundStyle(MuesliTheme.textTertiary)
-                    if let scratchpad = session.scratchpadText?.trimmingCharacters(in: .whitespacesAndNewlines),
-                       !scratchpad.isEmpty {
-                        Text(scratchpad)
+                    if let preview = (session.draftTranscriptText ?? session.scratchpadText)?
+                        .trimmingCharacters(in: .whitespacesAndNewlines),
+                       !preview.isEmpty {
+                        Text(preview)
                             .font(MuesliTheme.callout())
                             .foregroundStyle(MuesliTheme.textSecondary)
                             .lineLimit(2)

--- a/Muesli/KeyboardSessionKeeper.swift
+++ b/Muesli/KeyboardSessionKeeper.swift
@@ -2,6 +2,25 @@ import AVFoundation
 import Foundation
 import os
 
+enum RecentAudioInputHealth {
+    static func isReceiving(
+        hasActiveCapture: Bool,
+        graphIsRunning: Bool,
+        lastInputBufferAt: Date?,
+        now: Date,
+        maximumAge: TimeInterval
+    ) -> Bool {
+        guard hasActiveCapture,
+              graphIsRunning,
+              maximumAge >= 0,
+              let lastInputBufferAt
+        else { return false }
+
+        let age = now.timeIntervalSince(lastInputBufferAt)
+        return age >= 0 && age <= maximumAge
+    }
+}
+
 final class KeyboardSessionKeeper: @unchecked Sendable {
     struct SegmentResult: Sendable {
         let audioURL: URL
@@ -21,30 +40,48 @@ final class KeyboardSessionKeeper: @unchecked Sendable {
         var latestPowerDB: Float = -160
         var segmentFrames: AVAudioFramePosition = 0
         var lastInputBufferAt: Date?
+        var lastStandbyInputBufferAt: Date?
         var lastInputActivityNotifiedAt = Date.distantPast
+        var inputHealthEpoch: UInt64 = 0
+        var inputHealthInvalidated = false
         var isFinishingSegment = false
     }
 
     private struct PendingFileWrite: @unchecked Sendable {
         let segmentID: UUID
+        let tapGeneration: UInt64
+        let inputHealthEpoch: UInt64
         let file: AVAudioFile
         let buffer: AVAudioPCMBuffer
         let frameCount: Int
+        let powerDB: Float
+        let receivedAt: Date
     }
 
-    private let engine = AVAudioEngine()
+    private var engine = AVAudioEngine()
     private let lock = NSLock()
+    private let graphMutationLock = NSRecursiveLock()
     private let fileWriteQueue = DispatchQueue(label: "com.muesli.keyboardSessionKeeper.fileWrite")
     private var state = FileState()
     private var converter: AVAudioConverter?
     private var isEngineRunning = false
     private var isStarting = false
     private var tapInstalled = false
-    private var inputActivityHandler: (@Sendable (_ powerDB: Float, _ isCapturing: Bool) -> Void)?
-    var onRecordingFailure: (@Sendable (CheckpointingAudioWriterFailure) -> Void)?
+    private var tapGeneration: UInt64 = 0
+    private var inputActivityHandler: (@Sendable (
+        _ powerDB: Float,
+        _ isCapturing: Bool,
+        _ segmentID: UUID?
+    ) -> Void)?
+    var onRecordingFailure: (@Sendable (
+        _ failure: CheckpointingAudioWriterFailure,
+        _ segmentID: UUID
+    ) -> Void)?
 
     private static let sampleRate: Double = 16_000
     private static let bufferSize: AVAudioFrameCount = 2_048
+    private static let standbyInputMaximumAge: TimeInterval = 1.5
+    private static let inputActivityNotificationInterval: TimeInterval = 0.16
 
     static func discardAudioTap(_ buffer: AVAudioPCMBuffer, when _: AVAudioTime) {
         _ = buffer.frameLength
@@ -53,6 +90,7 @@ final class KeyboardSessionKeeper: @unchecked Sendable {
     var isRunning: Bool {
         lock.lock()
         let shouldBeRunning = isEngineRunning
+        let engine = self.engine
         lock.unlock()
         return shouldBeRunning && engine.isRunning
     }
@@ -61,9 +99,22 @@ final class KeyboardSessionKeeper: @unchecked Sendable {
         lock.lock()
         let shouldBeRunning = isEngineRunning
         let hasTap = tapInstalled
+        let inputHealthInvalidated = state.inputHealthInvalidated
+        let hasActiveSegment = state.activeFile != nil || state.checkpointWriter != nil
+        let lastStandbyInputBufferAt = state.lastStandbyInputBufferAt
+        let engine = self.engine
         lock.unlock()
 
-        return shouldBeRunning && hasTap && engine.isRunning
+        return RecentAudioInputHealth.isReceiving(
+            hasActiveCapture: shouldBeRunning
+                && hasTap
+                && !inputHealthInvalidated
+                && !hasActiveSegment,
+            graphIsRunning: engine.isRunning,
+            lastInputBufferAt: lastStandbyInputBufferAt,
+            now: .now,
+            maximumAge: Self.standbyInputMaximumAge
+        )
     }
 
     var isRecordingSegment: Bool {
@@ -71,6 +122,37 @@ final class KeyboardSessionKeeper: @unchecked Sendable {
         let recording = state.activeFile != nil || state.checkpointWriter != nil
         lock.unlock()
         return recording
+    }
+
+    var isCapturingAudio: Bool {
+        lock.lock()
+        let engine = self.engine
+        let inputHealthInvalidated = state.inputHealthInvalidated
+        lock.unlock()
+        return isRecordingSegment && !inputHealthInvalidated && engine.isRunning
+    }
+
+    /// `AVAudioEngine.isRunning` only describes the render graph. A graph can remain
+    /// running after a route/configuration change while its input tap receives no
+    /// buffers. Use this signal when deciding whether capture actually recovered.
+    func isReceivingAudio(
+        now: Date = .now,
+        maximumAge: TimeInterval = 1.5
+    ) -> Bool {
+        lock.lock()
+        let lastInputBufferAt = state.lastInputBufferAt
+        let hasActiveSegment = state.activeFile != nil || state.checkpointWriter != nil
+        let inputHealthInvalidated = state.inputHealthInvalidated
+        let engine = self.engine
+        lock.unlock()
+
+        return RecentAudioInputHealth.isReceiving(
+            hasActiveCapture: hasActiveSegment && !inputHealthInvalidated,
+            graphIsRunning: engine.isRunning,
+            lastInputBufferAt: lastInputBufferAt,
+            now: now,
+            maximumAge: maximumAge
+        )
     }
 
     func start() async throws {
@@ -85,25 +167,28 @@ final class KeyboardSessionKeeper: @unchecked Sendable {
         }
 
         do {
-            // Standby captures real keyboard dictation segments, so it must honor the selected route.
-            _ = try AudioInputRouteManager.configureForRecording(stage: "keyboard session")
-            prepareForStart()
+            try withGraphMutationLock {
+                // Standby captures real keyboard dictation segments, so it must honor the selected route.
+                _ = try AudioInputRouteManager.configureForRecording(stage: "keyboard session")
+                prepareForStart()
 
-            let targetFormat = try Self.makeTargetFormat()
-            let inputNode = engine.inputNode
-            let inputFormat = inputNode.outputFormat(forBus: 0)
-            converter = Self.requiresConversion(from: inputFormat, to: targetFormat)
-                ? AVAudioConverter(from: inputFormat, to: targetFormat)
-                : nil
+                let targetFormat = try Self.makeTargetFormat()
+                let engine = currentEngine()
+                let inputNode = engine.inputNode
+                let inputFormat = inputNode.outputFormat(forBus: 0)
+                setConverter(
+                    Self.requiresConversion(from: inputFormat, to: targetFormat)
+                        ? AVAudioConverter(from: inputFormat, to: targetFormat)
+                        : nil
+                )
 
-            inputNode.installTap(onBus: 0, bufferSize: Self.bufferSize, format: nil) { [weak self] buffer, _ in
-                self?.handle(buffer: buffer, targetFormat: targetFormat)
+                installInputTap(on: engine, targetFormat: targetFormat)
+                setTapInstalled(true)
+                engine.prepare()
+                try engine.start()
+
+                setEngineRunning(true)
             }
-            setTapInstalled(true)
-            engine.prepare()
-            try engine.start()
-
-            setEngineRunning(true)
         } catch {
             cleanupAfterFailedStart()
             if error is AudioRecorder.RecordingError {
@@ -114,23 +199,44 @@ final class KeyboardSessionKeeper: @unchecked Sendable {
     }
 
     func setInputActivityHandler(
-        _ handler: (@Sendable (_ powerDB: Float, _ isCapturing: Bool) -> Void)?
+        _ handler: (@Sendable (
+            _ powerDB: Float,
+            _ isCapturing: Bool,
+            _ segmentID: UUID?
+        ) -> Void)?
     ) {
         lock.lock()
         inputActivityHandler = handler
         lock.unlock()
     }
 
+    func isActiveSegment(_ segmentID: UUID) -> Bool {
+        lock.lock()
+        let isActive = state.activeSegmentID == segmentID && !state.isFinishingSegment
+        lock.unlock()
+        return isActive
+    }
+
     func beginSegment(outputURL: URL, checkpointDirectory: URL? = nil) throws {
-        guard isRunning else {
-            throw AudioRecorder.RecordingError.startFailed(stage: "keyboard session inactive")
+        graphMutationLock.lock()
+        defer { graphMutationLock.unlock() }
+
+        guard canAcceptStartCommand else {
+            throw AudioRecorder.RecordingError.startFailed(
+                stage: "keyboard session standby input not ready"
+            )
         }
 
         try FileManager.default.createDirectory(at: outputURL.deletingLastPathComponent(), withIntermediateDirectories: true)
         let format = try Self.makeTargetFormat()
-        let file = try checkpointDirectory == nil
-            ? AVAudioFile(forWriting: outputURL, settings: format.settings)
-            : nil
+        let file: AVAudioFile?
+        if checkpointDirectory == nil {
+            file = try AVAudioFile(forWriting: outputURL, settings: format.settings)
+            try SharedFileProtection.protectAudio(at: outputURL)
+        } else {
+            file = nil
+        }
+        let segmentID = UUID()
         let writer = try checkpointDirectory.map {
             try CheckpointingAudioWriter(
                 continuousAudioURL: outputURL,
@@ -138,10 +244,14 @@ final class KeyboardSessionKeeper: @unchecked Sendable {
                 format: format
             )
         }
-        writer?.onFailure = { [weak self] failure in
-            self?.onRecordingFailure?(failure)
+        writer?.onFailure = { [weak self, weak writer, segmentID] failure in
+            guard let writer else { return }
+            self?.handleWriterFailure(
+                failure,
+                writer: writer,
+                segmentID: segmentID
+            )
         }
-        let segmentID = UUID()
 
         lock.lock()
         state.activeFile = file
@@ -149,12 +259,36 @@ final class KeyboardSessionKeeper: @unchecked Sendable {
         state.activeURL = outputURL
         state.activeSegmentID = segmentID
         state.segmentFrames = 0
+        state.lastInputBufferAt = nil
+        state.lastStandbyInputBufferAt = nil
         state.isFinishingSegment = false
         lock.unlock()
     }
 
+    private func handleWriterFailure(
+        _ failure: CheckpointingAudioWriterFailure,
+        writer: CheckpointingAudioWriter,
+        segmentID: UUID
+    ) {
+        lock.lock()
+        guard state.activeSegmentID == segmentID,
+              state.checkpointWriter === writer,
+              !state.isFinishingSegment
+        else {
+            lock.unlock()
+            return
+        }
+        invalidateInputHealthLocked()
+        let callback = onRecordingFailure
+        lock.unlock()
+        callback?(failure, segmentID)
+    }
+
     @discardableResult
     func finishSegment() throws -> SegmentResult {
+        graphMutationLock.lock()
+        defer { graphMutationLock.unlock() }
+
         lock.lock()
         state.isFinishingSegment = true
         let url = state.activeURL
@@ -197,6 +331,9 @@ final class KeyboardSessionKeeper: @unchecked Sendable {
     }
 
     func cancelSegment() {
+        graphMutationLock.lock()
+        defer { graphMutationLock.unlock() }
+
         lock.lock()
         state.isFinishingSegment = true
         let url = state.activeURL
@@ -224,19 +361,20 @@ final class KeyboardSessionKeeper: @unchecked Sendable {
     }
 
     func stop(deactivateSession: Bool = true) {
+        graphMutationLock.lock()
+        defer { graphMutationLock.unlock() }
+
         cancelSegment()
-        if isTapInstalled {
-            engine.inputNode.removeTap(onBus: 0)
-            setTapInstalled(false)
-        }
-        engine.stop()
-        converter = nil
+        let engine = currentEngine()
+        tearDownGraph(engine)
+        setConverter(nil)
 
         lock.lock()
         isStarting = false
         isEngineRunning = false
         state.latestPowerDB = -160
         state.lastInputBufferAt = nil
+        state.lastStandbyInputBufferAt = nil
         lock.unlock()
 
         if deactivateSession {
@@ -251,6 +389,27 @@ final class KeyboardSessionKeeper: @unchecked Sendable {
         return value
     }
 
+    /// Fences the currently installed tap and clears its health evidence. This must
+    /// be called as soon as an interruption/configuration event arrives so a callback
+    /// already in flight before that event cannot satisfy a later health check.
+    func invalidateInputHealth() {
+        lock.lock()
+        invalidateInputHealthLocked()
+        lock.unlock()
+    }
+
+    /// Clears prior liveness evidence without invalidating the installed tap. A
+    /// callback that began before this reset may still be written, but cannot make
+    /// the post-event health probe pass; the next callback begins in the new epoch.
+    func resetInputHealthEvidence() {
+        lock.lock()
+        state.inputHealthEpoch &+= 1
+        state.lastInputBufferAt = nil
+        state.lastStandbyInputBufferAt = nil
+        state.latestPowerDB = -160
+        lock.unlock()
+    }
+
     func waitUntilCanAcceptStartCommand(timeout: TimeInterval = 1.5) async -> Bool {
         let deadline = Date().addingTimeInterval(timeout)
         while Date() < deadline {
@@ -262,16 +421,125 @@ final class KeyboardSessionKeeper: @unchecked Sendable {
         return canAcceptStartCommand
     }
 
-    private func handle(buffer: AVAudioPCMBuffer, targetFormat: AVAudioFormat) {
-        let powerDB = Self.powerDB(for: buffer)
-        let now = Date()
-        let handler: (@Sendable (_ powerDB: Float, _ isCapturing: Bool) -> Void)?
-        let shouldNotifyActivity: Bool
+    /// Repairs a phantom standby graph that reports running but is not delivering
+    /// input callbacks. This method only starts the graph; callers must subsequently
+    /// use `waitUntilCanAcceptStartCommand` so readiness is based on a real buffer.
+    @discardableResult
+    func ensureReadyForStartCommand(recreateEngine: Bool = false) throws -> Bool {
+        graphMutationLock.lock()
+        defer { graphMutationLock.unlock() }
+
+        guard !isRecordingSegment else { return false }
+        if canAcceptStartCommand, !recreateEngine {
+            return true
+        }
+
+        _ = try AudioInputRouteManager.configureForRecording(
+            stage: "keyboard standby recovery"
+        )
+        let targetFormat = try Self.makeTargetFormat()
+        var engine = currentEngine()
+
+        if recreateEngine {
+            abandonGraphAfterMediaServicesReset(engine)
+            engine = replaceEngine()
+            setConverter(nil)
+        } else {
+            tearDownGraph(engine)
+        }
+        try configureAndInstallInputTap(on: engine, targetFormat: targetFormat)
+
+        do {
+            engine.prepare()
+            try engine.start()
+            setEngineRunning(engine.isRunning)
+            return engine.isRunning
+        } catch {
+            tearDownGraph(engine)
+            setEngineRunning(false)
+            throw error
+        }
+    }
+
+    /// Restarts the existing capture graph without replacing the active segment writer.
+    /// This preserves the same continuous WAV/checkpoint sequence across lock-screen and
+    /// competing-audio interruptions.
+    @discardableResult
+    func resumeCaptureIfNeeded(
+        rebuildGraph: Bool = false,
+        recreateEngine: Bool = false
+    ) throws -> Bool {
+        graphMutationLock.lock()
+        defer { graphMutationLock.unlock() }
+
+        guard isRecordingSegment else { return false }
+        lock.lock()
+        let inputHealthInvalidated = state.inputHealthInvalidated
+        lock.unlock()
+        let shouldRebuildGraph = rebuildGraph || inputHealthInvalidated
+        var engine = currentEngine()
+        if engine.isRunning, !shouldRebuildGraph, !recreateEngine {
+            return true
+        }
+
+        _ = try AudioInputRouteManager.configureForRecording(
+            stage: "keyboard voice note interruption recovery"
+        )
+        let targetFormat = try Self.makeTargetFormat()
+        lock.lock()
+        state.lastInputBufferAt = nil
+        lock.unlock()
+
+        if recreateEngine {
+            abandonGraphAfterMediaServicesReset(engine)
+            engine = replaceEngine()
+            setConverter(nil)
+            try configureAndInstallInputTap(on: engine, targetFormat: targetFormat)
+        } else if shouldRebuildGraph {
+            tearDownGraph(engine)
+            try configureAndInstallInputTap(on: engine, targetFormat: targetFormat)
+        } else {
+            guard isTapInstalled else { return false }
+        }
+
+        do {
+            engine.prepare()
+            try engine.start()
+            setEngineRunning(engine.isRunning)
+            return engine.isRunning
+        } catch {
+            tearDownGraph(engine)
+            setEngineRunning(false)
+            throw error
+        }
+    }
+
+    /// `AVAudioSession.mediaServicesWereResetNotification` invalidates the process's
+    /// audio objects, not just the running graph. Recreate the engine while retaining
+    /// the active segment's file/checkpoint writer and accumulated frame count.
+    @discardableResult
+    func recoverAfterMediaServicesReset() throws -> Bool {
+        try resumeCaptureIfNeeded(rebuildGraph: true, recreateEngine: true)
+    }
+
+    private func handle(
+        buffer: AVAudioPCMBuffer,
+        targetFormat: AVAudioFormat,
+        tapGeneration: UInt64
+    ) {
         let file: AVAudioFile?
         let checkpointWriter: CheckpointingAudioWriter?
         let segmentID: UUID?
+        let converter: AVAudioConverter?
+        let inputHealthEpoch: UInt64
 
         lock.lock()
+        guard tapGeneration == self.tapGeneration,
+              !state.inputHealthInvalidated
+        else {
+            lock.unlock()
+            return
+        }
         if let activeFile = state.activeFile,
            let activeSegmentID = state.activeSegmentID,
            !state.isFinishingSegment
@@ -290,67 +558,188 @@ final class KeyboardSessionKeeper: @unchecked Sendable {
             segmentID = nil
             checkpointWriter = nil
         }
-        state.latestPowerDB = powerDB
-        state.lastInputBufferAt = now
-        shouldNotifyActivity = now.timeIntervalSince(state.lastInputActivityNotifiedAt) >= 0.5
-        if shouldNotifyActivity {
-            state.lastInputActivityNotifiedAt = now
-        }
-        handler = inputActivityHandler
+        converter = self.converter
+        inputHealthEpoch = state.inputHealthEpoch
         lock.unlock()
 
-        if let segmentID,
-           let monoBuffer = convert(buffer: buffer, targetFormat: targetFormat)
-        {
-            let frameCount = Int(monoBuffer.frameLength)
-            if frameCount > 0 {
-                lock.lock()
-                let shouldWrite = state.activeSegmentID == segmentID && !state.isFinishingSegment
-                lock.unlock()
+        guard let monoBuffer = convert(
+            buffer: buffer,
+            targetFormat: targetFormat,
+            converter: converter
+        ) else {
+            invalidateInputHealth(ifCurrentTapGeneration: tapGeneration)
+            return
+        }
+        let frameCount = Int(monoBuffer.frameLength)
+        guard frameCount > 0 else { return }
 
-                if shouldWrite {
-                    if let checkpointWriter {
-                        checkpointWriter.append(monoBuffer)
-                    } else if let file {
-                        enqueue(PendingFileWrite(
-                            segmentID: segmentID,
-                            file: file,
-                            buffer: monoBuffer,
-                            frameCount: frameCount
-                        ))
-                    }
+        let powerDB = Self.powerDB(for: monoBuffer)
+        let now = Date()
+        guard let segmentID else {
+            let handler: (@Sendable (Float, Bool, UUID?) -> Void)?
+            lock.lock()
+            let isCurrentStandbyInput = tapGeneration == self.tapGeneration
+                && inputHealthEpoch == state.inputHealthEpoch
+                && !state.inputHealthInvalidated
+                && state.activeFile == nil
+                && state.checkpointWriter == nil
+            if isCurrentStandbyInput {
+                handler = recordStandbyInputLocked(powerDB: powerDB, at: now)
+            } else {
+                handler = nil
+            }
+            lock.unlock()
+            handler?(powerDB, false, nil)
+            return
+        }
+
+        if let checkpointWriter {
+            lock.lock()
+            let shouldWrite = state.activeSegmentID == segmentID
+                && state.checkpointWriter === checkpointWriter
+                && !state.isFinishingSegment
+                && tapGeneration == self.tapGeneration
+                && !state.inputHealthInvalidated
+            if shouldWrite {
+                checkpointWriter.append(monoBuffer) { [weak self, weak checkpointWriter] in
+                    guard let checkpointWriter else { return }
+                    self?.recordSuccessfulCheckpointWrite(
+                        segmentID: segmentID,
+                        writer: checkpointWriter,
+                        tapGeneration: tapGeneration,
+                        inputHealthEpoch: inputHealthEpoch,
+                        powerDB: powerDB,
+                        receivedAt: now
+                    )
                 }
             }
+            lock.unlock()
+        } else if let file {
+            let pendingWrite = PendingFileWrite(
+                segmentID: segmentID,
+                tapGeneration: tapGeneration,
+                inputHealthEpoch: inputHealthEpoch,
+                file: file,
+                buffer: monoBuffer,
+                frameCount: frameCount,
+                powerDB: powerDB,
+                receivedAt: now
+            )
+            lock.lock()
+            let shouldEnqueue = state.activeSegmentID == segmentID
+                && state.activeFile === file
+                && !state.isFinishingSegment
+                && tapGeneration == self.tapGeneration
+                && !state.inputHealthInvalidated
+            if shouldEnqueue {
+                enqueue(pendingWrite)
+            }
+            lock.unlock()
         }
+    }
 
-        if shouldNotifyActivity {
-            handler?(powerDB, file != nil || checkpointWriter != nil)
+    private func recordAcceptedInputLocked(
+        powerDB: Float,
+        at receivedAt: Date
+    ) -> (@Sendable (Float, Bool, UUID?) -> Void)? {
+        state.latestPowerDB = powerDB
+        state.lastInputBufferAt = receivedAt
+        guard receivedAt.timeIntervalSince(state.lastInputActivityNotifiedAt)
+                >= Self.inputActivityNotificationInterval
+        else {
+            return nil
         }
+        state.lastInputActivityNotifiedAt = receivedAt
+        return inputActivityHandler
+    }
+
+    private func recordStandbyInputLocked(
+        powerDB: Float,
+        at receivedAt: Date
+    ) -> (@Sendable (Float, Bool, UUID?) -> Void)? {
+        state.latestPowerDB = powerDB
+        state.lastStandbyInputBufferAt = receivedAt
+        guard receivedAt.timeIntervalSince(state.lastInputActivityNotifiedAt) >= 0.5 else {
+            return nil
+        }
+        state.lastInputActivityNotifiedAt = receivedAt
+        return inputActivityHandler
     }
 
     private func enqueue(_ write: PendingFileWrite) {
         fileWriteQueue.async { [weak self] in
             do {
                 try write.file.write(from: write.buffer)
-                self?.recordWrittenFrames(write.frameCount, for: write.segmentID)
+                self?.recordSuccessfulFileWrite(write)
             } catch {
-                // Preserve the live session; stop/finish will surface missing audio if writes fail.
+                self?.invalidateInputHealth(ifCurrentTapGeneration: write.tapGeneration)
             }
         }
     }
 
-    private func recordWrittenFrames(_ frameCount: Int, for segmentID: UUID) {
+    private func recordSuccessfulFileWrite(_ write: PendingFileWrite) {
+        let handler: (@Sendable (Float, Bool, UUID?) -> Void)?
         lock.lock()
-        if state.activeSegmentID == segmentID {
-            state.segmentFrames += AVAudioFramePosition(frameCount)
+        if state.activeSegmentID == write.segmentID,
+           write.tapGeneration == tapGeneration,
+           !state.inputHealthInvalidated,
+           !state.isFinishingSegment
+        {
+            state.segmentFrames += AVAudioFramePosition(write.frameCount)
+            if write.inputHealthEpoch == state.inputHealthEpoch {
+                handler = recordAcceptedInputLocked(
+                    powerDB: write.powerDB,
+                    at: write.receivedAt
+                )
+            } else {
+                handler = nil
+            }
+        } else {
+            handler = nil
         }
         lock.unlock()
+        handler?(write.powerDB, true, write.segmentID)
     }
 
-    private func convert(buffer: AVAudioPCMBuffer, targetFormat: AVAudioFormat) -> AVAudioPCMBuffer? {
+    private func recordSuccessfulCheckpointWrite(
+        segmentID: UUID,
+        writer: CheckpointingAudioWriter,
+        tapGeneration: UInt64,
+        inputHealthEpoch: UInt64,
+        powerDB: Float,
+        receivedAt: Date
+    ) {
+        let handler: (@Sendable (Float, Bool, UUID?) -> Void)?
+        lock.lock()
+        if state.activeSegmentID == segmentID,
+           state.checkpointWriter === writer,
+           tapGeneration == self.tapGeneration,
+           inputHealthEpoch == state.inputHealthEpoch,
+           !state.inputHealthInvalidated,
+           !state.isFinishingSegment
+        {
+            handler = recordAcceptedInputLocked(powerDB: powerDB, at: receivedAt)
+        } else {
+            handler = nil
+        }
+        lock.unlock()
+        handler?(powerDB, true, segmentID)
+    }
+
+    private func convert(
+        buffer: AVAudioPCMBuffer,
+        targetFormat: AVAudioFormat,
+        converter: AVAudioConverter?
+    ) -> AVAudioPCMBuffer? {
+        guard buffer.frameLength > 0 else { return nil }
         guard let converter else {
+            guard Self.formatsMatch(buffer.format, targetFormat) else { return nil }
             return copy(buffer)
         }
+
+        guard Self.formatsMatch(buffer.format, converter.inputFormat),
+              Self.formatsMatch(targetFormat, converter.outputFormat)
+        else { return nil }
 
         let ratio = targetFormat.sampleRate / buffer.format.sampleRate
         let frameCapacity = max(1, AVAudioFrameCount(Double(buffer.frameLength) * ratio) + 1)
@@ -368,7 +757,10 @@ final class KeyboardSessionKeeper: @unchecked Sendable {
             return buffer
         }
 
-        guard error == nil else { return nil }
+        guard error == nil,
+              converted.frameLength > 0,
+              Self.formatsMatch(converted.format, targetFormat)
+        else { return nil }
         return converted
     }
 
@@ -409,12 +801,12 @@ final class KeyboardSessionKeeper: @unchecked Sendable {
     }
 
     private func cleanupAfterFailedStart() {
-        if isTapInstalled {
-            engine.inputNode.removeTap(onBus: 0)
-            setTapInstalled(false)
-        }
-        engine.stop()
-        converter = nil
+        graphMutationLock.lock()
+        defer { graphMutationLock.unlock() }
+
+        let engine = currentEngine()
+        tearDownGraph(engine)
+        setConverter(nil)
         lock.lock()
         state = FileState()
         isStarting = false
@@ -424,12 +816,9 @@ final class KeyboardSessionKeeper: @unchecked Sendable {
     }
 
     private func prepareForStart() {
-        if isTapInstalled {
-            engine.inputNode.removeTap(onBus: 0)
-            setTapInstalled(false)
-        }
-        engine.stop()
-        converter = nil
+        let engine = currentEngine()
+        tearDownGraph(engine)
+        setConverter(nil)
 
         lock.lock()
         state.activeFile = nil
@@ -437,6 +826,7 @@ final class KeyboardSessionKeeper: @unchecked Sendable {
         state.activeSegmentID = nil
         state.segmentFrames = 0
         state.lastInputBufferAt = nil
+        state.lastStandbyInputBufferAt = nil
         state.isFinishingSegment = false
         isEngineRunning = false
         lock.unlock()
@@ -445,6 +835,7 @@ final class KeyboardSessionKeeper: @unchecked Sendable {
     private func beginStartingIfNeeded() -> Bool {
         lock.lock()
         defer { lock.unlock() }
+        let engine = self.engine
         guard !isStarting, !(isEngineRunning && engine.isRunning) else {
             return false
         }
@@ -463,6 +854,110 @@ final class KeyboardSessionKeeper: @unchecked Sendable {
         lock.lock()
         tapInstalled = installed
         lock.unlock()
+    }
+
+    private func setConverter(_ newConverter: AVAudioConverter?) {
+        lock.lock()
+        converter = newConverter
+        lock.unlock()
+    }
+
+    private func currentEngine() -> AVAudioEngine {
+        lock.lock()
+        let engine = self.engine
+        lock.unlock()
+        return engine
+    }
+
+    private func withGraphMutationLock<T>(_ body: () throws -> T) rethrows -> T {
+        graphMutationLock.lock()
+        defer { graphMutationLock.unlock() }
+        return try body()
+    }
+
+    private func replaceEngine() -> AVAudioEngine {
+        let replacement = AVAudioEngine()
+        lock.lock()
+        engine = replacement
+        tapInstalled = false
+        isEngineRunning = false
+        lock.unlock()
+        return replacement
+    }
+
+    private func activateTapGeneration() -> UInt64 {
+        lock.lock()
+        tapGeneration &+= 1
+        state.inputHealthEpoch &+= 1
+        state.inputHealthInvalidated = false
+        state.lastInputBufferAt = nil
+        state.lastStandbyInputBufferAt = nil
+        let generation = tapGeneration
+        lock.unlock()
+        return generation
+    }
+
+    private func invalidateInputHealthLocked() {
+        tapGeneration &+= 1
+        state.inputHealthEpoch &+= 1
+        state.inputHealthInvalidated = true
+        state.lastInputBufferAt = nil
+        state.lastStandbyInputBufferAt = nil
+        state.latestPowerDB = -160
+    }
+
+    private func invalidateInputHealth(ifCurrentTapGeneration generation: UInt64) {
+        lock.lock()
+        if generation == tapGeneration {
+            invalidateInputHealthLocked()
+        }
+        lock.unlock()
+    }
+
+    private func installInputTap(on engine: AVAudioEngine, targetFormat: AVAudioFormat) {
+        let generation = activateTapGeneration()
+        engine.inputNode.installTap(
+            onBus: 0,
+            bufferSize: Self.bufferSize,
+            format: nil
+        ) { [weak self] buffer, _ in
+            self?.handle(
+                buffer: buffer,
+                targetFormat: targetFormat,
+                tapGeneration: generation
+            )
+        }
+    }
+
+    private func configureAndInstallInputTap(
+        on engine: AVAudioEngine,
+        targetFormat: AVAudioFormat
+    ) throws {
+        let inputFormat = engine.inputNode.outputFormat(forBus: 0)
+        setConverter(
+            Self.requiresConversion(from: inputFormat, to: targetFormat)
+                ? AVAudioConverter(from: inputFormat, to: targetFormat)
+                : nil
+        )
+        installInputTap(on: engine, targetFormat: targetFormat)
+        setTapInstalled(true)
+    }
+
+    private func tearDownGraph(_ engine: AVAudioEngine) {
+        if isTapInstalled {
+            engine.inputNode.removeTap(onBus: 0)
+            setTapInstalled(false)
+        }
+        engine.stop()
+        invalidateInputHealth()
+    }
+
+    private func abandonGraphAfterMediaServicesReset(_ engine: AVAudioEngine) {
+        // The reset invalidates the old audio objects. Do not query the old input
+        // node merely to remove its tap; stop it and fence any late callbacks.
+        engine.stop()
+        setTapInstalled(false)
+        invalidateInputHealth()
     }
 
     private func setEngineStarting(_ starting: Bool) {
@@ -491,9 +986,13 @@ final class KeyboardSessionKeeper: @unchecked Sendable {
     }
 
     private static func requiresConversion(from inputFormat: AVAudioFormat, to targetFormat: AVAudioFormat) -> Bool {
-        inputFormat.sampleRate != targetFormat.sampleRate
-            || inputFormat.channelCount != targetFormat.channelCount
-            || inputFormat.commonFormat != targetFormat.commonFormat
-            || inputFormat.isInterleaved != targetFormat.isInterleaved
+        !formatsMatch(inputFormat, targetFormat)
+    }
+
+    private static func formatsMatch(_ lhs: AVAudioFormat, _ rhs: AVAudioFormat) -> Bool {
+        lhs.sampleRate == rhs.sampleRate
+            && lhs.channelCount == rhs.channelCount
+            && lhs.commonFormat == rhs.commonFormat
+            && lhs.isInterleaved == rhs.isInterleaved
     }
 }

--- a/Muesli/LongVoiceNoteView.swift
+++ b/Muesli/LongVoiceNoteView.swift
@@ -98,7 +98,7 @@ struct LongVoiceNoteView: View {
     private var recordingHeader: some View {
         HStack(alignment: .top, spacing: MuesliTheme.spacing12) {
             VStack(alignment: .leading, spacing: MuesliTheme.spacing4) {
-                Text("Long Voice Note")
+                Text(session?.isLongForm == true ? "Long Voice Note" : "Voice Note Recovery")
                     .font(MuesliTheme.title2())
                     .foregroundStyle(MuesliTheme.textPrimary)
 
@@ -214,7 +214,9 @@ struct LongVoiceNoteView: View {
     @ViewBuilder
     private var failureRecoveryPanel: some View {
         VStack(alignment: .leading, spacing: MuesliTheme.spacing12) {
-            Text(session?.canRetryVoiceNoteTranscription == true ? "Transcription failed" : "Recovery unavailable")
+            Text(session?.canRetryVoiceNoteTranscription == true
+                ? "Transcription interrupted"
+                : (session?.draftTranscriptText == nil ? "Recovery unavailable" : "Partial transcript recovered"))
                 .font(MuesliTheme.headline())
                 .foregroundStyle(MuesliTheme.textPrimary)
 
@@ -227,7 +229,7 @@ struct LongVoiceNoteView: View {
 
             if session?.canRetryVoiceNoteTranscription != true,
                session?.audioFileName != nil {
-                Text("A durable audio checkpoint is not available, so this transcription cannot be retried safely.")
+                Text("The audio could not be verified yet. Muesli preserved the recovery files instead of deleting them.")
                     .font(MuesliTheme.callout())
                     .foregroundStyle(MuesliTheme.textSecondary)
                     .fixedSize(horizontal: false, vertical: true)
@@ -246,12 +248,16 @@ struct LongVoiceNoteView: View {
 
     @ViewBuilder
     private var completedTranscript: some View {
-        if session?.phase == .completed,
-           let text = coordinator.transcript(for: session ?? fallbackSession)?.text
-                ?? coordinator.dictationHistory.first(where: { $0.sessionID == sessionID })?.text,
+        if let text = (session?.phase == .completed
+            ? coordinator.transcript(for: session ?? fallbackSession)?.text
+                ?? coordinator.dictationHistory.first(where: { $0.sessionID == sessionID })?.text
+            : session?.draftTranscriptText),
            !text.isEmpty {
             VStack(alignment: .leading, spacing: MuesliTheme.spacing12) {
-                Label("Transcript", systemImage: "text.alignleft")
+                Label(
+                    session?.phase == .completed ? "Transcript" : "Recovered partial transcript",
+                    systemImage: "text.alignleft"
+                )
                     .font(MuesliTheme.headline())
                     .foregroundStyle(MuesliTheme.textPrimary)
                 Text(text)
@@ -367,6 +373,7 @@ struct LongVoiceNoteView: View {
         }
         switch session.phase {
         case .recording: return "Recovered recording"
+        case .interrupted: return "Recording interrupted — audio saved locally"
         case .transcriptionQueued: return "Waiting to transcribe"
         case .transcribing: return "Transcribing"
         case .completed: return "Transcript ready"

--- a/Muesli/MeetingLifecycle.swift
+++ b/Muesli/MeetingLifecycle.swift
@@ -218,6 +218,8 @@ enum MeetingPresentationPolicy {
         switch persistedPhase {
         case .completed, .failed, .cancelled:
             return .idle
+        case .interrupted:
+            return .recovery(sessionID)
         case .transcriptionQueued:
             return .recovery(sessionID)
         case .transcribing:

--- a/Muesli/MeetingsView.swift
+++ b/Muesli/MeetingsView.swift
@@ -2383,6 +2383,8 @@ private extension RecordingSessionPhase {
         switch self {
         case .recording:
             "Recording"
+        case .interrupted:
+            "Interrupted"
         case .transcriptionQueued:
             "Queued"
         case .transcribing:
@@ -2400,6 +2402,8 @@ private extension RecordingSessionPhase {
         switch self {
         case .recording:
             "Live"
+        case .interrupted:
+            "Interrupted"
         case .transcriptionQueued:
             "Saved"
         case .transcribing:
@@ -2417,6 +2421,8 @@ private extension RecordingSessionPhase {
         switch self {
         case .recording:
             "Live"
+        case .interrupted:
+            "Interrupted"
         case .transcriptionQueued:
             "Saved"
         case .transcribing:
@@ -2434,6 +2440,8 @@ private extension RecordingSessionPhase {
         switch self {
         case .recording:
             "In progress."
+        case .interrupted:
+            "Recording was interrupted; captured audio is being recovered."
         case .transcriptionQueued:
             "Audio is saved locally and ready for delayed transcription."
         case .transcribing:
@@ -2451,6 +2459,8 @@ private extension RecordingSessionPhase {
         switch self {
         case .recording:
             "mic.fill"
+        case .interrupted:
+            "waveform.badge.exclamationmark"
         case .transcriptionQueued:
             "clock"
         case .transcribing:
@@ -2468,6 +2478,8 @@ private extension RecordingSessionPhase {
         switch self {
         case .recording:
             MuesliTheme.recording
+        case .interrupted:
+            MuesliTheme.transcribing
         case .failed, .cancelled:
             MuesliTheme.destructive
         case .transcriptionQueued, .transcribing:

--- a/Muesli/MuesliApp.swift
+++ b/Muesli/MuesliApp.swift
@@ -29,6 +29,7 @@ struct MuesliApp: App {
                 .onChange(of: scenePhase) { _, phase in
                     if phase == .active, !isUITesting {
                         coordinator.reconcileMeetingRuntime(reason: "foreground")
+                        coordinator.reconcileVoiceNoteRuntime(reason: "foreground")
                         coordinator.prewarmModelIfNeeded(reason: "foreground")
                         coordinator.syncICloudTextIfEnabled(reason: "foreground")
                         coordinator.recoverLongVoiceNotesIfNeeded()

--- a/Muesli/StreamingMeetingRecorder.swift
+++ b/Muesli/StreamingMeetingRecorder.swift
@@ -10,6 +10,14 @@ struct MeetingAudioChunk: Sendable, Equatable {
 }
 
 final class StreamingMeetingRecorder: @unchecked Sendable {
+    private final class SendableAudioBuffer: @unchecked Sendable {
+        let value: AVAudioPCMBuffer
+
+        init(_ value: AVAudioPCMBuffer) {
+            self.value = value
+        }
+    }
+
     struct StopResult: Sendable {
         let finalChunk: MeetingAudioChunk?
         let retainedAudioURL: URL?
@@ -18,19 +26,30 @@ final class StreamingMeetingRecorder: @unchecked Sendable {
 
     var onAudioSamples: (([Float]) -> Void)?
     var onAudioBuffer: ((AVAudioPCMBuffer) -> Void)?
-    var onRecordingFailure: (@Sendable (CheckpointingAudioWriterFailure) -> Void)?
+    var onRecordingFailure: (@Sendable (
+        _ failure: CheckpointingAudioWriterFailure,
+        _ captureID: UUID
+    ) -> Void)?
 
     private struct FileState {
         var latestPowerDB: Float = -160
+        var lastInputBufferAt: Date?
+        var inputHealthEpoch: UInt64 = 0
+        var inputHealthInvalidated = false
     }
 
-    private let engine = AVAudioEngine()
+    private var engine = AVAudioEngine()
     private let lock = NSLock()
+    private let graphMutationLock = NSRecursiveLock()
     private var state = FileState()
     private var converter: AVAudioConverter?
+    private var targetFormat: AVAudioFormat?
     private var audioWriter: CheckpointingAudioWriter?
     private var isRunning = false
     private var tapInstalled = false
+    private var tapGeneration: UInt64 = 0
+    private var captureGeneration: UInt64 = 0
+    private var activeCaptureID: UUID?
     private var chunksDirectory: URL?
 
     private static let sampleRate: Double = 16_000
@@ -41,7 +60,13 @@ final class StreamingMeetingRecorder: @unchecked Sendable {
         retainedAudioURL: URL?,
         routeStage: String = "streaming recorder"
     ) throws {
-        guard !isRunning else { return }
+        graphMutationLock.lock()
+        defer { graphMutationLock.unlock() }
+
+        lock.lock()
+        let alreadyRunning = isRunning
+        lock.unlock()
+        guard !alreadyRunning else { return }
         self.chunksDirectory = chunksDirectory
         try FileManager.default.createDirectory(at: chunksDirectory, withIntermediateDirectories: true)
 
@@ -56,32 +81,41 @@ final class StreamingMeetingRecorder: @unchecked Sendable {
             ) else {
                 throw AudioRecorder.RecordingError.startFailed(stage: "streaming format")
             }
-
+            let engine = currentEngine()
             let inputNode = engine.inputNode
             let inputFormat = inputNode.outputFormat(forBus: 0)
-            converter = inputFormat.sampleRate != targetFormat.sampleRate || inputFormat.channelCount != targetFormat.channelCount
+            let converter = !Self.formatsMatch(inputFormat, targetFormat)
                 ? AVAudioConverter(from: inputFormat, to: targetFormat)
                 : nil
 
+            let captureID = UUID()
             let writer = try CheckpointingAudioWriter(
                 continuousAudioURL: retainedAudioURL,
                 checkpointDirectory: chunksDirectory,
                 format: targetFormat
             )
-            writer.onFailure = { [weak self] failure in
-                self?.onRecordingFailure?(failure)
+            writer.onFailure = { [weak self, weak writer, captureID] failure in
+                guard let writer else { return }
+                self?.handleWriterFailure(
+                    failure,
+                    writer: writer,
+                    captureID: captureID
+                )
             }
             lock.lock()
+            captureGeneration &+= 1
+            activeCaptureID = captureID
+            self.targetFormat = targetFormat
+            self.converter = converter
             audioWriter = writer
+            state.lastInputBufferAt = nil
             lock.unlock()
 
-            inputNode.installTap(onBus: 0, bufferSize: Self.bufferSize, format: nil) { [weak self] buffer, _ in
-                self?.handle(buffer: buffer, targetFormat: targetFormat)
-            }
-            tapInstalled = true
+            installInputTap(on: engine, targetFormat: targetFormat)
+            setTapInstalled(true)
             engine.prepare()
             try engine.start()
-            isRunning = true
+            setRunning(true)
         } catch {
             cleanupAfterFailedStart()
             if error is AudioRecorder.RecordingError {
@@ -92,45 +126,156 @@ final class StreamingMeetingRecorder: @unchecked Sendable {
     }
 
     func rotateChunk() -> MeetingAudioChunk? {
-        guard isRunning else { return nil }
         lock.lock()
+        let running = isRunning
         let writer = audioWriter
         lock.unlock()
+        guard running else { return nil }
         return writer?.rotateCheckpoint()
     }
 
     var isCapturingAudio: Bool {
-        isRunning && engine.isRunning
+        lock.lock()
+        let running = isRunning
+        let inputHealthInvalidated = state.inputHealthInvalidated
+        let engine = self.engine
+        lock.unlock()
+        return running && !inputHealthInvalidated && engine.isRunning
+    }
+
+    func isActiveCapture(_ captureID: UUID) -> Bool {
+        lock.lock()
+        let isActive = activeCaptureID == captureID && isRunning && audioWriter != nil
+        lock.unlock()
+        return isActive
+    }
+
+    private func handleWriterFailure(
+        _ failure: CheckpointingAudioWriterFailure,
+        writer: CheckpointingAudioWriter,
+        captureID: UUID
+    ) {
+        lock.lock()
+        guard activeCaptureID == captureID,
+              audioWriter === writer,
+              isRunning
+        else {
+            lock.unlock()
+            return
+        }
+        invalidateInputHealthLocked()
+        let callback = onRecordingFailure
+        lock.unlock()
+        callback?(failure, captureID)
+    }
+
+    /// `AVAudioEngine.isRunning` can remain true even when the input tap has stopped
+    /// receiving buffers after a route or media-services change.
+    func isReceivingAudio(
+        now: Date = .now,
+        maximumAge: TimeInterval = 1.5
+    ) -> Bool {
+        lock.lock()
+        let running = isRunning
+        let lastInputBufferAt = state.lastInputBufferAt
+        let inputHealthInvalidated = state.inputHealthInvalidated
+        let engine = self.engine
+        lock.unlock()
+
+        return RecentAudioInputHealth.isReceiving(
+            hasActiveCapture: running && !inputHealthInvalidated,
+            graphIsRunning: engine.isRunning,
+            lastInputBufferAt: lastInputBufferAt,
+            now: now,
+            maximumAge: maximumAge
+        )
     }
 
     @discardableResult
-    func resumeIfNeeded(routeStage: String = "meeting interruption recovery") throws -> Bool {
-        guard isRunning else { return false }
-        guard !engine.isRunning else { return true }
+    func resumeIfNeeded(
+        routeStage: String = "meeting interruption recovery",
+        rebuildGraph: Bool = false,
+        recreateEngine: Bool = false
+    ) throws -> Bool {
+        graphMutationLock.lock()
+        defer { graphMutationLock.unlock() }
+
+        lock.lock()
+        let running = isRunning
+        let targetFormat = self.targetFormat
+        let hasTap = tapInstalled
+        let inputHealthInvalidated = state.inputHealthInvalidated
+        var engine = self.engine
+        lock.unlock()
+        let shouldRebuildGraph = rebuildGraph || inputHealthInvalidated
+        guard running else { return false }
+        guard !engine.isRunning || shouldRebuildGraph || recreateEngine else { return true }
+        guard let targetFormat else { return false }
         _ = try AudioInputRouteManager.configureForRecording(stage: routeStage)
-        engine.prepare()
-        try engine.start()
-        return engine.isRunning
+        lock.lock()
+        state.lastInputBufferAt = nil
+        lock.unlock()
+
+        if recreateEngine {
+            abandonGraphAfterMediaServicesReset(engine)
+            engine = replaceEngine()
+            setConverter(nil)
+            configureAndInstallInputTap(on: engine, targetFormat: targetFormat)
+        } else if shouldRebuildGraph {
+            tearDownGraph(engine)
+            configureAndInstallInputTap(on: engine, targetFormat: targetFormat)
+        } else {
+            guard hasTap else { return false }
+        }
+        do {
+            engine.prepare()
+            try engine.start()
+            return engine.isRunning
+        } catch {
+            tearDownGraph(engine)
+            throw error
+        }
+    }
+
+    /// Media-services reset invalidates the engine instance itself. Replace it while
+    /// preserving the live checkpoint writer and its accumulated audio.
+    @discardableResult
+    func recoverAfterMediaServicesReset(
+        routeStage: String = "meeting media services reset recovery"
+    ) throws -> Bool {
+        try resumeIfNeeded(
+            routeStage: routeStage,
+            rebuildGraph: true,
+            recreateEngine: true
+        )
     }
 
     func stop() -> StopResult {
-        guard isRunning else {
+        graphMutationLock.lock()
+        defer { graphMutationLock.unlock() }
+
+        lock.lock()
+        let running = isRunning
+        let engine = self.engine
+        lock.unlock()
+        guard running else {
             return StopResult(
                 finalChunk: nil,
                 retainedAudioURL: nil,
                 writerFailure: nil
             )
         }
-        isRunning = false
-        if tapInstalled {
-            engine.inputNode.removeTap(onBus: 0)
-            tapInstalled = false
-        }
-        engine.stop()
+        setRunning(false)
+        tearDownGraph(engine)
 
         lock.lock()
         let writer = audioWriter
+        captureGeneration &+= 1
+        activeCaptureID = nil
         audioWriter = nil
+        converter = nil
+        targetFormat = nil
+        state.lastInputBufferAt = nil
         lock.unlock()
         let result = writer?.finish()
 
@@ -144,16 +289,28 @@ final class StreamingMeetingRecorder: @unchecked Sendable {
     }
 
     func cancel() {
-        if tapInstalled {
-            engine.inputNode.removeTap(onBus: 0)
-            tapInstalled = false
+        graphMutationLock.lock()
+        defer { graphMutationLock.unlock() }
+
+        lock.lock()
+        let hasTap = tapInstalled
+        let engine = self.engine
+        lock.unlock()
+        if hasTap {
+            tearDownGraph(engine)
+        } else {
+            engine.stop()
+            invalidateInputHealth()
         }
-        engine.stop()
-        isRunning = false
+        setRunning(false)
 
         lock.lock()
         let writer = audioWriter
+        captureGeneration &+= 1
+        activeCaptureID = nil
         audioWriter = nil
+        converter = nil
+        targetFormat = nil
         state = FileState()
         lock.unlock()
         writer?.cancel()
@@ -167,34 +324,58 @@ final class StreamingMeetingRecorder: @unchecked Sendable {
         return value
     }
 
-    private func handle(buffer: AVAudioPCMBuffer, targetFormat: AVAudioFormat) {
-        let monoBuffer: AVAudioPCMBuffer
-        if let converter {
-            let ratio = targetFormat.sampleRate / buffer.format.sampleRate
-            let frameCapacity = max(1, AVAudioFrameCount(Double(buffer.frameLength) * ratio) + 1)
-            guard let converted = AVAudioPCMBuffer(pcmFormat: targetFormat, frameCapacity: frameCapacity) else { return }
-            let didProvideInput = OSAllocatedUnfairLock(initialState: false)
-            var error: NSError?
-            converter.convert(to: converted, error: &error) { _, outStatus in
-                let shouldProvideInput = didProvideInput.withLock { hasProvidedInput in
-                    guard !hasProvidedInput else { return false }
-                    hasProvidedInput = true
-                    return true
-                }
-                guard shouldProvideInput else {
-                    outStatus.pointee = .noDataNow
-                    return nil
-                }
-                outStatus.pointee = .haveData
-                return buffer
-            }
-            guard error == nil else { return }
-            monoBuffer = converted
-        } else {
-            monoBuffer = buffer
+    /// Fences the active tap and clears all prior liveness evidence. Call this at
+    /// interruption/configuration-event delivery time so pre-event callbacks cannot
+    /// make the post-event graph appear healthy.
+    func invalidateInputHealth() {
+        lock.lock()
+        invalidateInputHealthLocked()
+        lock.unlock()
+    }
+
+    /// Clears liveness evidence while keeping the current tap eligible. Audio already
+    /// in flight may still reach the writer, but its old epoch cannot satisfy a health
+    /// probe issued after this reset.
+    func resetInputHealthEvidence() {
+        lock.lock()
+        state.inputHealthEpoch &+= 1
+        state.lastInputBufferAt = nil
+        state.latestPowerDB = -160
+        lock.unlock()
+    }
+
+    private func handle(
+        buffer: AVAudioPCMBuffer,
+        targetFormat: AVAudioFormat,
+        tapGeneration: UInt64
+    ) {
+        lock.lock()
+        guard tapGeneration == self.tapGeneration,
+              !state.inputHealthInvalidated,
+              isRunning,
+              let writer = audioWriter
+        else {
+            lock.unlock()
+            return
+        }
+        let converter = self.converter
+        let inputHealthEpoch = state.inputHealthEpoch
+        let captureGeneration = self.captureGeneration
+        lock.unlock()
+
+        guard let monoBuffer = convert(
+            buffer: buffer,
+            targetFormat: targetFormat,
+            converter: converter
+        ) else {
+            invalidateInputHealth(ifCurrentTapGeneration: tapGeneration)
+            return
         }
 
-        guard let floatData = monoBuffer.floatChannelData?[0] else { return }
+        guard let floatData = monoBuffer.floatChannelData?[0] else {
+            invalidateInputHealth(ifCurrentTapGeneration: tapGeneration)
+            return
+        }
         let frameCount = Int(monoBuffer.frameLength)
         guard frameCount > 0 else { return }
 
@@ -205,16 +386,106 @@ final class StreamingMeetingRecorder: @unchecked Sendable {
         }
         let rms = sqrt(sumSquares / Float(frameCount))
         let powerDB = rms > 0.000_001 ? max(-160, min(0, 20 * log10(rms))) : -160
+        let receivedAt = Date()
 
+        guard let callbackBuffer = Self.copyBuffer(monoBuffer) else {
+            invalidateInputHealth(ifCurrentTapGeneration: tapGeneration)
+            return
+        }
+        let sendableBuffer = SendableAudioBuffer(callbackBuffer)
+
+        // A tap callback only proves that AVAudioEngine produced bytes. Capture
+        // health must mean those bytes reached at least one durable sink. The
+        // writer acknowledges on its serial queue after a successful write; the
+        // generation/identity checks reject delayed acknowledgements from a torn
+        // down graph, an invalidated health epoch, or an earlier recording.
+        writer.append(monoBuffer) { [weak self, writer, sendableBuffer, samples] in
+            self?.acceptDurablyWrittenInput(
+                writer: writer,
+                buffer: sendableBuffer.value,
+                samples: samples,
+                powerDB: powerDB,
+                receivedAt: receivedAt,
+                tapGeneration: tapGeneration,
+                inputHealthEpoch: inputHealthEpoch,
+                captureGeneration: captureGeneration
+            )
+        }
+    }
+
+    private func acceptDurablyWrittenInput(
+        writer: CheckpointingAudioWriter,
+        buffer: AVAudioPCMBuffer,
+        samples: [Float],
+        powerDB: Float,
+        receivedAt: Date,
+        tapGeneration: UInt64,
+        inputHealthEpoch: UInt64,
+        captureGeneration: UInt64
+    ) {
         lock.lock()
-        audioWriter?.append(monoBuffer)
-        state.latestPowerDB = powerDB
+        let accepted = tapGeneration == self.tapGeneration
+            && inputHealthEpoch == state.inputHealthEpoch
+            && captureGeneration == self.captureGeneration
+            && !state.inputHealthInvalidated
+            && isRunning
+            && audioWriter === writer
+        if accepted {
+            state.latestPowerDB = powerDB
+            state.lastInputBufferAt = receivedAt
+        }
+        let onAudioBuffer = accepted ? self.onAudioBuffer : nil
+        let onAudioSamples = accepted ? self.onAudioSamples : nil
         lock.unlock()
 
-        if let audioBuffer = Self.copyBuffer(monoBuffer) {
-            onAudioBuffer?(audioBuffer)
-        }
+        guard accepted else { return }
+        onAudioBuffer?(buffer)
         onAudioSamples?(samples)
+    }
+
+    private func convert(
+        buffer: AVAudioPCMBuffer,
+        targetFormat: AVAudioFormat,
+        converter: AVAudioConverter?
+    ) -> AVAudioPCMBuffer? {
+        guard buffer.frameLength > 0 else { return nil }
+        guard let converter else {
+            guard Self.formatsMatch(buffer.format, targetFormat) else { return nil }
+            return Self.copyBuffer(buffer)
+        }
+        guard Self.formatsMatch(buffer.format, converter.inputFormat),
+              Self.formatsMatch(targetFormat, converter.outputFormat)
+        else { return nil }
+
+        let ratio = targetFormat.sampleRate / buffer.format.sampleRate
+        let frameCapacity = max(
+            1,
+            AVAudioFrameCount(Double(buffer.frameLength) * ratio) + 1
+        )
+        guard let converted = AVAudioPCMBuffer(
+            pcmFormat: targetFormat,
+            frameCapacity: frameCapacity
+        ) else { return nil }
+        let didProvideInput = OSAllocatedUnfairLock(initialState: false)
+        var error: NSError?
+        converter.convert(to: converted, error: &error) { _, outStatus in
+            let shouldProvideInput = didProvideInput.withLock { hasProvidedInput in
+                guard !hasProvidedInput else { return false }
+                hasProvidedInput = true
+                return true
+            }
+            guard shouldProvideInput else {
+                outStatus.pointee = .noDataNow
+                return nil
+            }
+            outStatus.pointee = .haveData
+            return buffer
+        }
+        guard error == nil,
+              converted.frameLength > 0,
+              Self.formatsMatch(converted.format, targetFormat)
+        else { return nil }
+        return converted
     }
 
     private static func copyBuffer(_ buffer: AVAudioPCMBuffer) -> AVAudioPCMBuffer? {
@@ -241,19 +512,147 @@ final class StreamingMeetingRecorder: @unchecked Sendable {
     }
 
     private func cleanupAfterFailedStart() {
-        if tapInstalled {
-            engine.inputNode.removeTap(onBus: 0)
-            tapInstalled = false
+        graphMutationLock.lock()
+        defer { graphMutationLock.unlock() }
+
+        lock.lock()
+        let hasTap = tapInstalled
+        let engine = self.engine
+        lock.unlock()
+        if hasTap {
+            tearDownGraph(engine)
+        } else {
+            engine.stop()
+            invalidateInputHealth()
         }
-        engine.stop()
         lock.lock()
         let writer = audioWriter
+        captureGeneration &+= 1
+        activeCaptureID = nil
         audioWriter = nil
+        converter = nil
+        targetFormat = nil
         state = FileState()
+        isRunning = false
         lock.unlock()
         writer?.cancel()
-        isRunning = false
         try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
+    }
+
+    private func setRunning(_ running: Bool) {
+        lock.lock()
+        isRunning = running
+        lock.unlock()
+    }
+
+    private func setTapInstalled(_ installed: Bool) {
+        lock.lock()
+        tapInstalled = installed
+        lock.unlock()
+    }
+
+    private func setConverter(_ newConverter: AVAudioConverter?) {
+        lock.lock()
+        converter = newConverter
+        lock.unlock()
+    }
+
+    private func currentEngine() -> AVAudioEngine {
+        lock.lock()
+        let engine = self.engine
+        lock.unlock()
+        return engine
+    }
+
+    private func replaceEngine() -> AVAudioEngine {
+        let replacement = AVAudioEngine()
+        lock.lock()
+        engine = replacement
+        tapInstalled = false
+        lock.unlock()
+        return replacement
+    }
+
+    private func activateTapGeneration() -> UInt64 {
+        lock.lock()
+        tapGeneration &+= 1
+        state.inputHealthEpoch &+= 1
+        state.inputHealthInvalidated = false
+        state.lastInputBufferAt = nil
+        let generation = tapGeneration
+        lock.unlock()
+        return generation
+    }
+
+    private func invalidateInputHealthLocked() {
+        tapGeneration &+= 1
+        state.inputHealthEpoch &+= 1
+        state.inputHealthInvalidated = true
+        state.lastInputBufferAt = nil
+        state.latestPowerDB = -160
+    }
+
+    private func invalidateInputHealth(ifCurrentTapGeneration generation: UInt64) {
+        lock.lock()
+        if generation == tapGeneration {
+            invalidateInputHealthLocked()
+        }
+        lock.unlock()
+    }
+
+    private func installInputTap(on engine: AVAudioEngine, targetFormat: AVAudioFormat) {
+        let generation = activateTapGeneration()
+        engine.inputNode.installTap(
+            onBus: 0,
+            bufferSize: Self.bufferSize,
+            format: nil
+        ) { [weak self] buffer, _ in
+            self?.handle(
+                buffer: buffer,
+                targetFormat: targetFormat,
+                tapGeneration: generation
+            )
+        }
+    }
+
+    private func configureAndInstallInputTap(
+        on engine: AVAudioEngine,
+        targetFormat: AVAudioFormat
+    ) {
+        let inputFormat = engine.inputNode.outputFormat(forBus: 0)
+        let converter = !Self.formatsMatch(inputFormat, targetFormat)
+            ? AVAudioConverter(from: inputFormat, to: targetFormat)
+            : nil
+        setConverter(converter)
+        installInputTap(on: engine, targetFormat: targetFormat)
+        setTapInstalled(true)
+    }
+
+    private func tearDownGraph(_ engine: AVAudioEngine) {
+        lock.lock()
+        let hasTap = tapInstalled
+        lock.unlock()
+        if hasTap {
+            engine.inputNode.removeTap(onBus: 0)
+            setTapInstalled(false)
+        }
+        engine.stop()
+        invalidateInputHealth()
+    }
+
+    private func abandonGraphAfterMediaServicesReset(_ engine: AVAudioEngine) {
+        // The reset invalidates the old audio objects. Avoid touching its input node;
+        // stopping and generation-fencing it is sufficient before releasing it.
+        engine.stop()
+        setTapInstalled(false)
+        invalidateInputHealth()
+    }
+
+    private static func formatsMatch(_ lhs: AVAudioFormat, _ rhs: AVAudioFormat) -> Bool {
+        lhs.sampleRate == rhs.sampleRate
+            && lhs.channelCount == rhs.channelCount
+            && lhs.commonFormat == rhs.commonFormat
+            && lhs.isInterleaved == rhs.isInterleaved
     }
 
 }

--- a/Muesli/VoiceNoteCheckpointStore.swift
+++ b/Muesli/VoiceNoteCheckpointStore.swift
@@ -55,15 +55,7 @@ actor VoiceNoteCheckpointStore {
         let directory = try store.voiceNoteCheckpointDirectoryURL(sessionID: sessionID)
         var manifest = try load(from: directory)
         guard !manifest.entries.contains(where: { $0.index == checkpoint.index }) else { return manifest }
-        let checkpointFile: AVAudioFile
-        do {
-            checkpointFile = try AVAudioFile(forReading: checkpoint.url)
-        } catch {
-            throw StoreError.invalidCheckpoint
-        }
-        guard checkpointFile.length > 0,
-              checkpointFile.processingFormat.sampleRate > 0
-        else {
+        guard let checkpointFile = readableAudioFile(at: checkpoint.url, repairingTrailingPCMHeader: true) else {
             throw StoreError.invalidCheckpoint
         }
         let frameCount = checkpointFile.length
@@ -99,6 +91,7 @@ actor VoiceNoteCheckpointStore {
         let directory = try store.voiceNoteCheckpointDirectoryURL(sessionID: sessionID)
         var manifest = try load(from: directory)
         var expectedIndex = (manifest.entries.map(\.index).max() ?? -1) + 1
+        var recoveredCheckpoint = false
         var startTime = manifest.entries
             .sorted(by: { $0.index < $1.index })
             .last
@@ -109,9 +102,7 @@ actor VoiceNoteCheckpointStore {
                 .appendingPathComponent("chunk-\(String(format: "%04d", expectedIndex))")
                 .appendingPathExtension("wav")
             guard FileManager.default.fileExists(atPath: url.path),
-                  let file = try? AVAudioFile(forReading: url),
-                  file.length > 0,
-                  file.processingFormat.sampleRate > 0
+                  let file = readableAudioFile(at: url, repairingTrailingPCMHeader: true)
             else { break }
 
             let duration = Double(file.length) / file.processingFormat.sampleRate
@@ -123,12 +114,15 @@ actor VoiceNoteCheckpointStore {
                 duration: duration,
                 finalizedAt: fileModificationDate(at: url) ?? .now
             ))
+            recoveredCheckpoint = true
             expectedIndex += 1
             startTime += duration
         }
 
-        manifest.entries.sort { $0.index < $1.index }
-        try write(manifest, to: directory)
+        if recoveredCheckpoint {
+            manifest.entries.sort { $0.index < $1.index }
+            try write(manifest, to: directory)
+        }
         return manifest
     }
 
@@ -141,10 +135,7 @@ actor VoiceNoteCheckpointStore {
     }
 
     func isReadableAudio(at url: URL) -> Bool {
-        guard FileManager.default.fileExists(atPath: url.path),
-              let file = try? AVAudioFile(forReading: url)
-        else { return false }
-        return file.length > 0
+        readableAudioFile(at: url, repairingTrailingPCMHeader: true) != nil
     }
 
     func reconstructAudio(sessionID: UUID, destinationURL: URL) throws -> URL {
@@ -153,15 +144,24 @@ actor VoiceNoteCheckpointStore {
         let entries = recoverableContiguousEntries(manifest.entries, directory: directory)
         guard !entries.isEmpty else { throw StoreError.noRecoverableAudio }
 
-        if FileManager.default.fileExists(atPath: destinationURL.path) {
-            try FileManager.default.removeItem(at: destinationURL)
-        }
+        let recoveryURL = destinationURL.deletingLastPathComponent()
+            .appendingPathComponent(".\(destinationURL.deletingPathExtension().lastPathComponent)-recovery-\(UUID().uuidString)")
+            .appendingPathExtension(destinationURL.pathExtension.isEmpty ? "wav" : destinationURL.pathExtension)
+        try? FileManager.default.removeItem(at: recoveryURL)
 
         var output: AVAudioFile?
+        defer {
+            output = nil
+            try? FileManager.default.removeItem(at: recoveryURL)
+        }
         for entry in entries {
-            let input = try AVAudioFile(forReading: directory.appendingPathComponent(entry.fileName))
+            guard let input = readableAudioFile(
+                at: directory.appendingPathComponent(entry.fileName),
+                repairingTrailingPCMHeader: true
+            ) else { throw StoreError.noRecoverableAudio }
             if output == nil {
-                output = try AVAudioFile(forWriting: destinationURL, settings: input.processingFormat.settings)
+                output = try AVAudioFile(forWriting: recoveryURL, settings: input.processingFormat.settings)
+                try SharedFileProtection.protectAudio(at: recoveryURL)
             } else if output?.processingFormat.sampleRate != input.processingFormat.sampleRate
                         || output?.processingFormat.channelCount != input.processingFormat.channelCount {
                 throw StoreError.incompatibleAudioFormat
@@ -179,6 +179,13 @@ actor VoiceNoteCheckpointStore {
             }
         }
         output = nil
+        guard isReadableAudio(at: recoveryURL) else { throw StoreError.noRecoverableAudio }
+        if FileManager.default.fileExists(atPath: destinationURL.path) {
+            _ = try FileManager.default.replaceItemAt(destinationURL, withItemAt: recoveryURL)
+        } else {
+            try FileManager.default.moveItem(at: recoveryURL, to: destinationURL)
+        }
+        try SharedFileProtection.protectAudio(at: destinationURL)
         guard isReadableAudio(at: destinationURL) else { throw StoreError.noRecoverableAudio }
         return destinationURL
     }
@@ -212,15 +219,226 @@ actor VoiceNoteCheckpointStore {
     private func load(from directory: URL) throws -> VoiceNoteCheckpointManifest {
         let url = directory.appendingPathComponent("manifest.json")
         guard FileManager.default.fileExists(atPath: url.path) else { throw StoreError.missingManifest }
+        SharedFileProtection.protectMetadataBestEffort(at: url)
         return try decoder.decode(VoiceNoteCheckpointManifest.self, from: Data(contentsOf: url))
     }
 
     private func write(_ manifest: VoiceNoteCheckpointManifest, to directory: URL) throws {
         let url = directory.appendingPathComponent("manifest.json")
-        try encoder.encode(manifest).write(to: url, options: .atomic)
+        try encoder.encode(manifest).write(
+            to: url,
+            options: [.atomic, .completeFileProtectionUntilFirstUserAuthentication]
+        )
+        try SharedFileProtection.protectMetadata(at: url)
+    }
+
+    private func readableAudioFile(
+        at url: URL,
+        repairingTrailingPCMHeader: Bool
+    ) -> AVAudioFile? {
+        guard FileManager.default.fileExists(atPath: url.path) else { return nil }
+        try? SharedFileProtection.protectAudio(at: url)
+        if let file = try? AVAudioFile(forReading: url),
+           file.length > 0,
+           file.processingFormat.sampleRate > 0 {
+            return file
+        }
+        guard repairingTrailingPCMHeader, repairTrailingPCMHeader(at: url) else { return nil }
+        guard let repaired = try? AVAudioFile(forReading: url),
+              repaired.length > 0,
+              repaired.processingFormat.sampleRate > 0
+        else { return nil }
+        return repaired
+    }
+
+    private func repairTrailingPCMHeader(at url: URL) -> Bool {
+        let repair: TrailingPCMWAVRepair.RepairPlan
+        do {
+            guard let candidate = try TrailingPCMWAVRepair.repairPlan(for: url) else {
+                return false
+            }
+            repair = candidate
+        } catch {
+            return false
+        }
+
+        do {
+            try TrailingPCMWAVRepair.apply(repair, to: url)
+            try SharedFileProtection.protectAudio(at: url)
+            guard let repairedFile = try? AVAudioFile(forReading: url),
+                  repairedFile.length > 0,
+                  repairedFile.processingFormat.sampleRate > 0
+            else {
+                try? TrailingPCMWAVRepair.restore(repair, at: url)
+                try? SharedFileProtection.protectAudio(at: url)
+                return false
+            }
+            return true
+        } catch {
+            try? TrailingPCMWAVRepair.restore(repair, at: url)
+            try? SharedFileProtection.protectAudio(at: url)
+            return false
+        }
     }
 
     private func fileModificationDate(at url: URL) -> Date? {
         try? url.resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate
+    }
+}
+
+private enum TrailingPCMWAVRepair {
+    struct RepairPlan {
+        let riffSizeOffset: UInt64
+        let dataSizeOffset: UInt64
+        let originalRIFFSize: UInt32
+        let originalDataSize: UInt32
+        let repairedRIFFSize: UInt32
+        let repairedDataSize: UInt32
+    }
+
+    private static let riff = Array("RIFF".utf8)
+    private static let wave = Array("WAVE".utf8)
+    private static let formatChunk = Array("fmt ".utf8)
+    private static let dataChunk = Array("data".utf8)
+    private static let supportedFormatTags: Set<UInt16> = [1, 3, 0xFFFE]
+
+    static func repairPlan(for url: URL) throws -> RepairPlan? {
+        let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
+        guard let sizeNumber = attributes[.size] as? NSNumber else { return nil }
+        let fileSize = sizeNumber.uint64Value
+        guard fileSize >= 44,
+              fileSize - 8 <= UInt64(UInt32.max)
+        else { return nil }
+
+        let handle = try FileHandle(forReadingFrom: url)
+        defer { try? handle.close() }
+        let header = try read(handle, offset: 0, count: 12)
+        guard matches(riff, in: header, at: 0),
+              matches(wave, in: header, at: 8)
+        else { return nil }
+
+        let originalRIFFSize = readUInt32(from: header, at: 4)
+        var cursor: UInt64 = 12
+        var validPCMFormat = false
+        var blockAlignment: UInt64 = 0
+
+        while cursor + 8 <= fileSize {
+            let chunkHeader = try read(handle, offset: cursor, count: 8)
+            let payloadOffset = cursor + 8
+            let declaredSize = UInt64(readUInt32(from: chunkHeader, at: 4))
+
+            if matches(formatChunk, in: chunkHeader, at: 0) {
+                guard declaredSize >= 16, payloadOffset + 16 <= fileSize else { return nil }
+                let format = try read(handle, offset: payloadOffset, count: 16)
+                let formatTag = readUInt16(from: format, at: 0)
+                let channels = readUInt16(from: format, at: 2)
+                let sampleRate = readUInt32(from: format, at: 4)
+                let alignment = readUInt16(from: format, at: 12)
+                let bitsPerSample = readUInt16(from: format, at: 14)
+                validPCMFormat = supportedFormatTags.contains(formatTag)
+                    && channels > 0
+                    && sampleRate > 0
+                    && alignment > 0
+                    && bitsPerSample > 0
+                blockAlignment = UInt64(alignment)
+            } else if matches(dataChunk, in: chunkHeader, at: 0) {
+                guard validPCMFormat, blockAlignment > 0 else { return nil }
+                let availableBytes = fileSize - payloadOffset
+                let recoveredBytes = availableBytes - (availableBytes % blockAlignment)
+                guard recoveredBytes > 0,
+                      recoveredBytes <= UInt64(UInt32.max)
+                else { return nil }
+
+                let expectedRIFFSize = UInt32(payloadOffset + recoveredBytes - 8)
+                let expectedDataSize = UInt32(recoveredBytes)
+                let originalDataSize = readUInt32(from: chunkHeader, at: 4)
+                guard originalRIFFSize != expectedRIFFSize || originalDataSize != expectedDataSize else {
+                    return nil
+                }
+                return RepairPlan(
+                    riffSizeOffset: 4,
+                    dataSizeOffset: cursor + 4,
+                    originalRIFFSize: originalRIFFSize,
+                    originalDataSize: originalDataSize,
+                    repairedRIFFSize: expectedRIFFSize,
+                    repairedDataSize: expectedDataSize
+                )
+            }
+
+            let paddedSize = declaredSize + (declaredSize % 2)
+            guard payloadOffset <= fileSize,
+                  paddedSize <= fileSize - payloadOffset
+            else { return nil }
+            cursor = payloadOffset + paddedSize
+        }
+        return nil
+    }
+
+    static func apply(_ plan: RepairPlan, to url: URL) throws {
+        try writeHeaderSizes(
+            riffSize: plan.repairedRIFFSize,
+            dataSize: plan.repairedDataSize,
+            plan: plan,
+            to: url
+        )
+    }
+
+    static func restore(_ plan: RepairPlan, at url: URL) throws {
+        try writeHeaderSizes(
+            riffSize: plan.originalRIFFSize,
+            dataSize: plan.originalDataSize,
+            plan: plan,
+            to: url
+        )
+    }
+
+    private static func matches(_ bytes: [UInt8], in data: Data, at offset: Int) -> Bool {
+        guard offset >= 0, offset + bytes.count <= data.count else { return false }
+        return bytes.indices.allSatisfy { data[offset + $0] == bytes[$0] }
+    }
+
+    private static func readUInt16(from data: Data, at offset: Int) -> UInt16 {
+        UInt16(data[offset]) | (UInt16(data[offset + 1]) << 8)
+    }
+
+    private static func readUInt32(from data: Data, at offset: Int) -> UInt32 {
+        UInt32(data[offset])
+            | (UInt32(data[offset + 1]) << 8)
+            | (UInt32(data[offset + 2]) << 16)
+            | (UInt32(data[offset + 3]) << 24)
+    }
+
+    private static func read(_ handle: FileHandle, offset: UInt64, count: Int) throws -> Data {
+        try handle.seek(toOffset: offset)
+        guard let data = try handle.read(upToCount: count), data.count == count else {
+            throw CocoaError(.fileReadCorruptFile)
+        }
+        return data
+    }
+
+    private static func writeHeaderSizes(
+        riffSize: UInt32,
+        dataSize: UInt32,
+        plan: RepairPlan,
+        to url: URL
+    ) throws {
+        let handle = try FileHandle(forUpdating: url)
+        defer { try? handle.close() }
+        // Write the payload size first. If the process is terminated between
+        // writes, the next salvage pass can still derive and finish both values.
+        try handle.seek(toOffset: plan.dataSizeOffset)
+        try handle.write(contentsOf: littleEndianBytes(dataSize))
+        try handle.seek(toOffset: plan.riffSizeOffset)
+        try handle.write(contentsOf: littleEndianBytes(riffSize))
+        try handle.synchronize()
+    }
+
+    private static func littleEndianBytes(_ value: UInt32) -> Data {
+        Data([
+            UInt8(truncatingIfNeeded: value),
+            UInt8(truncatingIfNeeded: value >> 8),
+            UInt8(truncatingIfNeeded: value >> 16),
+            UInt8(truncatingIfNeeded: value >> 24),
+        ])
     }
 }

--- a/Muesli/VoiceNoteLifecycle.swift
+++ b/Muesli/VoiceNoteLifecycle.swift
@@ -5,6 +5,8 @@ struct VoiceNoteLifecycleState: Equatable {
         case idle
         case recordingShort(UUID)
         case recordingLongProtected(UUID)
+        case interruptedShort(UUID)
+        case interruptedLongProtected(UUID)
         case stopping(UUID)
         case audioSaved(UUID)
         case transcriptionQueued(UUID)
@@ -17,6 +19,8 @@ struct VoiceNoteLifecycleState: Equatable {
             case .idle: "idle"
             case .recordingShort: "recording_short"
             case .recordingLongProtected: "recording_long_protected"
+            case .interruptedShort: "interrupted_short"
+            case .interruptedLongProtected: "interrupted_long_protected"
             case .stopping: "stopping"
             case .audioSaved: "audio_saved"
             case .transcriptionQueued: "transcription_queued"
@@ -33,9 +37,10 @@ struct VoiceNoteLifecycleState: Equatable {
         switch phase {
         case .idle:
             nil
-        case .recordingShort(let id), .recordingLongProtected(let id), .stopping(let id),
-             .audioSaved(let id), .transcriptionQueued(let id), .transcribing(let id),
-             .failedRetryable(let id), .cancelling(let id):
+        case .recordingShort(let id), .recordingLongProtected(let id),
+             .interruptedShort(let id), .interruptedLongProtected(let id),
+             .stopping(let id), .audioSaved(let id), .transcriptionQueued(let id),
+             .transcribing(let id), .failedRetryable(let id), .cancelling(let id):
             id
         }
     }
@@ -44,25 +49,27 @@ struct VoiceNoteLifecycleState: Equatable {
         switch phase {
         case .recordingShort, .recordingLongProtected, .stopping:
             true
-        case .idle, .audioSaved, .transcriptionQueued, .transcribing, .failedRetryable, .cancelling:
+        case .idle, .interruptedShort, .interruptedLongProtected, .audioSaved,
+             .transcriptionQueued, .transcribing, .failedRetryable, .cancelling:
             false
         }
     }
 
     var isLongFormVisible: Bool {
         switch phase {
-        case .recordingLongProtected, .stopping, .audioSaved, .transcriptionQueued,
-             .transcribing, .failedRetryable:
+        case .recordingLongProtected, .interruptedLongProtected, .stopping, .audioSaved,
+             .transcriptionQueued, .transcribing, .failedRetryable:
             true
-        case .idle, .recordingShort, .cancelling:
+        case .idle, .recordingShort, .interruptedShort, .cancelling:
             false
         }
     }
 
     var isWorkActive: Bool {
         switch phase {
-        case .recordingShort, .recordingLongProtected, .stopping, .audioSaved,
-             .transcriptionQueued, .transcribing, .cancelling:
+        case .recordingShort, .recordingLongProtected, .interruptedShort,
+             .interruptedLongProtected, .stopping, .audioSaved, .transcriptionQueued,
+             .transcribing, .cancelling:
             true
         case .idle, .failedRetryable:
             false
@@ -73,6 +80,8 @@ struct VoiceNoteLifecycleState: Equatable {
 enum VoiceNoteLifecycleEvent {
     case recordingStarted(UUID)
     case longFormActivated(UUID)
+    case captureInterrupted(UUID)
+    case captureResumed(UUID)
     case stopRequested(UUID)
     case audioFinalized(UUID)
     case transcriptionQueued(UUID)
@@ -86,6 +95,8 @@ enum VoiceNoteLifecycleEvent {
         switch self {
         case .recordingStarted: "recording_started"
         case .longFormActivated: "long_form_activated"
+        case .captureInterrupted: "capture_interrupted"
+        case .captureResumed: "capture_resumed"
         case .stopRequested: "stop_requested"
         case .audioFinalized: "audio_finalized"
         case .transcriptionQueued: "transcription_queued"
@@ -118,9 +129,31 @@ enum VoiceNoteLifecycleReducer {
             nextState = state
         case (.recordingShort(let activeID), .longFormActivated(let id)) where activeID == id:
             nextState = VoiceNoteLifecycleState(phase: .recordingLongProtected(id))
+        case (.interruptedShort(let activeID), .longFormActivated(let id)) where activeID == id:
+            nextState = VoiceNoteLifecycleState(phase: .interruptedLongProtected(id))
+        case (.recordingShort(let activeID), .captureInterrupted(let id)) where activeID == id:
+            nextState = VoiceNoteLifecycleState(phase: .interruptedShort(id))
+        case (.recordingLongProtected(let activeID), .captureInterrupted(let id)) where activeID == id:
+            nextState = VoiceNoteLifecycleState(phase: .interruptedLongProtected(id))
+        case (.interruptedShort(let activeID), .captureInterrupted(let id)) where activeID == id:
+            nextState = state
+        case (.interruptedLongProtected(let activeID), .captureInterrupted(let id)) where activeID == id:
+            nextState = state
+        case (.interruptedShort(let activeID), .captureResumed(let id)) where activeID == id:
+            nextState = VoiceNoteLifecycleState(phase: .recordingShort(id))
+        case (.interruptedLongProtected(let activeID), .captureResumed(let id)) where activeID == id:
+            nextState = VoiceNoteLifecycleState(phase: .recordingLongProtected(id))
+        case (.recordingShort(let activeID), .captureResumed(let id)) where activeID == id:
+            nextState = state
+        case (.recordingLongProtected(let activeID), .captureResumed(let id)) where activeID == id:
+            nextState = state
         case (.recordingShort(let activeID), .stopRequested(let id)) where activeID == id:
             nextState = VoiceNoteLifecycleState(phase: .stopping(id))
         case (.recordingLongProtected(let activeID), .stopRequested(let id)) where activeID == id:
+            nextState = VoiceNoteLifecycleState(phase: .stopping(id))
+        case (.interruptedShort(let activeID), .stopRequested(let id)) where activeID == id:
+            nextState = VoiceNoteLifecycleState(phase: .stopping(id))
+        case (.interruptedLongProtected(let activeID), .stopRequested(let id)) where activeID == id:
             nextState = VoiceNoteLifecycleState(phase: .stopping(id))
         case (.stopping(let activeID), .audioFinalized(let id)) where activeID == id:
             nextState = VoiceNoteLifecycleState(phase: .audioSaved(id))
@@ -147,6 +180,10 @@ enum VoiceNoteLifecycleReducer {
         case (.recordingShort(let activeID), .cancelRequested(let id)) where activeID == id:
             nextState = VoiceNoteLifecycleState(phase: .cancelling(id))
         case (.recordingLongProtected(let activeID), .cancelRequested(let id)) where activeID == id:
+            nextState = VoiceNoteLifecycleState(phase: .cancelling(id))
+        case (.interruptedShort(let activeID), .cancelRequested(let id)) where activeID == id:
+            nextState = VoiceNoteLifecycleState(phase: .cancelling(id))
+        case (.interruptedLongProtected(let activeID), .cancelRequested(let id)) where activeID == id:
             nextState = VoiceNoteLifecycleState(phase: .cancelling(id))
         case (.stopping(let activeID), .cancelRequested(let id)) where activeID == id:
             nextState = VoiceNoteLifecycleState(phase: .cancelling(id))
@@ -283,7 +320,7 @@ enum VoiceNoteFailureLifecycleDisposition: Equatable {
     case finished
 
     static func resolve(for session: RecordingSession) -> VoiceNoteFailureLifecycleDisposition {
-        session.isLongForm ? .retryable : .finished
+        session.protectedAudioUntilTranscriptCompletes ? .retryable : .finished
     }
 }
 
@@ -310,8 +347,8 @@ enum VoiceNoteFailureSessionPolicy {
         failedSession.phase = .failed
         failedSession.errorMessage = message
         failedSession.lastTranscriptionFailureReason = reason
-        failedSession.protectedAudioUntilTranscriptCompletes = session.isLongForm
-            && hasRecoverableAudio
+        failedSession.protectedAudioUntilTranscriptCompletes =
+            session.protectedAudioUntilTranscriptCompletes || hasRecoverableAudio
         return failedSession
     }
 }
@@ -336,14 +373,9 @@ enum VoiceNoteCheckpointRetentionPolicy {
         if session.phase == .completed || session.phase == .cancelled {
             return true
         }
-        if session.protectedAudioUntilTranscriptCompletes,
-           session.audioFileName != nil {
-            return false
-        }
-        if !session.isLongForm {
-            return ![.recording, .transcriptionQueued, .transcribing].contains(session.phase)
-        }
-        return session.audioFileName == nil
-            && !session.protectedAudioUntilTranscriptCompletes
+        // A failed/interrupted row can lag a checkpoint already sealed on disk.
+        // Only an explicit completion/cancellation may garbage-collect that evidence;
+        // treating missing booleans as proof of absence recreates the lock-screen loss.
+        return false
     }
 }

--- a/Muesli/VoiceNoteTimeline.swift
+++ b/Muesli/VoiceNoteTimeline.swift
@@ -80,10 +80,17 @@ enum VoiceNoteTimelineBuilder {
             )
         }
         let recoverable = input.sessions.compactMap { session -> VoiceNoteTimelineItem? in
+            let hasDraft = !(session.draftTranscriptText?
+                .trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ?? true)
+            let hasRecoveryEvidence = session.audioFileName != nil
+                || session.protectedAudioUntilTranscriptCompletes
+                || session.hasDurableAudioCheckpoint
+                || hasDraft
             guard input.sourceFilter.includes(session.syncOrigin),
                   session.kind != .meeting,
-                  session.isLongForm,
-                  [.recording, .transcriptionQueued, .transcribing, .failed].contains(session.phase)
+                  hasRecoveryEvidence,
+                  [.recording, .interrupted, .transcriptionQueued, .transcribing, .failed]
+                    .contains(session.phase)
             else { return nil }
             return .recoverable(session)
         }

--- a/MuesliKeyboard/KeyboardController.swift
+++ b/MuesliKeyboard/KeyboardController.swift
@@ -7,10 +7,13 @@ final class KeyboardController {
     private static let staleRecordingInterval: TimeInterval = 45
     private static let staleStoppingInterval: TimeInterval = 10
     private static let staleTranscribingInterval: TimeInterval = 120
+    private static let runtimeFreshnessInterval: TimeInterval = 2
+    private static let activeReconciliationInterval = Duration.milliseconds(750)
     private let store: SharedStore
     private let eventBus: any CrossProcessEventStreaming
     private let handoffRecoveryPolicy = KeyboardHandoffRecoveryPolicy.keyboardDefaults
     private var eventObservationTask: Task<Void, Never>?
+    private var presentationReconciliationTask: Task<Void, Never>?
     private var commandAcknowledgementTask: Task<Void, Never>?
     private var latestResultID: UUID?
     private var preparedRequest: DictationRequest?
@@ -20,6 +23,11 @@ final class KeyboardController {
     private var latestRuntimeStatus: KeyboardRuntimeStatus?
     private var insertedRequestIDs = Set<UUID>()
     private var cancelledRequestIDs = Set<UUID>()
+    private let presentationOwnerID = UUID()
+    private var isPresentationEligible = false
+    private var hasPresentationLease = false
+    private var pendingManualInsertionResult: DictationResult?
+    private var manualInsertionAwaitingConfirmation = false
     private var isBlockedByAppVoiceNote = false
 
     var statusText = "Record a voice note first"
@@ -32,7 +40,9 @@ final class KeyboardController {
     var keyboardDismisser: (@MainActor () -> Void)?
     var liveTranscript = ""
     var inputLevel = 0.0
+    var isCaptureRecovering = false
     var isLaunchSettled = false
+    var waveformRenderGeneration = 0
     private var lastInsertedCharacterCount = 0
     private var canUseRuntimeStart = false
 
@@ -66,6 +76,10 @@ final class KeyboardController {
             "Transcribing"
         case .inserted:
             "Inserted"
+        case .manualInsert:
+            manualInsertionAwaitingConfirmation
+                ? "Insert if missing"
+                : "Review recovered text"
         case .record:
             "Record"
         }
@@ -87,6 +101,10 @@ final class KeyboardController {
             "waveform"
         case .inserted:
             "checkmark"
+        case .manualInsert:
+            manualInsertionAwaitingConfirmation
+                ? "text.badge.plus"
+                : "exclamationmark.triangle"
         case .record:
             "mic.fill"
         }
@@ -102,6 +120,9 @@ final class KeyboardController {
         }
         if recoveryRequestID != nil {
             return .openMuesliRecovery
+        }
+        if pendingManualInsertionResult != nil {
+            return .manualInsert
         }
 
         if latestHandoffState.map({ [.stopRequested, .cancelRequested].contains($0.phase) }) == true {
@@ -138,15 +159,22 @@ final class KeyboardController {
     }
 
     var waveformMode: MuesliFloatingWaveformMode {
-        MuesliKeyboardWaveformPresentation.mode(for: dictationPhase)
+        isCaptureRecovering
+            ? .waiting
+            : MuesliKeyboardWaveformPresentation.mode(for: dictationPhase)
     }
 
     var waveformLevel: Double? {
-        MuesliKeyboardWaveformPresentation.level(for: dictationPhase, inputLevel: inputLevel)
+        isCaptureRecovering
+            ? nil
+            : MuesliKeyboardWaveformPresentation.level(for: dictationPhase, inputLevel: inputLevel)
     }
 
     var canCancelActiveDictation: Bool {
         [.requested, .recording, .transcribing].contains(dictationPhase)
+            && latestHandoffState.map {
+                ![.stopRequested, .cancelRequested].contains($0.phase)
+            } != false
     }
 
     var settingsURL: URL? {
@@ -182,6 +210,15 @@ final class KeyboardController {
     func primaryAction() {
         refreshLatestDictation()
         guard !isBlockedByAppVoiceNote else { return }
+        if pendingManualInsertionResult != nil {
+            guard manualInsertionAwaitingConfirmation else {
+                manualInsertionAwaitingConfirmation = true
+                statusText = "Verify the text is missing before inserting"
+                return
+            }
+            insertRecoveredResultAfterUserConfirmation()
+            return
+        }
         switch dictationPhase {
         case .requested, .recording:
             stopActiveDictation()
@@ -217,16 +254,13 @@ final class KeyboardController {
         }
     }
 
-    func prepareLaunchRequestIfNeeded(clearsPendingCommand: Bool = true) {
+    func prepareLaunchRequestIfNeeded() {
         guard preparedRequest == nil, activeRequestID == nil else { return }
         let request = DictationRequest()
         preparedRequest = request
         launchURL = makeLaunchURL(for: request)
 
         do {
-            if clearsPendingCommand, !hasPendingCancelCommand() {
-                try store.clearPendingCommand()
-            }
             try store.saveRequest(request)
         } catch {
             statusText = "Enable Full Access"
@@ -236,8 +270,9 @@ final class KeyboardController {
     func startDictation() {
         refreshLatestDictation()
         guard !isBlockedByAppVoiceNote else { return }
-        if hasPendingCancelCommand() {
-            try? store.clearPendingCommand()
+        guard ensurePresentationAuthority() else {
+            statusText = "Switch back to Muesli Keyboard"
+            return
         }
 
         MuesliHaptics.dictationStart()
@@ -253,16 +288,24 @@ final class KeyboardController {
         statusText = "Opening Muesli"
 
         do {
-            try store.clearPendingCommand()
             try store.clearKeyboardLiveTranscript()
-            try store.saveRequest(request)
-            try store.saveKeyboardHandoffState(.init(
+            let handoff = makeLocalHandoffState(
                 requestID: request.id,
                 phase: .startRequested,
-                message: canUseRuntimeStart ? "Starting" : "Opening Muesli"
-            ))
+                message: canUseRuntimeStart ? "Starting" : "Opening Muesli",
+                createdAt: request.createdAt
+            )
+            let command = DictationCommand(requestID: request.id, action: .start)
+            guard try store.submitKeyboardIntent(
+                request: request,
+                command: command,
+                handoffState: handoff
+            ) else {
+                refreshLatestDictation()
+                return
+            }
+            latestHandoffState = handoff
             if canUseRuntimeStart {
-                try store.saveCommand(.init(requestID: request.id, action: .start))
                 awaitCommandAcknowledgement(
                     requestID: request.id,
                     action: .start,
@@ -280,6 +323,10 @@ final class KeyboardController {
     }
 
     private func stopActiveDictation() {
+        guard ensurePresentationAuthority() else {
+            statusText = "Switch back to Muesli Keyboard"
+            return
+        }
         guard let activeRequestID else {
             dictationPhase = .idle
             statusText = hasLatestDictation ? "Latest ready" : "Ready"
@@ -289,12 +336,21 @@ final class KeyboardController {
 
         MuesliHaptics.dictationStop()
         do {
-            try store.saveKeyboardHandoffState(.init(
+            let handoff = makeLocalHandoffState(
                 requestID: activeRequestID,
                 phase: .stopRequested,
                 message: "Stopping"
-            ))
-            try store.saveCommand(.init(requestID: activeRequestID, action: .stop))
+            )
+            let command = DictationCommand(requestID: activeRequestID, action: .stop)
+            guard try store.submitKeyboardIntent(
+                request: nil,
+                command: command,
+                handoffState: handoff
+            ) else {
+                refreshLatestDictation()
+                return
+            }
+            latestHandoffState = handoff
             dictationPhase = .recording
             statusText = "Stopping"
             awaitCommandAcknowledgement(
@@ -346,6 +402,10 @@ final class KeyboardController {
             statusText = dictationPhase == .transcribing ? "Transcribing" : statusText
             return
         }
+        guard ensurePresentationAuthority() else {
+            statusText = "Switch back to Muesli Keyboard"
+            return
+        }
 
         guard let activeRequestID else {
             dictationPhase = .idle
@@ -357,12 +417,21 @@ final class KeyboardController {
 
         MuesliHaptics.dictationStop()
         do {
-            try store.saveKeyboardHandoffState(.init(
+            let handoff = makeLocalHandoffState(
                 requestID: activeRequestID,
                 phase: .cancelRequested,
                 message: "Cancelling"
-            ))
-            try store.saveCommand(.init(requestID: activeRequestID, action: .cancel))
+            )
+            let command = DictationCommand(requestID: activeRequestID, action: .cancel)
+            guard try store.submitKeyboardIntent(
+                request: nil,
+                command: command,
+                handoffState: handoff
+            ) else {
+                refreshLatestDictation()
+                return
+            }
+            latestHandoffState = handoff
             dictationPhase = .recording
             statusText = "Cancelling"
             awaitCommandAcknowledgement(
@@ -375,21 +444,32 @@ final class KeyboardController {
         }
     }
 
-    private func hasPendingCancelCommand() -> Bool {
-        guard let command = try? store.pendingCommand(), command.action == .cancel else { return false }
-        return cancelledRequestIDs.contains(command.requestID)
-    }
-
     func prepareInitialPresentationState() {
+        guard isPresentationEligible else { return }
         refreshLatestDictation()
         prepareLaunchRequestIfNeeded()
     }
 
     func startObservingSharedState() {
+        beginObservingSharedState(reconciliation: .full)
+    }
+
+    private enum ObservationReconciliation {
+        case full
+        case activePresentation
+    }
+
+    private func beginObservingSharedState(reconciliation: ObservationReconciliation) {
+        renewPresentationLease()
         markKeyboardVisible()
         eventObservationTask?.cancel()
         let events = eventBus.events()
-        refreshLatestDictation()
+        switch reconciliation {
+        case .full:
+            refreshLatestDictation()
+        case .activePresentation:
+            refreshActivePresentationState()
+        }
         prepareLaunchRequestIfNeeded()
         eventObservationTask = Task { @MainActor [weak self] in
             for await event in events {
@@ -399,13 +479,51 @@ final class KeyboardController {
                     self.refreshRuntimeStatus()
                 case .liveTranscriptChanged:
                     self.refreshLiveTranscript()
-                case .handoffStatusChanged, .resultChanged, .ownershipChanged:
+                case .handoffStatusChanged, .resultChanged:
                     self.refreshLatestDictation()
+                case .ownershipChanged:
+                    if self.hasActivePresentationWork {
+                        self.refreshActivePresentationState()
+                    } else {
+                        self.refreshLatestDictation()
+                    }
                 case .commandChanged:
                     break
                 }
             }
         }
+        startActivePresentationReconciliation()
+    }
+
+    /// Darwin notifications are an acceleration hint, not a durable event log.
+    /// The extension host may suspend while the container continues recording,
+    /// so every host activation restarts the stream and pulls the latest SQLite
+    /// projection before accepting more UI input.
+    func resumeAfterHostActivation() {
+        guard isPresentationEligible else { return }
+        renewPresentationLease()
+        waveformRenderGeneration &+= 1
+        beginObservingSharedState(reconciliation: .activePresentation)
+    }
+
+    func activatePresentationLease() {
+        isPresentationEligible = true
+        renewPresentationLease()
+    }
+
+    func suspendPresentationEligibility() {
+        isPresentationEligible = false
+        hasPresentationLease = false
+    }
+
+    func deactivatePresentationLease() {
+        isPresentationEligible = false
+        _ = try? store.releaseKeyboardPresentationLease(ownerID: presentationOwnerID)
+        hasPresentationLease = false
+    }
+
+    func reconcileSharedPresentationState() {
+        refreshActivePresentationState()
     }
 
     func markKeyboardVisible() {
@@ -419,29 +537,82 @@ final class KeyboardController {
     func stopObservingSharedState() {
         eventObservationTask?.cancel()
         eventObservationTask = nil
+        presentationReconciliationTask?.cancel()
+        presentationReconciliationTask = nil
         commandAcknowledgementTask?.cancel()
         commandAcknowledgementTask = nil
     }
 
+    private func startActivePresentationReconciliation() {
+        presentationReconciliationTask?.cancel()
+        presentationReconciliationTask = Task { @MainActor [weak self] in
+            while !Task.isCancelled {
+                do {
+                    try await Task.sleep(for: Self.activeReconciliationInterval)
+                } catch {
+                    return
+                }
+                guard let self, self.isPresentationEligible else { continue }
+                self.renewPresentationLease()
+                if self.hasActivePresentationWork {
+                    self.refreshActivePresentationState()
+                }
+            }
+        }
+    }
+
+    private func renewPresentationLease() {
+        guard isPresentationEligible else {
+            hasPresentationLease = false
+            return
+        }
+        hasPresentationLease = (try? store.acquireKeyboardPresentationLease(
+            ownerID: presentationOwnerID
+        )) == true
+    }
+
+    private func ensurePresentationAuthority() -> Bool {
+        guard isPresentationEligible else { return false }
+        renewPresentationLease()
+        return hasPresentationLease
+    }
+
+    private var hasActivePresentationWork: Bool {
+        activeRequestID != nil
+            || recoveryRequestID != nil
+            || latestHandoffState.map {
+                ![.idle, .inserted, .failed, .cancelled].contains($0.phase)
+            } == true
+    }
+
     private func refreshLatestDictation() {
         do {
-            let runtimeStatus = try store.keyboardRuntimeStatus()
+            let snapshot = try store.keyboardPresentationSnapshot(
+                preferredRequestID: activeRequestID
+            )
+            let runtimeStatus = snapshot.runtimeStatus
             latestRuntimeStatus = runtimeStatus
-            apply(runtimeStatus: runtimeStatus)
-            let status = try store.status()
+            let status = snapshot.status
 
-            let handoffState = try store.keyboardHandoffState()
+            let handoffState = snapshot.handoffState
             latestHandoffState = handoffState
             apply(handoffState: handoffState)
-            apply(liveTranscript: try store.keyboardLiveTranscript())
 
             let statusBelongsToAppVoiceNote = applyAppVoiceNoteOwnership(status: status)
             if !statusBelongsToAppVoiceNote,
-               (handoffState.requestID == nil
-                || [.idle, .failed, .cancelled, .inserted].contains(handoffState.phase)) {
+               (handoffState.requestID == nil || handoffState.phase == .idle) {
                 apply(status: status)
             }
+            apply(runtimeStatus: runtimeStatus)
+            apply(liveTranscript: snapshot.liveTranscript)
             if isBlockedByAppVoiceNote {
+                return
+            }
+
+            if let activeRequestID,
+               snapshot.targetRequestID == activeRequestID,
+               let activeResult = snapshot.result {
+                insertCompletedResult(activeResult)
                 return
             }
 
@@ -455,11 +626,6 @@ final class KeyboardController {
             }
 
             hasLatestDictation = true
-            if let activeRequestID, let activeResult = try store.result(for: activeRequestID) {
-                insertCompletedResult(activeResult)
-                return
-            }
-
             if latestResultID != result.id {
                 latestResultID = result.id
                 if activeRequestID == nil, !isBlockedByAppVoiceNote {
@@ -470,6 +636,43 @@ final class KeyboardController {
                       statusText != "Inserted" {
                 statusText = "Latest ready"
             }
+        } catch {
+            apply(runtimeStatus: latestRuntimeStatus)
+            statusText = "Waiting for Full Access"
+        }
+    }
+
+    /// Lightweight reconciliation used while a request is active. It deliberately
+    /// avoids loading the complete history, which may contain thousands of notes.
+    /// Request ownership is established before applying the meter row so the first
+    /// post-resume level cannot be discarded during cold rehydration.
+    private func refreshActivePresentationState() {
+        do {
+            let snapshot = try store.keyboardPresentationSnapshot(
+                preferredRequestID: activeRequestID
+            )
+            let runtimeStatus = snapshot.runtimeStatus
+            let status = snapshot.status
+            let handoffState = snapshot.handoffState
+
+            latestRuntimeStatus = runtimeStatus
+            latestHandoffState = handoffState
+            apply(handoffState: handoffState)
+
+            let statusBelongsToAppVoiceNote = applyAppVoiceNoteOwnership(status: status)
+            if !statusBelongsToAppVoiceNote,
+               (handoffState.requestID == nil || handoffState.phase == .idle) {
+                apply(status: status)
+            }
+            apply(runtimeStatus: runtimeStatus)
+            apply(liveTranscript: snapshot.liveTranscript)
+
+            guard !isBlockedByAppVoiceNote,
+                  let requestID = activeRequestID,
+                  snapshot.targetRequestID == requestID,
+                  let result = snapshot.result
+            else { return }
+            insertCompletedResult(result)
         } catch {
             apply(runtimeStatus: latestRuntimeStatus)
             statusText = "Waiting for Full Access"
@@ -494,12 +697,26 @@ final class KeyboardController {
         }
     }
 
-    private func apply(handoffState: KeyboardHandoffState) {
+    private func apply(
+        handoffState: KeyboardHandoffState,
+        evaluatesRecovery: Bool = true
+    ) {
+        reconcilePendingManualInsertion(with: handoffState)
         guard let requestID = handoffState.requestID else { return }
 
         if ![.startRequested, .stopRequested, .cancelRequested].contains(handoffState.phase) {
             commandAcknowledgementTask?.cancel()
             commandAcknowledgementTask = nil
+        }
+
+        if activeRequestID != requestID {
+            // The single durable handoff row is the cross-process authority.
+            // After suspension the extension may still remember an older local
+            // request; replace it before applying terminal state, meter, or result.
+            activeRequestID = requestID
+            recoveryRequestID = nil
+            liveTranscript = ""
+            inputLevel = 0
         }
 
         if cancelledRequestIDs.contains(requestID) {
@@ -516,29 +733,14 @@ final class KeyboardController {
             return
         }
 
-        let resumablePhases: [KeyboardHandoffPhase] = [
-            .startRequested,
-            .startAcknowledged,
-            .recordingStarted,
-            .stopRequested,
-            .cancelRequested,
-            .stopAcknowledged,
-            .audioSaved,
-            .transcribingStarted,
-            .resultReady,
-            .recoveryRequested
-        ]
-        if activeRequestID == nil, resumablePhases.contains(handoffState.phase) {
-            activeRequestID = requestID
-        }
-
-        guard activeRequestID == requestID else { return }
-
-        if markHandoffForRecoveryIfStale(handoffState) {
+        if evaluatesRecovery, markHandoffForRecoveryIfStale(handoffState) {
             return
         }
 
         recoveryRequestID = handoffState.phase == .recoveryRequested ? requestID : nil
+        if handoffState.phase != .recordingStarted {
+            isCaptureRecovering = false
+        }
 
         switch handoffState.phase {
         case .idle:
@@ -579,7 +781,7 @@ final class KeyboardController {
             inputLevel = 0
             statusText = handoffState.message ?? "Inserting"
         case .inserted:
-            dictationPhase = .finished
+            dictationPhase = .idle
             activeRequestID = nil
             liveTranscript = ""
             inputLevel = 0
@@ -612,25 +814,71 @@ final class KeyboardController {
 
     private func apply(runtimeStatus: KeyboardRuntimeStatus?) {
         let now = Date()
-        let hasFreshRecordingLevel = runtimeStatus.map {
-            $0.phase == .recording
+        let isFresh = runtimeStatus.map {
+            now.timeIntervalSince($0.updatedAt) >= 0
+                && now.timeIntervalSince($0.updatedAt) < Self.runtimeFreshnessInterval
+        } ?? false
+        let runtimeMatchesActiveRequest = runtimeStatus.map {
+            isFresh
+                && $0.isActive
                 && $0.activeRequestID == activeRequestID
-                && now.timeIntervalSince($0.updatedAt) < 2
+        } ?? false
+        let blocksRecordingRuntime = activeRequestID.map {
+            handoffBlocksRecordingRuntime(requestID: $0)
+        } ?? false
+        let isWaitingForControlAcknowledgement = latestHandoffState.map {
+            [.stopRequested, .cancelRequested].contains($0.phase)
+        } == true
+        let hasFreshRecordingLevel = runtimeStatus.map {
+            runtimeMatchesActiveRequest
+                && $0.phase == .recording
+                && !$0.isRecoveringCapture
+                && !blocksRecordingRuntime
         } ?? false
         inputLevel = hasFreshRecordingLevel ? (runtimeStatus?.inputLevel ?? 0) : 0
-        canUseRuntimeStart = runtimeStatus?.canAcceptStartCommand == true
+        canUseRuntimeStart = isFresh && runtimeStatus?.canAcceptStartCommand == true
+        isCaptureRecovering = dictationPhase == .recording
+            && !isWaitingForControlAcknowledgement
+            && (!runtimeMatchesActiveRequest || runtimeStatus?.isRecoveringCapture == true)
 
-        guard activeRequestID == nil, canUseRuntimeStart else { return }
-        guard let runtimeRequestID = runtimeStatus?.activeRequestID,
-              !cancelledRequestIDs.contains(runtimeRequestID)
-        else {
+        guard isFresh,
+              let runtimeStatus,
+              let runtimeRequestID = runtimeStatus.activeRequestID,
+              runtimeRequestID == activeRequestID,
+              !cancelledRequestIDs.contains(runtimeRequestID),
+              [.recording, .transcribing].contains(runtimeStatus.phase)
+        else { return }
+
+        if runtimeStatus.phase == .recording, blocksRecordingRuntime {
+            isCaptureRecovering = false
+            inputLevel = 0
             return
         }
 
-        activeRequestID = runtimeRequestID
-        if runtimeStatus?.phase == .idle {
-            statusText = runtimeStatus?.message ?? "Session ready"
+        recoveryRequestID = nil
+        dictationPhase = runtimeStatus.phase
+        if runtimeStatus.phase == .transcribing {
+            isCaptureRecovering = false
+            inputLevel = 0
         }
+        if !isWaitingForControlAcknowledgement {
+            statusText = runtimeStatus.message ?? runtimeStatus.phase.rawValue.capitalized
+        }
+    }
+
+    private func handoffBlocksRecordingRuntime(requestID: UUID) -> Bool {
+        guard let latestHandoffState,
+              latestHandoffState.requestID == requestID
+        else { return false }
+        return [
+            .stopAcknowledged,
+            .audioSaved,
+            .transcribingStarted,
+            .resultReady,
+            .inserted,
+            .failed,
+            .cancelled,
+        ].contains(latestHandoffState.phase)
     }
 
     private func apply(status: DictationStatus) {
@@ -681,12 +929,14 @@ final class KeyboardController {
         case .transcribing:
             recoveryRequestID = nil
             dictationPhase = .transcribing
+            isCaptureRecovering = false
             statusText = status.message ?? "Transcribing"
         case .failed:
             recoveryRequestID = nil
             dictationPhase = .failed
             activeRequestID = nil
             liveTranscript = ""
+            isCaptureRecovering = false
             statusText = status.message ?? "Voice note failed"
         case .finished:
             recoveryRequestID = nil
@@ -697,6 +947,7 @@ final class KeyboardController {
             dictationPhase = .idle
             activeRequestID = nil
             liveTranscript = ""
+            isCaptureRecovering = false
             statusText = hasLatestDictation ? "Latest ready" : "Ready"
         }
     }
@@ -768,6 +1019,11 @@ final class KeyboardController {
 
         guard age > threshold else { return false }
 
+        if hasDurableActiveSession(requestID: requestID) {
+            recoveryRequestID = nil
+            return false
+        }
+
         recoveryRequestID = requestID
         launchURL = makeLaunchURL(for: requestID, action: MuesliAppConstants.startAction)
         dictationPhase = .failed
@@ -780,6 +1036,15 @@ final class KeyboardController {
     private func markHandoffForRecoveryIfStale(_ state: KeyboardHandoffState) -> Bool {
         guard let requestID = state.requestID else { return false }
 
+        // A stale cross-process heartbeat is not evidence that recording died.
+        // Persisted session phase is the container-owned authority; keep Stop and
+        // Cancel available while transport catches up instead of mutating the
+        // durable handoff to recoveryRequested from the extension.
+        if hasDurableActiveSession(requestID: requestID) {
+            recoveryRequestID = nil
+            return false
+        }
+
         let action = handoffRecoveryPolicy.action(
             for: state,
             latestRuntimeStatus: latestRuntimeStatus,
@@ -791,15 +1056,21 @@ final class KeyboardController {
             return false
 
         case let .retry(retryAction, retrying):
-            try? store.saveCommand(.init(requestID: requestID, action: retryAction))
-            try? store.saveKeyboardHandoffState(retrying)
+            guard (try? store.saveKeyboardHandoffState(retrying)) == true else {
+                reconcileRejectedHandoffTransition()
+                return true
+            }
             latestHandoffState = retrying
+            _ = try? store.saveCommand(.init(requestID: requestID, action: retryAction))
             dictationPhase = retrying.phase.dictationPhase
             statusText = retrying.message ?? "Retrying"
             return true
 
         case let .recover(recovery):
-            try? store.saveKeyboardHandoffState(recovery)
+            guard (try? store.saveKeyboardHandoffState(recovery)) == true else {
+                reconcileRejectedHandoffTransition()
+                return true
+            }
             latestHandoffState = recovery
             recoveryRequestID = requestID
             launchURL = makeLaunchURL(for: requestID, action: MuesliAppConstants.startAction)
@@ -812,10 +1083,98 @@ final class KeyboardController {
     }
 
     private func insertCompletedResult(_ result: DictationResult) {
-        guard !insertedRequestIDs.contains(result.requestID) else { return }
         guard !cancelledRequestIDs.contains(result.requestID) else { return }
+        guard ensurePresentationAuthority() else { return }
+        attemptResultInsertion(result, allowsAbandonedClaimRecovery: false)
+    }
+
+    private func insertRecoveredResultAfterUserConfirmation() {
+        guard let result = pendingManualInsertionResult else { return }
+        guard ensurePresentationAuthority() else {
+            statusText = "Switch back to Muesli Keyboard to insert"
+            return
+        }
+        attemptResultInsertion(result, allowsAbandonedClaimRecovery: true)
+    }
+
+    private func attemptResultInsertion(
+        _ result: DictationResult,
+        allowsAbandonedClaimRecovery: Bool
+    ) {
+        let claim = KeyboardResultInsertionClaim(
+            id: UUID(),
+            requestID: result.requestID,
+            ownerID: presentationOwnerID,
+            claimedAt: .now
+        )
+        let outcome: KeyboardResultInsertionClaimOutcome
+        do {
+            outcome = try store.claimKeyboardResultInsertion(
+                claim: claim,
+                allowsAbandonedClaimRecovery: allowsAbandonedClaimRecovery
+            )
+        } catch {
+            statusText = "Waiting to insert"
+            return
+        }
+
+        switch outcome {
+        case .acquired:
+            performClaimedResultInsertion(result, claim: claim)
+        case .busy:
+            statusText = "Finishing insertion"
+        case .recoveryRequired:
+            if pendingManualInsertionResult?.requestID != result.requestID {
+                manualInsertionAwaitingConfirmation = false
+            }
+            pendingManualInsertionResult = result
+            dictationPhase = .finished
+            inputLevel = 0
+            statusText = "Tap to insert recovered text"
+        case .unavailable:
+            statusText = "Waiting for result"
+        }
+    }
+
+    private func performClaimedResultInsertion(
+        _ result: DictationResult,
+        claim: KeyboardResultInsertionClaim
+    ) {
+        guard ensurePresentationAuthority(),
+              (try? store.validateKeyboardResultInsertionClaim(claim)) == true
+        else {
+            // The controller lost its visible text proxy or presentation lease
+            // after claiming. Preserve the claim and require explicit recovery;
+            // never send text through a stale keyboard instance.
+            pendingManualInsertionResult = result
+            manualInsertionAwaitingConfirmation = false
+            dictationPhase = .finished
+            statusText = "Insertion paused; verify the text is missing"
+            return
+        }
         insertText(result.text)
         insertedRequestIDs.insert(result.requestID)
+        let inserted = makeLocalHandoffState(
+            requestID: result.requestID,
+            phase: .inserted,
+            message: "Inserted"
+        )
+        guard (try? store.finalizeKeyboardResultInsertion(
+            claim: claim,
+            handoffState: inserted
+        )) == true else {
+            // The proxy side effect cannot participate in SQLite's transaction.
+            // Keep the durable claim so a future instance never auto-inserts a
+            // possible duplicate; recovery becomes an explicit user decision.
+            pendingManualInsertionResult = result
+            dictationPhase = .finished
+            statusText = "Inserted; tap only if text is missing"
+            return
+        }
+
+        latestHandoffState = inserted
+        pendingManualInsertionResult = nil
+        manualInsertionAwaitingConfirmation = false
         latestResultID = result.id
         hasLatestDictation = true
         activeRequestID = nil
@@ -824,18 +1183,69 @@ final class KeyboardController {
         recoveryRequestID = nil
         launchURL = nil
         dictationPhase = .idle
+        isCaptureRecovering = false
         statusText = "Latest ready"
-        try? store.clearPendingRequest()
-        try? store.clearPendingCommand()
         try? store.clearKeyboardLiveTranscript()
-        try? store.saveKeyboardHandoffState(.init(
-            requestID: result.requestID,
-            phase: .inserted,
-            message: "Inserted"
-        ))
-        try? store.saveStatus(.idle)
         prepareLaunchRequestIfNeeded()
+    }
 
+    private func reconcilePendingManualInsertion(with handoffState: KeyboardHandoffState) {
+        guard let pendingResult = pendingManualInsertionResult else { return }
+        let pickupStillExists = (try? store.result(for: pendingResult.requestID)) != nil
+        guard handoffState.phase == .resultReady,
+              handoffState.requestID == pendingResult.requestID,
+              pickupStillExists
+        else {
+            pendingManualInsertionResult = nil
+            manualInsertionAwaitingConfirmation = false
+            return
+        }
+    }
+
+    private func makeLocalHandoffState(
+        requestID: UUID,
+        phase: KeyboardHandoffPhase,
+        message: String?,
+        createdAt: Date? = nil
+    ) -> KeyboardHandoffState {
+        let current = latestHandoffState ?? (try? store.keyboardHandoffState())
+        if let current, current.requestID == requestID {
+            return current.advanced(to: phase, message: message)
+        }
+        return KeyboardHandoffState(
+            requestID: requestID,
+            phase: phase,
+            message: message,
+            createdAt: createdAt ?? .now
+        )
+    }
+
+    @discardableResult
+    private func saveLocalHandoffState(_ state: KeyboardHandoffState) throws -> Bool {
+        let didSave = try store.saveKeyboardHandoffState(state)
+        if didSave {
+            latestHandoffState = state
+        }
+        return didSave
+    }
+
+    /// A rejected write means another process advanced the durable row first.
+    /// Adopt that projection instead of continuing to mutate the UI from the
+    /// stale state that lost the compare-and-set race.
+    private func reconcileRejectedHandoffTransition() {
+        guard let persisted = try? store.keyboardHandoffState() else { return }
+        latestHandoffState = persisted
+        // Avoid re-entering stale-recovery policy while resolving a rejected
+        // transition. The persisted phase itself is authoritative here.
+        apply(handoffState: persisted, evaluatesRecovery: false)
+    }
+
+    private func hasDurableActiveSession(requestID: UUID) -> Bool {
+        guard let session = try? store.recordingSession(requestID: requestID),
+              session.isKeyboardOwnedVoiceNote
+        else { return false }
+        return [.recording, .interrupted, .transcriptionQueued, .transcribing]
+            .contains(session.phase)
     }
 
     private func awaitCommandAcknowledgement(
@@ -856,6 +1266,30 @@ final class KeyboardController {
             self.refreshLatestDictation()
             guard self.isAwaitingAcknowledgement(requestID: requestID, phase: requestedPhase) else { return }
 
+            if let session = try? self.store.recordingSession(requestID: requestID),
+               session.isKeyboardOwnedVoiceNote,
+               [.recording, .interrupted, .transcriptionQueued, .transcribing].contains(session.phase)
+            {
+                self.recoveryRequestID = nil
+                self.activeRequestID = requestID
+                switch session.phase {
+                case .recording, .interrupted:
+                    self.dictationPhase = .recording
+                    self.isCaptureRecovering = session.phase == .interrupted
+                case .transcriptionQueued, .transcribing:
+                    self.dictationPhase = .transcribing
+                    self.isCaptureRecovering = false
+                    self.inputLevel = 0
+                default:
+                    break
+                }
+                // The command is durable; re-notify the container and let the
+                // periodic reconciliation observe its authoritative progress.
+                // A slow acknowledgement must not be converted into failure.
+                eventBus.post(.commandChanged)
+                return
+            }
+
             let urlAction: String
             let message: String
             switch action {
@@ -869,15 +1303,28 @@ final class KeyboardController {
                 urlAction = MuesliAppConstants.cancelAction
                 message = "Open Muesli to cancel"
             }
-            let recovery = KeyboardHandoffState(
-                requestID: requestID,
-                phase: .recoveryRequested,
-                message: message,
-                recoveryAttemptCount: 1,
-                recoveryAction: action
-            )
-            try? self.store.saveKeyboardHandoffState(recovery)
-            self.latestHandoffState = recovery
+            let current = self.latestHandoffState ?? (try? self.store.keyboardHandoffState())
+            let recovery: KeyboardHandoffState
+            if let current, current.requestID == requestID {
+                recovery = current.advanced(
+                    to: .recoveryRequested,
+                    message: message,
+                    recoveryAttemptCount: max(current.recoveryAttemptCount, 1),
+                    recoveryAction: action
+                )
+            } else {
+                recovery = KeyboardHandoffState(
+                    requestID: requestID,
+                    phase: .recoveryRequested,
+                    message: message,
+                    recoveryAttemptCount: 1,
+                    recoveryAction: action
+                )
+            }
+            guard (try? self.saveLocalHandoffState(recovery)) == true else {
+                self.reconcileRejectedHandoffTransition()
+                return
+            }
             self.canUseRuntimeStart = false
             self.recoveryRequestID = requestID
             self.activeRequestID = nil
@@ -925,7 +1372,7 @@ final class KeyboardController {
     }
 }
 
-enum KeyboardPrimaryButtonRole {
+enum KeyboardPrimaryButtonRole: Equatable {
     case blocked
     case openMuesliRecovery
     case waitingForMuesli
@@ -933,5 +1380,6 @@ enum KeyboardPrimaryButtonRole {
     case stop
     case transcribing
     case inserted
+    case manualInsert
     case record
 }

--- a/MuesliKeyboard/KeyboardRootView.swift
+++ b/MuesliKeyboard/KeyboardRootView.swift
@@ -170,6 +170,7 @@ struct KeyboardRootView: View {
                     framesPerSecond: 18,
                     refreshDriver: .timeline
                 )
+                .id(controller.waveformRenderGeneration)
                 .frame(height: 24)
                 .shadow(color: activeStatusColor.opacity(0.28), radius: 8)
 
@@ -271,13 +272,23 @@ struct KeyboardRootView: View {
     }
 
     private var activeStatusText: String {
+        if controller.isCaptureRecovering {
+            return "Resuming"
+        }
+
         switch controller.dictationPhase {
         case .transcribing:
-            "Transcribing"
+            return "Transcribing"
         case .requested:
-            "Starting"
+            return "Starting"
         default:
-            controller.statusText == "Stopping" ? "Stopping" : "Listening"
+            if controller.statusText == "Stopping" {
+                return "Stopping"
+            }
+            if controller.statusText == "Cancelling" {
+                return "Cancelling"
+            }
+            return "Listening"
         }
     }
 

--- a/MuesliKeyboard/KeyboardViewController.swift
+++ b/MuesliKeyboard/KeyboardViewController.swift
@@ -9,6 +9,11 @@ final class KeyboardViewController: UIInputViewController {
     private var hasEnteredAppearance = false
     private var isKeyboardPresented = false
     private var hasActivatedKeyboardRuntime = false
+    private var hasPendingHostActivation = false
+    private var extensionHostIsActive = true
+    private var presentationGeneration: UInt64 = 0
+    private var suspendedPresentationGeneration: UInt64?
+    private var pendingHostResumeGeneration: UInt64?
     private var appearanceGuard = MuesliKeyboardAppearanceGuard()
     private var stableGeometryFrameCount = 0
     private var launchSnapshotWidth: CGFloat = 0
@@ -52,8 +57,6 @@ final class KeyboardViewController: UIInputViewController {
         controller.keyboardDismisser = { [weak self] in
             self?.dismissKeyboard()
         }
-        controller.prepareInitialPresentationState()
-
         let hostingController = UIHostingController(
             rootView: KeyboardRootView(controller: controller)
         )
@@ -87,9 +90,27 @@ final class KeyboardViewController: UIInputViewController {
             launchSnapshotView.heightAnchor.constraint(equalToConstant: KeyboardRootView.preferredHeight)
         ])
         refreshLaunchSnapshot()
+
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(extensionHostDidBecomeActive),
+            name: .NSExtensionHostDidBecomeActive,
+            object: nil
+        )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(extensionHostWillResignActive),
+            name: .NSExtensionHostWillResignActive,
+            object: nil
+        )
     }
 
     override func viewWillAppear(_ animated: Bool) {
+        presentationGeneration &+= 1
+        suspendedPresentationGeneration = nil
+        pendingHostResumeGeneration = nil
+        extensionHostIsActive = true
+        controller.activatePresentationLease()
         appearanceGuard.beginAppearance()
         controller.isLaunchSettled = false
         controller.prepareInitialPresentationState()
@@ -120,6 +141,8 @@ final class KeyboardViewController: UIInputViewController {
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
 
+        resumeSuspendedPresentationIfAttached()
+
         let laidOutWidth = view.bounds.width
         guard isKeyboardPresented,
               !hasActivatedKeyboardRuntime,
@@ -136,16 +159,88 @@ final class KeyboardViewController: UIInputViewController {
         isKeyboardPresented = false
         hasEnteredAppearance = false
         stopLaunchGeometryGate()
+        controller.deactivatePresentationLease()
         controller.isLaunchSettled = false
         launchSnapshotView.isHidden = false
+    }
 
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
         controller.stopObservingSharedState()
+    }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self)
     }
 }
 
 private extension KeyboardViewController {
     static let settledHeightTolerance: CGFloat = 1
     static let requiredStableGeometryFrames = 2
+
+    @objc
+    func extensionHostDidBecomeActive() {
+        extensionHostIsActive = true
+        pendingHostResumeGeneration = suspendedPresentationGeneration
+        resumeSuspendedPresentationIfAttached()
+        // The host-active notification can precede UIKit reattaching the input
+        // view. Retain the generation and retry from layout instead of guessing
+        // with a delay. A keyboard that was switched away never regains a window.
+        DispatchQueue.main.async { [weak self] in
+            self?.resumeSuspendedPresentationIfAttached()
+        }
+    }
+
+    @objc
+    func extensionHostWillResignActive() {
+        extensionHostIsActive = false
+        suspendedPresentationGeneration = presentationGeneration == 0
+            ? nil
+            : presentationGeneration
+        pendingHostResumeGeneration = nil
+        hasPendingHostActivation = false
+        stopLaunchGeometryGate()
+        controller.suspendPresentationEligibility()
+        controller.stopObservingSharedState()
+    }
+
+    func resumeSuspendedPresentationIfAttached() {
+        guard extensionHostIsActive,
+              let generation = pendingHostResumeGeneration,
+              generation == presentationGeneration,
+              viewIfLoaded?.window != nil || inputView?.window != nil
+        else { return }
+
+        pendingHostResumeGeneration = nil
+        suspendedPresentationGeneration = nil
+        isKeyboardPresented = true
+        hasEnteredAppearance = true
+        controller.activatePresentationLease()
+
+        if hasActivatedKeyboardRuntime {
+            hasPendingHostActivation = true
+            resumePendingHostActivationIfPossible()
+            return
+        }
+
+        // Lock can occur before the initial 0.75-second geometry gate settles.
+        // Restart that same presentation generation instead of leaving the
+        // keyboard permanently on a stale launch snapshot.
+        appearanceGuard.beginAppearance()
+        controller.isLaunchSettled = false
+        refreshLaunchSnapshot()
+        launchSnapshotView.isHidden = false
+        stableGeometryFrameCount = 0
+        startLaunchGeometryGate()
+    }
+
+    func resumePendingHostActivationIfPossible() {
+        guard hasPendingHostActivation,
+              hasActivatedKeyboardRuntime
+        else { return }
+        hasPendingHostActivation = false
+        controller.resumeAfterHostActivation()
+    }
 
     func startLaunchGeometryGate() {
         stopLaunchGeometryGate()
@@ -208,7 +303,13 @@ private extension KeyboardViewController {
                     isPresented: self.isKeyboardPresented,
                     hasActivatedRuntime: self.hasActivatedKeyboardRuntime
                   ) else { return }
-            self.controller.startObservingSharedState()
+            // Runtime activation is also a successful host activation. Using
+            // the resume path both rehydrates the lightweight presentation
+            // projection and recreates the leaf waveform timeline. This also
+            // consumes a host-active notification that arrived before launch
+            // geometry settled instead of dropping it.
+            self.hasPendingHostActivation = false
+            self.controller.resumeAfterHostActivation()
 
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
                 guard let self,

--- a/Shared/DictationModels.swift
+++ b/Shared/DictationModels.swift
@@ -1,3 +1,4 @@
+import CryptoKit
 import Foundation
 
 enum DictationPhase: String, Codable, Sendable, Equatable {
@@ -13,6 +14,30 @@ enum DictationCommandAction: String, Codable, Sendable, Equatable {
     case start
     case stop
     case cancel
+}
+
+enum KeyboardIntentTransitionPolicy {
+    /// `pending_command` is a durable desired state, not a lossy event edge.
+    /// Within one request intent may only become more terminal; an old Start
+    /// retry must never revive a Stop/Cancel that the user already requested.
+    static func permits(
+        current: DictationCommand?,
+        proposed: DictationCommand
+    ) -> Bool {
+        guard let current else { return true }
+
+        guard current.requestID == proposed.requestID else {
+            return proposed.action == .start && proposed.createdAt >= current.createdAt
+        }
+        guard proposed.createdAt >= current.createdAt else { return false }
+
+        switch (current.action, proposed.action) {
+        case (.start, _), (.stop, .stop), (.stop, .cancel), (.cancel, .cancel):
+            return true
+        case (.stop, .start), (.cancel, .start), (.cancel, .stop):
+            return false
+        }
+    }
 }
 
 enum KeyboardHandoffPhase: String, Codable, Sendable, Equatable {
@@ -47,6 +72,81 @@ enum KeyboardHandoffPhase: String, Codable, Sendable, Equatable {
     }
 }
 
+enum KeyboardHandoffTransitionPolicy {
+    /// Handoff rows are shared by the container app and keyboard extension. Writes
+    /// can therefore arrive out of order even though each process is internally
+    /// serialized. Keep same-request transitions monotonic so a late container
+    /// update cannot revive a result that the keyboard already inserted.
+    static func permits(
+        current: KeyboardHandoffState?,
+        proposed: KeyboardHandoffState
+    ) -> Bool {
+        guard let current else { return true }
+        guard current.requestID == proposed.requestID else {
+            // Only an explicit Start may replace the global handoff row. Late
+            // completion/failure callbacks from an older request must never
+            // clobber a different request that is already in flight.
+            guard proposed.phase == .startRequested,
+                  [.idle, .inserted, .failed, .cancelled].contains(current.phase)
+            else { return false }
+            return proposed.createdAt >= current.createdAt
+        }
+
+        if current.phase == proposed.phase {
+            return proposed.updatedAt >= current.updatedAt
+        }
+
+        switch current.phase {
+        case .inserted, .cancelled:
+            return false
+        case .failed:
+            return proposed.phase == .inserted
+                || (proposed.phase == .transcribingStarted
+                    && proposed.recoveryAttemptCount > current.recoveryAttemptCount)
+        case .resultReady:
+            return proposed.phase == .inserted
+        case .recoveryRequested:
+            // Opening Muesli explicitly resumes the same durable request. The
+            // container is then allowed to replace the transport-recovery marker
+            // with the authoritative lifecycle phase it observes.
+            return ![.idle, .startRequested].contains(proposed.phase)
+        default:
+            break
+        }
+
+        if proposed.phase == .inserted {
+            return true
+        }
+        if [.failed, .cancelled, .recoveryRequested].contains(proposed.phase) {
+            return true
+        }
+
+        let proposedProgress = progress(of: proposed.phase)
+        let currentProgress = progress(of: current.phase)
+        if proposedProgress == currentProgress {
+            return proposed.updatedAt >= current.updatedAt
+        }
+        return proposedProgress > currentProgress
+    }
+
+    private static func progress(of phase: KeyboardHandoffPhase) -> Int {
+        switch phase {
+        case .idle: 0
+        case .startRequested: 10
+        case .startAcknowledged: 20
+        case .recordingStarted: 30
+        case .stopRequested, .cancelRequested: 40
+        case .stopAcknowledged: 50
+        case .audioSaved: 60
+        case .transcribingStarted: 70
+        case .resultReady: 80
+        case .recoveryRequested: 85
+        case .failed: 90
+        case .inserted, .cancelled: 100
+        }
+    }
+}
+
 enum RecordingSessionKind: String, Codable, Sendable, Equatable, CaseIterable {
     case quickDictation
     case keyboardDictation
@@ -66,11 +166,21 @@ enum RecordingSessionKind: String, Codable, Sendable, Equatable, CaseIterable {
 
 enum RecordingSessionPhase: String, Codable, Sendable, Equatable, Hashable {
     case recording
+    case interrupted
     case transcriptionQueued
     case transcribing
     case completed
     case failed
     case cancelled
+}
+
+enum VoiceNoteCaptureInterruptionReason: String, Codable, Sendable, Equatable {
+    case system
+    case appSuspended
+    case routeDisconnected
+    case microphoneMuted
+    case mediaServicesReset
+    case engineConfigurationChanged
 }
 
 enum VoiceNoteTranscriptionFailureReason: String, Codable, Sendable, Equatable {
@@ -185,18 +295,69 @@ struct DictationRequest: Codable, Sendable, Equatable, Identifiable {
 }
 
 struct DictationCommand: Codable, Sendable, Equatable {
+    let id: UUID
     let requestID: UUID
     let action: DictationCommandAction
     let createdAt: Date
 
     init(
+        id: UUID = UUID(),
         requestID: UUID,
         action: DictationCommandAction,
         createdAt: Date = .now
     ) {
+        self.id = id
         self.requestID = requestID
         self.action = action
         self.createdAt = createdAt
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case requestID
+        case action
+        case createdAt
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let requestID = try container.decode(UUID.self, forKey: .requestID)
+        let action = try container.decode(DictationCommandAction.self, forKey: .action)
+        let createdAt = try container.decode(Date.self, forKey: .createdAt)
+        self.requestID = requestID
+        self.action = action
+        self.createdAt = createdAt
+        id = try container.decodeIfPresent(UUID.self, forKey: .id)
+            ?? Self.legacyIdentifier(
+                requestID: requestID,
+                action: action,
+                createdAt: createdAt
+            )
+    }
+
+    private static func legacyIdentifier(
+        requestID: UUID,
+        action: DictationCommandAction,
+        createdAt: Date
+    ) -> UUID {
+        var fingerprint = Data("muesli.keyboard.intent.v1".utf8)
+        var requestBytes = requestID.uuid
+        withUnsafeBytes(of: &requestBytes) { fingerprint.append(contentsOf: $0) }
+        fingerprint.append(contentsOf: action.rawValue.utf8)
+        var timestamp = createdAt.timeIntervalSinceReferenceDate.bitPattern.bigEndian
+        withUnsafeBytes(of: &timestamp) { fingerprint.append(contentsOf: $0) }
+
+        var bytes = Array(SHA256.hash(data: fingerprint).prefix(16))
+        // RFC 4122 variant with a name-derived (v5-shaped) identifier. SHA-256
+        // supplies the bytes; these bits make the serialized UUID conventional.
+        bytes[6] = (bytes[6] & 0x0f) | 0x50
+        bytes[8] = (bytes[8] & 0x3f) | 0x80
+        return UUID(uuid: (
+            bytes[0], bytes[1], bytes[2], bytes[3],
+            bytes[4], bytes[5], bytes[6], bytes[7],
+            bytes[8], bytes[9], bytes[10], bytes[11],
+            bytes[12], bytes[13], bytes[14], bytes[15]
+        ))
     }
 }
 
@@ -246,6 +407,29 @@ struct KeyboardHandoffState: Codable, Sendable, Equatable {
     }
 
     static let idle = KeyboardHandoffState(requestID: nil, phase: .idle)
+}
+
+struct KeyboardPresentationLease: Codable, Sendable, Equatable {
+    static let expirationInterval: TimeInterval = 3
+
+    let ownerID: UUID
+    let updatedAt: Date
+}
+
+struct KeyboardResultInsertionClaim: Codable, Sendable, Equatable {
+    static let expirationInterval: TimeInterval = 30
+
+    let id: UUID
+    let requestID: UUID
+    let ownerID: UUID
+    let claimedAt: Date
+}
+
+enum KeyboardResultInsertionClaimOutcome: Sendable, Equatable {
+    case acquired
+    case busy
+    case recoveryRequired
+    case unavailable
 }
 
 enum KeyboardHandoffRecoveryAction: Sendable, Equatable {
@@ -407,6 +591,10 @@ struct RecordingSession: Codable, Sendable, Equatable, Identifiable {
     var scratchpadText: String?
     var longFormRecoveryValidatedAt: Date?
     var meetingOperationID: UUID?
+    var captureInterruptionReason: VoiceNoteCaptureInterruptionReason?
+    var captureInterruptedAt: Date?
+    var draftTranscriptText: String?
+    var draftTranscriptUpdatedAt: Date?
 
     init(
         id: UUID = UUID(),
@@ -435,7 +623,11 @@ struct RecordingSession: Codable, Sendable, Equatable, Identifiable {
         lastTranscriptionFailureReason: VoiceNoteTranscriptionFailureReason? = nil,
         scratchpadText: String? = nil,
         longFormRecoveryValidatedAt: Date? = nil,
-        meetingOperationID: UUID? = nil
+        meetingOperationID: UUID? = nil,
+        captureInterruptionReason: VoiceNoteCaptureInterruptionReason? = nil,
+        captureInterruptedAt: Date? = nil,
+        draftTranscriptText: String? = nil,
+        draftTranscriptUpdatedAt: Date? = nil
     ) {
         self.id = id
         self.requestID = requestID
@@ -464,6 +656,10 @@ struct RecordingSession: Codable, Sendable, Equatable, Identifiable {
         self.scratchpadText = scratchpadText
         self.longFormRecoveryValidatedAt = longFormRecoveryValidatedAt
         self.meetingOperationID = meetingOperationID
+        self.captureInterruptionReason = captureInterruptionReason
+        self.captureInterruptedAt = captureInterruptedAt
+        self.draftTranscriptText = draftTranscriptText
+        self.draftTranscriptUpdatedAt = draftTranscriptUpdatedAt
     }
 
     var duration: TimeInterval? {
@@ -485,7 +681,7 @@ struct RecordingSession: Codable, Sendable, Equatable, Identifiable {
 
     var hasActiveVoiceNoteWork: Bool {
         kind != .meeting
-            && [.recording, .transcriptionQueued, .transcribing].contains(phase)
+            && [.recording, .interrupted, .transcriptionQueued, .transcribing].contains(phase)
     }
 
     var voiceNoteDurabilityEvidence: VoiceNoteDurabilityEvidence {
@@ -497,9 +693,8 @@ struct RecordingSession: Codable, Sendable, Equatable, Identifiable {
 
     var canRetryVoiceNoteTranscription: Bool {
         kind != .meeting
-            && isLongForm
             && phase == .failed
-            && voiceNoteDurabilityEvidence == .durableCheckpoint
+            && protectedAudioUntilTranscriptCompletes
             && audioFileName != nil
     }
 
@@ -539,6 +734,10 @@ struct RecordingSession: Codable, Sendable, Equatable, Identifiable {
         case scratchpadText
         case longFormRecoveryValidatedAt
         case meetingOperationID
+        case captureInterruptionReason
+        case captureInterruptedAt
+        case draftTranscriptText
+        case draftTranscriptUpdatedAt
     }
 
     init(from decoder: Decoder) throws {
@@ -582,6 +781,13 @@ struct RecordingSession: Codable, Sendable, Equatable, Identifiable {
             forKey: .longFormRecoveryValidatedAt
         )
         meetingOperationID = try container.decodeIfPresent(UUID.self, forKey: .meetingOperationID)
+        captureInterruptionReason = try container.decodeIfPresent(
+            VoiceNoteCaptureInterruptionReason.self,
+            forKey: .captureInterruptionReason
+        )
+        captureInterruptedAt = try container.decodeIfPresent(Date.self, forKey: .captureInterruptedAt)
+        draftTranscriptText = try container.decodeIfPresent(String.self, forKey: .draftTranscriptText)
+        draftTranscriptUpdatedAt = try container.decodeIfPresent(Date.self, forKey: .draftTranscriptUpdatedAt)
     }
 }
 
@@ -753,6 +959,7 @@ struct KeyboardRuntimeStatus: Codable, Sendable, Equatable {
     let supportsBackgroundStart: Bool
     let canAcceptStartCommand: Bool
     let inputLevel: Double
+    let isRecoveringCapture: Bool
     let updatedAt: Date
 
     init(
@@ -763,6 +970,7 @@ struct KeyboardRuntimeStatus: Codable, Sendable, Equatable {
         supportsBackgroundStart: Bool = false,
         canAcceptStartCommand: Bool? = nil,
         inputLevel: Double = 0,
+        isRecoveringCapture: Bool = false,
         updatedAt: Date = .now
     ) {
         self.isActive = isActive
@@ -772,6 +980,7 @@ struct KeyboardRuntimeStatus: Codable, Sendable, Equatable {
         self.supportsBackgroundStart = supportsBackgroundStart
         self.canAcceptStartCommand = canAcceptStartCommand ?? (isActive && supportsBackgroundStart)
         self.inputLevel = min(max(inputLevel, 0), 1)
+        self.isRecoveringCapture = isRecoveringCapture
         self.updatedAt = updatedAt
     }
 
@@ -783,6 +992,7 @@ struct KeyboardRuntimeStatus: Codable, Sendable, Equatable {
         case supportsBackgroundStart
         case canAcceptStartCommand
         case inputLevel
+        case isRecoveringCapture
         case updatedAt
     }
 
@@ -795,6 +1005,10 @@ struct KeyboardRuntimeStatus: Codable, Sendable, Equatable {
         supportsBackgroundStart = try container.decodeIfPresent(Bool.self, forKey: .supportsBackgroundStart) ?? false
         canAcceptStartCommand = try container.decodeIfPresent(Bool.self, forKey: .canAcceptStartCommand) ?? (isActive && supportsBackgroundStart)
         inputLevel = try container.decodeIfPresent(Double.self, forKey: .inputLevel) ?? 0
+        isRecoveringCapture = try container.decodeIfPresent(
+            Bool.self,
+            forKey: .isRecoveringCapture
+        ) ?? false
         updatedAt = try container.decode(Date.self, forKey: .updatedAt)
     }
 }

--- a/Shared/SharedStore.swift
+++ b/Shared/SharedStore.swift
@@ -1,6 +1,45 @@
 import Foundation
 import SQLite3
 
+enum SharedFileProtection {
+    // Voice-note audio is deliberately reopenable after the first device unlock.
+    // Checkpoint rotation closes a chunk before validation, and transcription may
+    // reopen finalized audio while the screen is locked. `completeUnlessOpen`
+    // only protects an already-open descriptor and therefore cannot satisfy that
+    // lifecycle contract.
+    static let reopenableAudio: FileProtectionType = .completeUntilFirstUserAuthentication
+    static let metadata: FileProtectionType = .completeUntilFirstUserAuthentication
+
+    static func prepareMetadataDirectory(at url: URL) throws {
+        try FileManager.default.createDirectory(
+            at: url,
+            withIntermediateDirectories: true,
+            attributes: [.protectionKey: metadata]
+        )
+        try protectMetadata(at: url)
+    }
+
+    static func protectAudio(at url: URL) throws {
+        try protect(url, as: reopenableAudio)
+    }
+
+    static func protectMetadata(at url: URL) throws {
+        try protect(url, as: metadata)
+    }
+
+    static func protectMetadataBestEffort(at url: URL) {
+        try? protectMetadata(at: url)
+    }
+
+    private static func protect(_ url: URL, as protection: FileProtectionType) throws {
+        guard FileManager.default.fileExists(atPath: url.path) else { return }
+        try FileManager.default.setAttributes(
+            [.protectionKey: protection],
+            ofItemAtPath: url.path
+        )
+    }
+}
+
 enum SharedStoreError: Error, LocalizedError {
     case appGroupUnavailable(String)
 
@@ -10,6 +49,20 @@ enum SharedStoreError: Error, LocalizedError {
             "App Group container is unavailable for \(identifier)."
         }
     }
+}
+
+/// A coherent, lightweight view of the shared keyboard presentation state.
+///
+/// The keyboard extension refreshes these values together. Reading them through
+/// one store operation avoids repeatedly opening SQLite and ensures every field
+/// comes from the same read transaction.
+struct KeyboardPresentationSnapshot: Sendable, Equatable {
+    let runtimeStatus: KeyboardRuntimeStatus?
+    let status: DictationStatus
+    let handoffState: KeyboardHandoffState
+    let liveTranscript: KeyboardLiveTranscript?
+    let targetRequestID: UUID?
+    let result: DictationResult?
 }
 
 struct SharedStore: Sendable {
@@ -43,9 +96,62 @@ struct SharedStore: Sendable {
         try database().clearValue(key: .pendingRequest)
     }
 
-    func saveCommand(_ command: DictationCommand) throws {
-        try database().saveValue(command, key: .pendingCommand)
-        eventPoster.post(.commandChanged)
+    @discardableResult
+    func clearPendingRequest(id: UUID) throws -> Bool {
+        try database().clearPendingRequest(id: id)
+    }
+
+    @discardableResult
+    func saveCommand(_ command: DictationCommand) throws -> Bool {
+        let didSave = try database().saveKeyboardIntent(command)
+        if didSave {
+            eventPoster.post(.commandChanged)
+        }
+        return didSave
+    }
+
+    /// Publishes the keyboard request, desired intent, and its presentation
+    /// projection as one SQLite commit. Cross-process observers can never see a
+    /// Stop without its request or a handoff phase without the matching intent.
+    @discardableResult
+    func submitKeyboardIntent(
+        request: DictationRequest?,
+        command: DictationCommand,
+        handoffState: KeyboardHandoffState
+    ) throws -> Bool {
+        let didSubmit = try database().submitKeyboardIntent(
+            request: request,
+            command: command,
+            handoffState: handoffState
+        )
+        if didSubmit {
+            eventPoster.post(.commandChanged)
+            eventPoster.post(.handoffStatusChanged)
+        }
+        return didSubmit
+    }
+
+    /// Resolves an exact intent generation together with its terminal handoff.
+    /// Used when Stop/Cancel arrives before capture has begun; a newer keyboard
+    /// request cannot be erased by late cleanup from this request.
+    @discardableResult
+    func resolveKeyboardIntent(
+        commandID: UUID,
+        requestID: UUID,
+        handoffState: KeyboardHandoffState,
+        clearsPendingRequest: Bool
+    ) throws -> Bool {
+        let didResolve = try database().resolveKeyboardIntent(
+            commandID: commandID,
+            requestID: requestID,
+            handoffState: handoffState,
+            clearsPendingRequest: clearsPendingRequest
+        )
+        if didResolve {
+            eventPoster.post(.commandChanged)
+            eventPoster.post(.handoffStatusChanged)
+        }
+        return didResolve
     }
 
     func pendingCommand() throws -> DictationCommand? {
@@ -56,9 +162,22 @@ struct SharedStore: Sendable {
         try database().clearValue(key: .pendingCommand)
     }
 
-    func saveKeyboardHandoffState(_ state: KeyboardHandoffState) throws {
-        try database().saveValue(state, key: .keyboardHandoffState)
-        eventPoster.post(.handoffStatusChanged)
+    @discardableResult
+    func clearPendingCommand(id: UUID) throws -> Bool {
+        let didClear = try database().clearPendingCommand(id: id)
+        if didClear {
+            eventPoster.post(.commandChanged)
+        }
+        return didClear
+    }
+
+    @discardableResult
+    func saveKeyboardHandoffState(_ state: KeyboardHandoffState) throws -> Bool {
+        let didSave = try database().saveKeyboardHandoffState(state)
+        if didSave {
+            eventPoster.post(.handoffStatusChanged)
+        }
+        return didSave
     }
 
     func keyboardHandoffState() throws -> KeyboardHandoffState {
@@ -133,6 +252,75 @@ struct SharedStore: Sendable {
         try database().value(KeyboardLiveTranscript.self, key: .keyboardLiveTranscript)
     }
 
+    func keyboardPresentationSnapshot(
+        preferredRequestID: UUID? = nil
+    ) throws -> KeyboardPresentationSnapshot {
+        try database().keyboardPresentationSnapshot(preferredRequestID: preferredRequestID)
+    }
+
+    @discardableResult
+    func acquireKeyboardPresentationLease(
+        ownerID: UUID,
+        now: Date = .now,
+        expirationInterval: TimeInterval = KeyboardPresentationLease.expirationInterval
+    ) throws -> Bool {
+        try database().acquireKeyboardPresentationLease(
+            ownerID: ownerID,
+            now: now,
+            expirationInterval: expirationInterval
+        )
+    }
+
+    @discardableResult
+    func releaseKeyboardPresentationLease(ownerID: UUID) throws -> Bool {
+        try database().releaseKeyboardPresentationLease(ownerID: ownerID)
+    }
+
+    func claimKeyboardResultInsertion(
+        claim: KeyboardResultInsertionClaim,
+        now: Date = .now,
+        leaseExpirationInterval: TimeInterval = KeyboardPresentationLease.expirationInterval,
+        claimExpirationInterval: TimeInterval = KeyboardResultInsertionClaim.expirationInterval,
+        allowsAbandonedClaimRecovery: Bool = false
+    ) throws -> KeyboardResultInsertionClaimOutcome {
+        try database().claimKeyboardResultInsertion(
+            claim: claim,
+            now: now,
+            leaseExpirationInterval: leaseExpirationInterval,
+            claimExpirationInterval: claimExpirationInterval,
+            allowsAbandonedClaimRecovery: allowsAbandonedClaimRecovery
+        )
+    }
+
+    func validateKeyboardResultInsertionClaim(
+        _ claim: KeyboardResultInsertionClaim,
+        now: Date = .now,
+        leaseExpirationInterval: TimeInterval = KeyboardPresentationLease.expirationInterval
+    ) throws -> Bool {
+        try database().validateKeyboardResultInsertionClaim(
+            claim,
+            now: now,
+            leaseExpirationInterval: leaseExpirationInterval
+        )
+    }
+
+    @discardableResult
+    func finalizeKeyboardResultInsertion(
+        claim: KeyboardResultInsertionClaim,
+        handoffState: KeyboardHandoffState
+    ) throws -> Bool {
+        let didFinalize = try database().finalizeKeyboardResultInsertion(
+            claim: claim,
+            handoffState: handoffState
+        )
+        if didFinalize {
+            eventPoster.post(.resultChanged)
+            eventPoster.post(.handoffStatusChanged)
+            eventPoster.post(.commandChanged)
+        }
+        return didFinalize
+    }
+
     func clearKeyboardLiveTranscript() throws {
         try database().clearValue(key: .keyboardLiveTranscript)
         eventPoster.post(.liveTranscriptChanged)
@@ -170,6 +358,48 @@ struct SharedStore: Sendable {
             eventPoster.post(.ownershipChanged)
         }
         return session
+    }
+
+    @discardableResult
+    func transitionVoiceNoteSession(
+        id: UUID,
+        expectedPhases: Set<RecordingSessionPhase>,
+        update: (inout RecordingSession) -> Void
+    ) throws -> RecordingSession? {
+        let session = try database().transitionVoiceNoteSession(
+            id: id,
+            expectedPhases: expectedPhases,
+            update: update
+        )
+        if session != nil {
+            eventPoster.post(.ownershipChanged)
+        }
+        return session
+    }
+
+    @discardableResult
+    func completeVoiceNoteSession(
+        _ completedSession: RecordingSession,
+        transcript: Transcript,
+        result: DictationResult,
+        expectedPhase: RecordingSessionPhase = .transcribing,
+        keyboardHandoffState: KeyboardHandoffState? = nil
+    ) throws -> Bool {
+        let outcome = try database().completeVoiceNoteSession(
+            completedSession,
+            transcript: transcript,
+            result: result,
+            expectedPhase: expectedPhase,
+            keyboardHandoffState: keyboardHandoffState
+        )
+        if outcome.didComplete {
+            eventPoster.post(.ownershipChanged)
+            eventPoster.post(.resultChanged)
+            if outcome.didUpdateKeyboardHandoff {
+                eventPoster.post(.handoffStatusChanged)
+            }
+        }
+        return outcome.didComplete
     }
 
     @discardableResult
@@ -295,14 +525,14 @@ struct SharedStore: Sendable {
     func voiceNoteCheckpointDirectoryURL(sessionID: UUID) throws -> URL {
         let root = try recordingsDirectoryURL()
             .appendingPathComponent("VoiceNoteCheckpoints", isDirectory: true)
-        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        try SharedFileProtection.prepareMetadataDirectory(at: root)
         var values = URLResourceValues()
         values.isExcludedFromBackup = true
         var mutableRoot = root
         try? mutableRoot.setResourceValues(values)
 
         let directory = root.appendingPathComponent(sessionID.uuidString, isDirectory: true)
-        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        try SharedFileProtection.prepareMetadataDirectory(at: directory)
         return directory
     }
 
@@ -334,6 +564,7 @@ struct SharedStore: Sendable {
             try FileManager.default.removeItem(at: destinationURL)
         }
         try FileManager.default.copyItem(at: sourceURL, to: destinationURL)
+        try SharedFileProtection.protectAudio(at: destinationURL)
         return destinationURL
     }
 
@@ -376,7 +607,7 @@ struct SharedStore: Sendable {
 
     private func recordingsDirectoryURL() throws -> URL {
         let directory = try containerURL().appendingPathComponent("Recordings", isDirectory: true)
-        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        try SharedFileProtection.prepareMetadataDirectory(at: directory)
         return directory
     }
 
@@ -386,7 +617,7 @@ struct SharedStore: Sendable {
         }
 
         let directory = documentsURL.appendingPathComponent("Muesli Recordings", isDirectory: true)
-        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        try SharedFileProtection.prepareMetadataDirectory(at: directory)
         return directory
     }
 
@@ -398,7 +629,7 @@ struct SharedStore: Sendable {
 
     private func containerURL() throws -> URL {
         if let overrideContainerURL {
-            try FileManager.default.createDirectory(at: overrideContainerURL, withIntermediateDirectories: true)
+            try SharedFileProtection.prepareMetadataDirectory(at: overrideContainerURL)
             return overrideContainerURL
         }
 
@@ -417,6 +648,8 @@ private enum SharedStoreKey: String {
     case keyboardExtensionStatus = "keyboard_extension_status"
     case keyboardRuntimeStatus = "keyboard_runtime_status"
     case keyboardLiveTranscript = "keyboard_live_transcript"
+    case keyboardPresentationLease = "keyboard_presentation_lease"
+    case keyboardResultInsertionClaim = "keyboard_result_insertion_claim"
     case legacyJSONMigrated = "legacy_json_migrated_v1"
     case customWordsInitialized = "custom_words_initialized"
 }
@@ -439,6 +672,11 @@ private enum SharedStoreDatabaseError: Error, LocalizedError {
             "Could not bind Muesli data query: \(message)"
         }
     }
+}
+
+private struct VoiceNoteCompletionOutcome {
+    var didComplete = false
+    var didUpdateKeyboardHandoff = false
 }
 
 private struct SharedStoreDatabase {
@@ -467,6 +705,145 @@ private struct SharedStoreDatabase {
         }
     }
 
+    func saveKeyboardIntent(_ command: DictationCommand) throws -> Bool {
+        try withDatabase { db in
+            var didSave = false
+            try transaction(db: db) {
+                let current = try valueData(key: .pendingCommand, db: db)
+                    .map { try decoder.decode(DictationCommand.self, from: $0) }
+                guard KeyboardIntentTransitionPolicy.permits(
+                    current: current,
+                    proposed: command
+                ) else { return }
+                try upsertValue(
+                    try encoder.encode(command),
+                    key: .pendingCommand,
+                    db: db
+                )
+                didSave = true
+            }
+            return didSave
+        }
+    }
+
+    func submitKeyboardIntent(
+        request: DictationRequest?,
+        command: DictationCommand,
+        handoffState: KeyboardHandoffState
+    ) throws -> Bool {
+        try withDatabase { db in
+            var didSubmit = false
+            try transaction(db: db) {
+                guard handoffState.requestID == command.requestID else { return }
+                if let request, request.id != command.requestID { return }
+
+                let currentCommand = try valueData(key: .pendingCommand, db: db)
+                    .map { try decoder.decode(DictationCommand.self, from: $0) }
+                let currentHandoff = try valueData(key: .keyboardHandoffState, db: db)
+                    .map { try decoder.decode(KeyboardHandoffState.self, from: $0) }
+                guard KeyboardIntentTransitionPolicy.permits(
+                    current: currentCommand,
+                    proposed: command
+                ), KeyboardHandoffTransitionPolicy.permits(
+                    current: currentHandoff,
+                    proposed: handoffState
+                ) else { return }
+
+                if let request {
+                    try upsertValue(
+                        try encoder.encode(request),
+                        key: .pendingRequest,
+                        db: db
+                    )
+                }
+                try upsertValue(
+                    try encoder.encode(command),
+                    key: .pendingCommand,
+                    db: db
+                )
+                try upsertValue(
+                    try encoder.encode(handoffState),
+                    key: .keyboardHandoffState,
+                    db: db
+                )
+                didSubmit = true
+            }
+            return didSubmit
+        }
+    }
+
+    func resolveKeyboardIntent(
+        commandID: UUID,
+        requestID: UUID,
+        handoffState: KeyboardHandoffState,
+        clearsPendingRequest: Bool
+    ) throws -> Bool {
+        try withDatabase { db in
+            var didResolve = false
+            try transaction(db: db) {
+                guard handoffState.requestID == requestID,
+                      let commandData = try valueData(key: .pendingCommand, db: db),
+                      let command = try? decoder.decode(DictationCommand.self, from: commandData),
+                      command.id == commandID,
+                      command.requestID == requestID
+                else { return }
+
+                let currentHandoff = try valueData(key: .keyboardHandoffState, db: db)
+                    .map { try decoder.decode(KeyboardHandoffState.self, from: $0) }
+                guard KeyboardHandoffTransitionPolicy.permits(
+                    current: currentHandoff,
+                    proposed: handoffState
+                ) else { return }
+
+                try execute("DELETE FROM key_values WHERE key = ?", db: db) { statement in
+                    try bind(SharedStoreKey.pendingCommand.rawValue, to: statement, at: 1)
+                }
+                if clearsPendingRequest,
+                   let requestData = try valueData(key: .pendingRequest, db: db),
+                   let pendingRequest = try? decoder.decode(DictationRequest.self, from: requestData),
+                   pendingRequest.id == requestID {
+                    try execute("DELETE FROM key_values WHERE key = ?", db: db) { statement in
+                        try bind(SharedStoreKey.pendingRequest.rawValue, to: statement, at: 1)
+                    }
+                }
+                try upsertValue(
+                    try encoder.encode(handoffState),
+                    key: .keyboardHandoffState,
+                    db: db
+                )
+                try upsertValue(
+                    try encoder.encode(DictationStatus.idle),
+                    key: .dictationStatus,
+                    db: db
+                )
+                didResolve = true
+            }
+            return didResolve
+        }
+    }
+
+    func saveKeyboardHandoffState(_ state: KeyboardHandoffState) throws -> Bool {
+        try withDatabase { db in
+            var didSave = false
+            try transaction(db: db) {
+                let current = try valueData(key: .keyboardHandoffState, db: db)
+                    .map { try decoder.decode(KeyboardHandoffState.self, from: $0) }
+                guard KeyboardHandoffTransitionPolicy.permits(
+                    current: current,
+                    proposed: state
+                ) else { return }
+
+                try upsertValue(
+                    try encoder.encode(state),
+                    key: .keyboardHandoffState,
+                    db: db
+                )
+                didSave = true
+            }
+            return didSave
+        }
+    }
+
     func value<T: Decodable>(_ type: T.Type, key: SharedStoreKey) throws -> T? {
         try withDatabase { db in
             guard let data = try valueData(key: key, db: db) else { return nil }
@@ -479,6 +856,40 @@ private struct SharedStoreDatabase {
             try execute("DELETE FROM key_values WHERE key = ?", db: db) { statement in
                 try bind(key.rawValue, to: statement, at: 1)
             }
+        }
+    }
+
+    func clearPendingCommand(id: UUID) throws -> Bool {
+        try withDatabase { db in
+            var didClear = false
+            try transaction(db: db) {
+                guard let data = try valueData(key: .pendingCommand, db: db),
+                      let current = try? decoder.decode(DictationCommand.self, from: data),
+                      current.id == id
+                else { return }
+                try execute("DELETE FROM key_values WHERE key = ?", db: db) { statement in
+                    try bind(SharedStoreKey.pendingCommand.rawValue, to: statement, at: 1)
+                }
+                didClear = true
+            }
+            return didClear
+        }
+    }
+
+    func clearPendingRequest(id: UUID) throws -> Bool {
+        try withDatabase { db in
+            var didClear = false
+            try transaction(db: db) {
+                guard let data = try valueData(key: .pendingRequest, db: db),
+                      let current = try? decoder.decode(DictationRequest.self, from: data),
+                      current.id == id
+                else { return }
+                try execute("DELETE FROM key_values WHERE key = ?", db: db) { statement in
+                    try bind(SharedStoreKey.pendingRequest.rawValue, to: statement, at: 1)
+                }
+                didClear = true
+            }
+            return didClear
         }
     }
 
@@ -495,13 +906,251 @@ private struct SharedStoreDatabase {
 
     func result(for requestID: UUID) throws -> DictationResult? {
         try withDatabase { db in
-            try querySingleBlob(
-                "SELECT payload FROM result_pickups WHERE request_id = ? LIMIT 1",
-                db: db
-            ) { statement in
-                try bind(requestID.uuidString, to: statement, at: 1)
-            }.map { try decoder.decode(DictationResult.self, from: $0) }
+            try result(for: requestID, db: db)
         }
+    }
+
+    func keyboardPresentationSnapshot(
+        preferredRequestID: UUID?
+    ) throws -> KeyboardPresentationSnapshot {
+        try withDatabase { db in
+            try readTransaction(db: db) {
+                let runtimeStatus = try valueData(key: .keyboardRuntimeStatus, db: db)
+                    .map { try decoder.decode(KeyboardRuntimeStatus.self, from: $0) }
+                let status = try valueData(key: .dictationStatus, db: db)
+                    .map { try decoder.decode(DictationStatus.self, from: $0) }
+                    ?? .idle
+                let handoffState = try valueData(key: .keyboardHandoffState, db: db)
+                    .map { try decoder.decode(KeyboardHandoffState.self, from: $0) }
+                    ?? .idle
+                let liveTranscript = try valueData(key: .keyboardLiveTranscript, db: db)
+                    .map { try decoder.decode(KeyboardLiveTranscript.self, from: $0) }
+                let targetRequestID = preferredRequestID
+                    ?? handoffState.requestID
+                    ?? status.requestID
+                    ?? runtimeStatus?.activeRequestID
+                let presentationResult: DictationResult?
+                if let targetRequestID {
+                    presentationResult = try result(for: targetRequestID, db: db)
+                } else {
+                    presentationResult = nil
+                }
+
+                return KeyboardPresentationSnapshot(
+                    runtimeStatus: runtimeStatus,
+                    status: status,
+                    handoffState: handoffState,
+                    liveTranscript: liveTranscript,
+                    targetRequestID: targetRequestID,
+                    result: presentationResult
+                )
+            }
+        }
+    }
+
+    func acquireKeyboardPresentationLease(
+        ownerID: UUID,
+        now: Date,
+        expirationInterval: TimeInterval
+    ) throws -> Bool {
+        try withDatabase { db in
+            var didAcquire = false
+            try transaction(db: db) {
+                let current = try valueData(key: .keyboardPresentationLease, db: db)
+                    .flatMap { try? decoder.decode(KeyboardPresentationLease.self, from: $0) }
+                let isExpired = current.map {
+                    let age = now.timeIntervalSince($0.updatedAt)
+                    return age < 0 || age >= expirationInterval
+                } ?? true
+                guard current?.ownerID == ownerID || isExpired else { return }
+                let lease = KeyboardPresentationLease(ownerID: ownerID, updatedAt: now)
+                try upsertValue(
+                    try encoder.encode(lease),
+                    key: .keyboardPresentationLease,
+                    db: db
+                )
+                didAcquire = true
+            }
+            return didAcquire
+        }
+    }
+
+    func releaseKeyboardPresentationLease(ownerID: UUID) throws -> Bool {
+        try withDatabase { db in
+            var didRelease = false
+            try transaction(db: db) {
+                guard let data = try valueData(key: .keyboardPresentationLease, db: db),
+                      let current = try? decoder.decode(KeyboardPresentationLease.self, from: data),
+                      current.ownerID == ownerID
+                else { return }
+                try execute("DELETE FROM key_values WHERE key = ?", db: db) { statement in
+                    try bind(SharedStoreKey.keyboardPresentationLease.rawValue, to: statement, at: 1)
+                }
+                didRelease = true
+            }
+            return didRelease
+        }
+    }
+
+    func claimKeyboardResultInsertion(
+        claim: KeyboardResultInsertionClaim,
+        now: Date,
+        leaseExpirationInterval: TimeInterval,
+        claimExpirationInterval: TimeInterval,
+        allowsAbandonedClaimRecovery: Bool
+    ) throws -> KeyboardResultInsertionClaimOutcome {
+        try withDatabase { db in
+            var outcome = KeyboardResultInsertionClaimOutcome.unavailable
+            try transaction(db: db) {
+                guard let leaseData = try valueData(key: .keyboardPresentationLease, db: db),
+                      let lease = try? decoder.decode(KeyboardPresentationLease.self, from: leaseData),
+                      lease.ownerID == claim.ownerID,
+                      Self.isFresh(
+                        timestamp: lease.updatedAt,
+                        now: now,
+                        expirationInterval: leaseExpirationInterval
+                      ),
+                      try result(for: claim.requestID, db: db) != nil,
+                      let handoffData = try valueData(key: .keyboardHandoffState, db: db),
+                      let handoff = try? decoder.decode(KeyboardHandoffState.self, from: handoffData),
+                      handoff.requestID == claim.requestID,
+                      handoff.phase == .resultReady
+                else { return }
+
+                if let existingData = try valueData(key: .keyboardResultInsertionClaim, db: db),
+                   let existing = try? decoder.decode(
+                    KeyboardResultInsertionClaim.self,
+                    from: existingData
+                   ) {
+                    if try result(for: existing.requestID, db: db) != nil {
+                        if Self.isFresh(
+                            timestamp: existing.claimedAt,
+                            now: now,
+                            expirationInterval: claimExpirationInterval
+                        ) {
+                            outcome = .busy
+                            return
+                        }
+                        guard existing.requestID == claim.requestID,
+                              allowsAbandonedClaimRecovery
+                        else {
+                            outcome = .recoveryRequired
+                            return
+                        }
+                    } else {
+                        try execute("DELETE FROM key_values WHERE key = ?", db: db) { statement in
+                            try bind(SharedStoreKey.keyboardResultInsertionClaim.rawValue, to: statement, at: 1)
+                        }
+                    }
+                }
+
+                try upsertValue(
+                    try encoder.encode(claim),
+                    key: .keyboardResultInsertionClaim,
+                    db: db
+                )
+                outcome = .acquired
+            }
+            return outcome
+        }
+    }
+
+    func finalizeKeyboardResultInsertion(
+        claim: KeyboardResultInsertionClaim,
+        handoffState: KeyboardHandoffState
+    ) throws -> Bool {
+        try withDatabase { db in
+            var didFinalize = false
+            try transaction(db: db) {
+                guard handoffState.requestID == claim.requestID,
+                      handoffState.phase == .inserted,
+                      let claimData = try valueData(key: .keyboardResultInsertionClaim, db: db),
+                      let currentClaim = try? decoder.decode(
+                        KeyboardResultInsertionClaim.self,
+                        from: claimData
+                      ), currentClaim == claim,
+                      try result(for: claim.requestID, db: db) != nil,
+                      let handoffData = try valueData(key: .keyboardHandoffState, db: db),
+                      let currentHandoff = try? decoder.decode(
+                        KeyboardHandoffState.self,
+                        from: handoffData
+                      ), KeyboardHandoffTransitionPolicy.permits(
+                        current: currentHandoff,
+                        proposed: handoffState
+                      )
+                else { return }
+
+                try execute("DELETE FROM result_pickups WHERE request_id = ?", db: db) { statement in
+                    try bind(claim.requestID.uuidString, to: statement, at: 1)
+                }
+                try execute("DELETE FROM key_values WHERE key = ?", db: db) { statement in
+                    try bind(SharedStoreKey.keyboardResultInsertionClaim.rawValue, to: statement, at: 1)
+                }
+                if let requestData = try valueData(key: .pendingRequest, db: db),
+                   let request = try? decoder.decode(DictationRequest.self, from: requestData),
+                   request.id == claim.requestID {
+                    try execute("DELETE FROM key_values WHERE key = ?", db: db) { statement in
+                        try bind(SharedStoreKey.pendingRequest.rawValue, to: statement, at: 1)
+                    }
+                }
+                if let commandData = try valueData(key: .pendingCommand, db: db),
+                   let command = try? decoder.decode(DictationCommand.self, from: commandData),
+                   command.requestID == claim.requestID {
+                    try execute("DELETE FROM key_values WHERE key = ?", db: db) { statement in
+                        try bind(SharedStoreKey.pendingCommand.rawValue, to: statement, at: 1)
+                    }
+                }
+                try upsertValue(
+                    try encoder.encode(handoffState),
+                    key: .keyboardHandoffState,
+                    db: db
+                )
+                didFinalize = true
+            }
+            return didFinalize
+        }
+    }
+
+    func validateKeyboardResultInsertionClaim(
+        _ claim: KeyboardResultInsertionClaim,
+        now: Date,
+        leaseExpirationInterval: TimeInterval
+    ) throws -> Bool {
+        try withDatabase { db in
+            try readTransaction(db: db) {
+                guard let leaseData = try valueData(key: .keyboardPresentationLease, db: db),
+                      let lease = try? decoder.decode(KeyboardPresentationLease.self, from: leaseData),
+                      lease.ownerID == claim.ownerID,
+                      Self.isFresh(
+                        timestamp: lease.updatedAt,
+                        now: now,
+                        expirationInterval: leaseExpirationInterval
+                      ),
+                      let claimData = try valueData(key: .keyboardResultInsertionClaim, db: db),
+                      let currentClaim = try? decoder.decode(
+                        KeyboardResultInsertionClaim.self,
+                        from: claimData
+                      ), currentClaim == claim,
+                      try result(for: claim.requestID, db: db) != nil,
+                      let handoffData = try valueData(key: .keyboardHandoffState, db: db),
+                      let handoff = try? decoder.decode(
+                        KeyboardHandoffState.self,
+                        from: handoffData
+                      ), handoff.requestID == claim.requestID,
+                      handoff.phase == .resultReady
+                else { return false }
+                return true
+            }
+        }
+    }
+
+    private static func isFresh(
+        timestamp: Date,
+        now: Date,
+        expirationInterval: TimeInterval
+    ) -> Bool {
+        let age = now.timeIntervalSince(timestamp)
+        return age >= 0 && age < expirationInterval
     }
 
     func resultsHistory() throws -> [DictationResult] {
@@ -604,6 +1253,98 @@ private struct SharedStoreDatabase {
                 transitionedSession = session
             }
             return transitionedSession
+        }
+    }
+
+    func transitionVoiceNoteSession(
+        id: UUID,
+        expectedPhases: Set<RecordingSessionPhase>,
+        update: (inout RecordingSession) -> Void
+    ) throws -> RecordingSession? {
+        try withDatabase { db in
+            var transitionedSession: RecordingSession?
+            try transaction(db: db) {
+                guard var session = try activeRecordingSession(id: id, db: db),
+                      session.kind != .meeting,
+                      expectedPhases.contains(session.phase)
+                else { return }
+
+                update(&session)
+                try upsertSession(session, db: db)
+                transitionedSession = session
+            }
+            return transitionedSession
+        }
+    }
+
+    func completeVoiceNoteSession(
+        _ completedSession: RecordingSession,
+        transcript: Transcript,
+        result: DictationResult,
+        expectedPhase: RecordingSessionPhase,
+        keyboardHandoffState: KeyboardHandoffState?
+    ) throws -> VoiceNoteCompletionOutcome {
+        try withDatabase { db in
+            var outcome = VoiceNoteCompletionOutcome()
+            try transaction(db: db) {
+                guard let current = try activeRecordingSession(id: completedSession.id, db: db),
+                      current.kind != .meeting,
+                      current.phase == expectedPhase,
+                      completedSession.phase == .completed,
+                      completedSession.requestID == current.requestID,
+                      transcript.sessionID == current.id,
+                      completedSession.transcriptID == transcript.id,
+                      result.sessionID == current.id,
+                      result.requestID == current.requestID,
+                      result.text == transcript.text,
+                      keyboardHandoffState.map({ handoff in
+                          current.isKeyboardOwnedVoiceNote
+                              && handoff.requestID == current.requestID
+                              && handoff.phase == .resultReady
+                      }) ?? true
+                else { return }
+
+                var resolvedSession = completedSession
+                resolvedSession.cloudRecordName = current.cloudRecordName
+                resolvedSession.scratchpadText = current.scratchpadText
+                // Retention controls remain user-owned while transcription runs.
+                // A concurrent Keep/Delete action must win over the caller's
+                // pre-transcription snapshot, otherwise post-commit cleanup can
+                // remove audio the user explicitly chose to retain.
+                resolvedSession.keepsAudioRecording = current.keepsAudioRecording
+                resolvedSession.audioFileName = current.audioFileName
+
+                try execute("DELETE FROM transcripts WHERE id = ? OR session_id = ?", db: db) { statement in
+                    try bind(transcript.id.uuidString, to: statement, at: 1)
+                    try bind(transcript.sessionID.uuidString, to: statement, at: 2)
+                }
+                try insertTranscript(transcript, db: db)
+                try upsertSession(resolvedSession, db: db)
+                try upsertResultPickup(result, db: db)
+                try upsertResultHistory(result, db: db)
+                let status = DictationStatus(requestID: result.requestID, phase: .finished)
+                try upsertValue(try encoder.encode(status), key: .dictationStatus, db: db)
+                if let keyboardHandoffState {
+                    let currentHandoff = try valueData(key: .keyboardHandoffState, db: db)
+                        .map { try decoder.decode(KeyboardHandoffState.self, from: $0) }
+                    let handoffBelongsToCompletedRequest = currentHandoff?.requestID == nil
+                        || currentHandoff?.requestID == result.requestID
+                    if handoffBelongsToCompletedRequest,
+                       KeyboardHandoffTransitionPolicy.permits(
+                        current: currentHandoff,
+                        proposed: keyboardHandoffState
+                    ) {
+                        try upsertValue(
+                            try encoder.encode(keyboardHandoffState),
+                            key: .keyboardHandoffState,
+                            db: db
+                        )
+                        outcome.didUpdateKeyboardHandoff = true
+                    }
+                }
+                outcome.didComplete = true
+            }
+            return outcome
         }
     }
 
@@ -1072,6 +1813,11 @@ private struct SharedStoreDatabase {
     }
 
     private func withDatabase<T>(_ body: (OpaquePointer) throws -> T) throws -> T {
+        try SharedFileProtection.prepareMetadataDirectory(at: containerURL)
+        if FileManager.default.fileExists(atPath: databaseURL.path) {
+            try SharedFileProtection.protectMetadata(at: databaseURL)
+        }
+
         var database: OpaquePointer?
         let flags = SQLITE_OPEN_CREATE | SQLITE_OPEN_READWRITE | SQLITE_OPEN_FULLMUTEX
         guard sqlite3_open_v2(databaseURL.path, &database, flags, nil) == SQLITE_OK,
@@ -1082,12 +1828,27 @@ private struct SharedStoreDatabase {
             }
             throw SharedStoreDatabaseError.openFailed(message)
         }
-        defer { sqlite3_close(database) }
+        defer {
+            protectDatabaseFilesBestEffort()
+            sqlite3_close(database)
+        }
 
+        try SharedFileProtection.protectMetadata(at: databaseURL)
         try configure(database)
+        protectDatabaseFilesBestEffort()
         try ensureInitialized(database)
 
         return try body(database)
+    }
+
+    private func protectDatabaseFilesBestEffort() {
+        SharedFileProtection.protectMetadataBestEffort(at: databaseURL)
+        SharedFileProtection.protectMetadataBestEffort(
+            at: URL(fileURLWithPath: databaseURL.path + "-wal")
+        )
+        SharedFileProtection.protectMetadataBestEffort(
+            at: URL(fileURLWithPath: databaseURL.path + "-shm")
+        )
     }
 
     private func configure(_ db: OpaquePointer) throws {
@@ -1484,6 +2245,15 @@ private struct SharedStoreDatabase {
         try querySingleBlob("SELECT payload FROM key_values WHERE key = ? LIMIT 1", db: db) { statement in
             try bind(key.rawValue, to: statement, at: 1)
         }
+    }
+
+    private func result(for requestID: UUID, db: OpaquePointer) throws -> DictationResult? {
+        try querySingleBlob(
+            "SELECT payload FROM result_pickups WHERE request_id = ? LIMIT 1",
+            db: db
+        ) { statement in
+            try bind(requestID.uuidString, to: statement, at: 1)
+        }.map { try decoder.decode(DictationResult.self, from: $0) }
     }
 
     private func upsertResultPickup(_ result: DictationResult, db: OpaquePointer) throws {
@@ -1981,6 +2751,21 @@ private struct SharedStoreDatabase {
         do {
             try body()
             try exec("COMMIT", db: db)
+        } catch {
+            try? exec("ROLLBACK", db: db)
+            throw error
+        }
+    }
+
+    private func readTransaction<T>(
+        db: OpaquePointer,
+        _ body: () throws -> T
+    ) throws -> T {
+        try exec("BEGIN DEFERRED TRANSACTION", db: db)
+        do {
+            let value = try body()
+            try exec("COMMIT", db: db)
+            return value
         } catch {
             try? exec("ROLLBACK", db: db)
             throw error

--- a/Tests/MuesliTests/KeyboardControllerPresentationTests.swift
+++ b/Tests/MuesliTests/KeyboardControllerPresentationTests.swift
@@ -1,0 +1,288 @@
+import XCTest
+@testable import Muesli
+
+@MainActor
+final class KeyboardControllerPresentationTests: XCTestCase {
+    func testColdReconciliationRestoresRequestBeforeApplyingFreshMeterLevel() throws {
+        let fixture = try makeRecordingFixture(level: 0.82)
+        defer { fixture.cleanup() }
+
+        let controller = KeyboardController(store: fixture.store, eventBus: fixture.bus)
+        controller.reconcileSharedPresentationState()
+
+        XCTAssertEqual(controller.dictationPhase, .recording)
+        XCTAssertEqual(controller.primaryButtonTitle, "Stop")
+        XCTAssertFalse(controller.isPrimaryButtonDisabled)
+        XCTAssertEqual(controller.waveformMode, .level)
+        XCTAssertEqual(try XCTUnwrap(controller.waveformLevel), 0.82, accuracy: 0.001)
+        XCTAssertEqual(controller.liveTranscript, "Before lock and after lock")
+    }
+
+    func testStaleMeterDoesNotDisableControlsOrMutateDurableRecording() throws {
+        let fixture = try makeRecordingFixture(
+            level: 0.91,
+            runtimeUpdatedAt: Date().addingTimeInterval(-10),
+            handoffUpdatedAt: Date().addingTimeInterval(-60)
+        )
+        defer { fixture.cleanup() }
+
+        let controller = KeyboardController(store: fixture.store, eventBus: fixture.bus)
+        controller.reconcileSharedPresentationState()
+
+        XCTAssertEqual(controller.dictationPhase, .recording)
+        XCTAssertEqual(controller.primaryButtonTitle, "Stop")
+        XCTAssertFalse(controller.isPrimaryButtonDisabled)
+        XCTAssertTrue(controller.isCaptureRecovering)
+        XCTAssertEqual(controller.waveformMode, .waiting)
+        XCTAssertNil(controller.waveformLevel)
+        XCTAssertEqual(try fixture.store.keyboardHandoffState().phase, .recordingStarted)
+        XCTAssertEqual(
+            try fixture.store.recordingSession(id: fixture.session.id)?.phase,
+            .recording
+        )
+    }
+
+    func testRecoveringRuntimeUsesWaitingPresentationUntilFreshLevelsResume() throws {
+        let fixture = try makeRecordingFixture(level: 0.91, isRecoveringCapture: true)
+        defer { fixture.cleanup() }
+
+        let controller = KeyboardController(store: fixture.store, eventBus: fixture.bus)
+        controller.reconcileSharedPresentationState()
+
+        XCTAssertEqual(controller.dictationPhase, .recording)
+        XCTAssertEqual(controller.primaryButtonTitle, "Stop")
+        XCTAssertFalse(controller.isPrimaryButtonDisabled)
+        XCTAssertTrue(controller.isCaptureRecovering)
+        XCTAssertEqual(controller.waveformMode, .waiting)
+        XCTAssertNil(controller.waveformLevel)
+
+        try fixture.store.saveKeyboardRuntimeStatus(.init(
+            isActive: true,
+            activeRequestID: fixture.session.requestID,
+            phase: .recording,
+            message: "Listening",
+            supportsBackgroundStart: false,
+            inputLevel: 0.64
+        ))
+        controller.reconcileSharedPresentationState()
+
+        XCTAssertFalse(controller.isCaptureRecovering)
+        XCTAssertEqual(controller.waveformMode, .level)
+        XCTAssertEqual(try XCTUnwrap(controller.waveformLevel), 0.64, accuracy: 0.001)
+    }
+
+    func testHostResumeRecreatesWaveformLeafAndReconcilesActiveState() throws {
+        let fixture = try makeRecordingFixture(level: 0.52)
+        defer { fixture.cleanup() }
+
+        let controller = KeyboardController(store: fixture.store, eventBus: fixture.bus)
+        let initialGeneration = controller.waveformRenderGeneration
+        controller.activatePresentationLease()
+        controller.resumeAfterHostActivation()
+        defer { controller.stopObservingSharedState() }
+
+        XCTAssertEqual(controller.waveformRenderGeneration, initialGeneration + 1)
+        XCTAssertEqual(controller.dictationPhase, .recording)
+        XCTAssertEqual(try XCTUnwrap(controller.waveformLevel), 0.52, accuracy: 0.001)
+    }
+
+    func testMissedResultNotificationInsertsExactlyOnceAndRepairsTerminalUI() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let bus = SilentCrossProcessEventBus()
+        let store = SharedStore(containerURL: directory, eventPoster: bus)
+        let requestID = UUID()
+        let session = RecordingSession(
+            requestID: requestID,
+            kind: .keyboardDictation,
+            phase: .completed,
+            source: "keyboard"
+        )
+        try store.saveSession(session)
+        try store.saveStatus(.init(requestID: requestID, phase: .finished))
+        try store.saveKeyboardHandoffState(.init(
+            requestID: requestID,
+            phase: .resultReady,
+            message: "Ready to insert"
+        ))
+        let result = DictationResult(
+            requestID: requestID,
+            sessionID: session.id,
+            text: "Recovered once",
+            engineIdentifier: "test-engine",
+            source: "keyboard"
+        )
+        try store.saveResult(result)
+
+        var inserted: [String] = []
+        let controller = KeyboardController(store: store, eventBus: bus)
+        controller.textInserter = { inserted.append($0) }
+        controller.activatePresentationLease()
+        controller.reconcileSharedPresentationState()
+
+        XCTAssertEqual(inserted, ["Recovered once"])
+        XCTAssertEqual(controller.dictationPhase, .idle)
+        XCTAssertEqual(controller.primaryButtonTitle, "Record")
+        XCTAssertEqual(try store.keyboardHandoffState().phase, .inserted)
+
+        let lateResultReady = KeyboardHandoffState(
+            requestID: requestID,
+            phase: .resultReady,
+            message: "Late result-ready",
+            updatedAt: Date().addingTimeInterval(1)
+        )
+        XCTAssertFalse(try store.saveKeyboardHandoffState(lateResultReady))
+        controller.reconcileSharedPresentationState()
+
+        XCTAssertEqual(inserted, ["Recovered once"])
+        XCTAssertEqual(controller.dictationPhase, .idle)
+        XCTAssertNotEqual(controller.primaryButtonTitle, "Transcribing")
+    }
+
+    func testPreloadedControllerCannotConsumeResultBeforePresentationBecomesEligible() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let bus = SilentCrossProcessEventBus()
+        let store = SharedStore(containerURL: directory, eventPoster: bus)
+        let requestID = UUID()
+        try store.saveKeyboardHandoffState(.init(requestID: requestID, phase: .resultReady))
+        try store.saveResult(.init(
+            requestID: requestID,
+            text: "Only the visible keyboard may insert",
+            engineIdentifier: "test"
+        ))
+
+        var hiddenInsertions: [String] = []
+        let preloaded = KeyboardController(store: store, eventBus: bus)
+        preloaded.textInserter = { hiddenInsertions.append($0) }
+        preloaded.reconcileSharedPresentationState()
+
+        XCTAssertTrue(hiddenInsertions.isEmpty)
+        XCTAssertNotNil(try store.result(for: requestID))
+
+        var visibleInsertions: [String] = []
+        let visible = KeyboardController(store: store, eventBus: bus)
+        visible.textInserter = { visibleInsertions.append($0) }
+        visible.activatePresentationLease()
+        visible.reconcileSharedPresentationState()
+
+        XCTAssertEqual(visibleInsertions, ["Only the visible keyboard may insert"])
+        XCTAssertTrue(hiddenInsertions.isEmpty)
+        XCTAssertNil(try store.result(for: requestID))
+    }
+
+    func testAbandonedInsertionRequiresTwoStepConfirmationAndClearsAfterTerminalHandoff() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let bus = SilentCrossProcessEventBus()
+        let store = SharedStore(containerURL: directory, eventPoster: bus)
+        let requestID = UUID()
+        let oldTime = Date().addingTimeInterval(-60)
+        let oldOwner = UUID()
+        try store.saveKeyboardHandoffState(.init(requestID: requestID, phase: .resultReady))
+        try store.saveResult(.init(
+            requestID: requestID,
+            text: "Recover only when missing",
+            engineIdentifier: "test"
+        ))
+        XCTAssertTrue(try store.acquireKeyboardPresentationLease(ownerID: oldOwner, now: oldTime))
+        XCTAssertEqual(try store.claimKeyboardResultInsertion(
+            claim: .init(
+                id: UUID(),
+                requestID: requestID,
+                ownerID: oldOwner,
+                claimedAt: oldTime
+            ),
+            now: oldTime
+        ), .acquired)
+
+        var inserted: [String] = []
+        let controller = KeyboardController(store: store, eventBus: bus)
+        controller.textInserter = { inserted.append($0) }
+        controller.activatePresentationLease()
+        controller.reconcileSharedPresentationState()
+
+        XCTAssertEqual(controller.primaryButtonTitle, "Review recovered text")
+        controller.primaryAction()
+        XCTAssertTrue(inserted.isEmpty)
+        XCTAssertEqual(controller.primaryButtonTitle, "Insert if missing")
+        XCTAssertEqual(controller.statusText, "Verify the text is missing before inserting")
+
+        controller.primaryAction()
+        XCTAssertEqual(inserted, ["Recover only when missing"])
+        XCTAssertEqual(try store.keyboardHandoffState().phase, .inserted)
+        XCTAssertNotEqual(controller.primaryButtonRole, .manualInsert)
+    }
+
+    private func makeRecordingFixture(
+        level: Double,
+        isRecoveringCapture: Bool = false,
+        runtimeUpdatedAt: Date = .now,
+        handoffUpdatedAt: Date = .now
+    ) throws -> RecordingFixture {
+        let directory = try makeTemporaryDirectory()
+        let bus = SilentCrossProcessEventBus()
+        let store = SharedStore(containerURL: directory, eventPoster: bus)
+        let requestID = UUID()
+        let session = RecordingSession(
+            requestID: requestID,
+            kind: .keyboardDictation,
+            phase: .recording,
+            source: "keyboard"
+        )
+        try store.saveSession(session)
+        try store.saveStatus(.init(requestID: requestID, phase: .recording))
+        try store.saveKeyboardHandoffState(.init(
+            requestID: requestID,
+            phase: .recordingStarted,
+            message: "Listening",
+            updatedAt: handoffUpdatedAt
+        ))
+        try store.saveKeyboardRuntimeStatus(.init(
+            isActive: true,
+            activeRequestID: requestID,
+            phase: .recording,
+            message: "Listening",
+            supportsBackgroundStart: false,
+            inputLevel: level,
+            isRecoveringCapture: isRecoveringCapture,
+            updatedAt: runtimeUpdatedAt
+        ))
+        try store.saveKeyboardLiveTranscript(.init(
+            requestID: requestID,
+            text: "Before lock and after lock"
+        ))
+        return RecordingFixture(
+            directory: directory,
+            bus: bus,
+            store: store,
+            session: session
+        )
+    }
+
+    private func makeTemporaryDirectory() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+}
+
+private struct RecordingFixture {
+    let directory: URL
+    let bus: SilentCrossProcessEventBus
+    let store: SharedStore
+    let session: RecordingSession
+
+    func cleanup() {
+        try? FileManager.default.removeItem(at: directory)
+    }
+}
+
+private final class SilentCrossProcessEventBus: CrossProcessEventStreaming, @unchecked Sendable {
+    func post(_: CrossProcessEvent) {}
+
+    func events() -> AsyncStream<CrossProcessEvent> {
+        AsyncStream { _ in }
+    }
+}

--- a/Tests/MuesliTests/KeyboardHandoffInvariantTests.swift
+++ b/Tests/MuesliTests/KeyboardHandoffInvariantTests.swift
@@ -1,0 +1,200 @@
+import XCTest
+@testable import Muesli
+
+final class KeyboardHandoffInvariantTests: XCTestCase {
+    func testOlderRequestCannotOverwriteNewerActiveRequest() throws {
+        let fixture = try makeFixture()
+        defer { fixture.cleanup() }
+
+        let olderRequestID = UUID()
+        let newerRequestID = UUID()
+        let newerActive = KeyboardHandoffState(
+            requestID: newerRequestID,
+            phase: .recordingStarted,
+            message: "Listening",
+            createdAt: Date(timeIntervalSince1970: 200),
+            updatedAt: Date(timeIntervalSince1970: 210)
+        )
+        let lateOlderCompletion = KeyboardHandoffState(
+            requestID: olderRequestID,
+            phase: .resultReady,
+            message: "Late result",
+            createdAt: Date(timeIntervalSince1970: 100),
+            updatedAt: Date(timeIntervalSince1970: 300)
+        )
+
+        XCTAssertTrue(try fixture.store.saveKeyboardHandoffState(newerActive))
+        XCTAssertFalse(try fixture.store.saveKeyboardHandoffState(lateOlderCompletion))
+        XCTAssertEqual(try fixture.store.keyboardHandoffState(), newerActive)
+    }
+
+    func testNewerRequestCanStartAfterTerminalOlderRequest() throws {
+        let fixture = try makeFixture()
+        defer { fixture.cleanup() }
+
+        let terminalOlderRequest = KeyboardHandoffState(
+            requestID: UUID(),
+            phase: .inserted,
+            message: "Inserted",
+            createdAt: Date(timeIntervalSince1970: 100),
+            updatedAt: Date(timeIntervalSince1970: 150)
+        )
+        let newerStart = KeyboardHandoffState(
+            requestID: UUID(),
+            phase: .startRequested,
+            message: "Starting",
+            createdAt: Date(timeIntervalSince1970: 200),
+            updatedAt: Date(timeIntervalSince1970: 200)
+        )
+
+        XCTAssertTrue(try fixture.store.saveKeyboardHandoffState(terminalOlderRequest))
+        XCTAssertTrue(try fixture.store.saveKeyboardHandoffState(newerStart))
+        XCTAssertEqual(try fixture.store.keyboardHandoffState(), newerStart)
+    }
+
+    func testFailedRequestRetryWithNewAttemptCanReachResultReady() throws {
+        let fixture = try makeFixture()
+        defer { fixture.cleanup() }
+
+        let failed = KeyboardHandoffState(
+            requestID: UUID(),
+            phase: .failed,
+            message: "Transcription failed",
+            recoveryAttemptCount: 1,
+            createdAt: Date(timeIntervalSince1970: 100),
+            updatedAt: Date(timeIntervalSince1970: 200)
+        )
+        let retrying = failed.advanced(
+            to: .transcribingStarted,
+            message: "Retrying transcription",
+            recoveryAttemptCount: 2,
+            updatedAt: Date(timeIntervalSince1970: 300)
+        )
+        let resultReady = retrying.advanced(
+            to: .resultReady,
+            message: "Ready to insert",
+            updatedAt: Date(timeIntervalSince1970: 400)
+        )
+
+        XCTAssertTrue(try fixture.store.saveKeyboardHandoffState(failed))
+        XCTAssertTrue(try fixture.store.saveKeyboardHandoffState(retrying))
+        XCTAssertTrue(try fixture.store.saveKeyboardHandoffState(resultReady))
+        XCTAssertEqual(try fixture.store.keyboardHandoffState(), resultReady)
+    }
+
+    func testConditionalPendingCommandClearPreservesNewerCommand() throws {
+        let fixture = try makeFixture()
+        defer { fixture.cleanup() }
+
+        let requestID = UUID()
+        let consumedStop = DictationCommand(
+            requestID: requestID,
+            action: .stop,
+            createdAt: Date(timeIntervalSince1970: 100)
+        )
+        let newerCancel = DictationCommand(
+            requestID: requestID,
+            action: .cancel,
+            createdAt: Date(timeIntervalSince1970: 200)
+        )
+
+        try fixture.store.saveCommand(consumedStop)
+        XCTAssertEqual(try fixture.store.pendingCommand(), consumedStop)
+
+        try fixture.store.saveCommand(newerCancel)
+        XCTAssertFalse(try fixture.store.clearPendingCommand(id: consumedStop.id))
+        XCTAssertEqual(try fixture.store.pendingCommand(), newerCancel)
+
+        XCTAssertTrue(try fixture.store.clearPendingCommand(id: newerCancel.id))
+        XCTAssertNil(try fixture.store.pendingCommand())
+    }
+
+    func testAtomicCompletionRejectsMismatchedKeyboardHandoffWithoutPartialWrites() throws {
+        let fixture = try makeFixture()
+        defer { fixture.cleanup() }
+
+        let requestID = UUID()
+        let currentSession = RecordingSession(
+            requestID: requestID,
+            kind: .keyboardDictation,
+            phase: .transcribing,
+            source: "keyboard"
+        )
+        try fixture.store.saveSession(currentSession)
+        let sessionBeforeAttempt = try XCTUnwrap(
+            try fixture.store.recordingSession(id: currentSession.id)
+        )
+
+        let statusBeforeAttempt = DictationStatus(
+            requestID: requestID,
+            phase: .transcribing,
+            message: "Transcribing"
+        )
+        try fixture.store.saveStatus(statusBeforeAttempt)
+        let handoffBeforeAttempt = KeyboardHandoffState(
+            requestID: requestID,
+            phase: .transcribingStarted,
+            message: "Transcribing",
+            createdAt: currentSession.createdAt,
+            updatedAt: Date(timeIntervalSince1970: 200)
+        )
+        XCTAssertTrue(try fixture.store.saveKeyboardHandoffState(handoffBeforeAttempt))
+
+        let transcript = Transcript(
+            sessionID: currentSession.id,
+            text: "Must commit as one coherent request",
+            engineIdentifier: "test-engine"
+        )
+        var completedSession = currentSession
+        completedSession.phase = .completed
+        completedSession.transcriptID = transcript.id
+        completedSession.engineIdentifier = transcript.engineIdentifier
+        let result = DictationResult(
+            requestID: requestID,
+            sessionID: currentSession.id,
+            text: transcript.text,
+            engineIdentifier: transcript.engineIdentifier,
+            source: "keyboard"
+        )
+        let mismatchedHandoff = KeyboardHandoffState(
+            requestID: UUID(),
+            phase: .resultReady,
+            message: "Wrong request",
+            createdAt: Date(timeIntervalSince1970: 300),
+            updatedAt: Date(timeIntervalSince1970: 300)
+        )
+
+        XCTAssertFalse(try fixture.store.completeVoiceNoteSession(
+            completedSession,
+            transcript: transcript,
+            result: result,
+            keyboardHandoffState: mismatchedHandoff
+        ))
+
+        XCTAssertEqual(try fixture.store.recordingSession(id: currentSession.id), sessionBeforeAttempt)
+        XCTAssertNil(try fixture.store.transcript(for: currentSession.id))
+        XCTAssertNil(try fixture.store.result(for: requestID))
+        XCTAssertTrue(try fixture.store.resultsHistory().isEmpty)
+        XCTAssertEqual(try fixture.store.status(), statusBeforeAttempt)
+        XCTAssertEqual(try fixture.store.keyboardHandoffState(), handoffBeforeAttempt)
+    }
+
+    private func makeFixture() throws -> StoreFixture {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("muesli-handoff-tests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        return StoreFixture(
+            directory: directory,
+            store: SharedStore(containerURL: directory)
+        )
+    }
+}
+
+private struct StoreFixture {
+    let directory: URL
+    let store: SharedStore
+
+    func cleanup() {
+        try? FileManager.default.removeItem(at: directory)
+    }
+}

--- a/Tests/MuesliTests/KeyboardSessionKeeperTests.swift
+++ b/Tests/MuesliTests/KeyboardSessionKeeperTests.swift
@@ -16,4 +16,62 @@ final class KeyboardSessionKeeperTests: XCTestCase {
 
         KeyboardSessionKeeper.discardAudioTap(buffer, when: time)
     }
+
+    func testRecentAudioInputRequiresAnActiveRunningCapture() {
+        let now = Date()
+        let recent = now.addingTimeInterval(-0.25)
+
+        XCTAssertFalse(RecentAudioInputHealth.isReceiving(
+            hasActiveCapture: false,
+            graphIsRunning: true,
+            lastInputBufferAt: recent,
+            now: now,
+            maximumAge: 1.5
+        ))
+        XCTAssertFalse(RecentAudioInputHealth.isReceiving(
+            hasActiveCapture: true,
+            graphIsRunning: false,
+            lastInputBufferAt: recent,
+            now: now,
+            maximumAge: 1.5
+        ))
+    }
+
+    func testRecentAudioInputRejectsMissingStaleAndFutureBuffers() {
+        let now = Date()
+
+        XCTAssertFalse(RecentAudioInputHealth.isReceiving(
+            hasActiveCapture: true,
+            graphIsRunning: true,
+            lastInputBufferAt: nil,
+            now: now,
+            maximumAge: 1.5
+        ))
+        XCTAssertFalse(RecentAudioInputHealth.isReceiving(
+            hasActiveCapture: true,
+            graphIsRunning: true,
+            lastInputBufferAt: now.addingTimeInterval(-1.51),
+            now: now,
+            maximumAge: 1.5
+        ))
+        XCTAssertFalse(RecentAudioInputHealth.isReceiving(
+            hasActiveCapture: true,
+            graphIsRunning: true,
+            lastInputBufferAt: now.addingTimeInterval(0.01),
+            now: now,
+            maximumAge: 1.5
+        ))
+    }
+
+    func testRecentAudioInputAcceptsBufferAtFreshnessBoundary() {
+        let now = Date()
+
+        XCTAssertTrue(RecentAudioInputHealth.isReceiving(
+            hasActiveCapture: true,
+            graphIsRunning: true,
+            lastInputBufferAt: now.addingTimeInterval(-1.5),
+            now: now,
+            maximumAge: 1.5
+        ))
+    }
 }

--- a/Tests/MuesliTests/LongVoiceNotePersistenceTests.swift
+++ b/Tests/MuesliTests/LongVoiceNotePersistenceTests.swift
@@ -10,6 +10,8 @@ final class LongVoiceNotePersistenceTests: XCTestCase {
         let activatedAt = Date(timeIntervalSince1970: 200)
         let attemptedAt = Date(timeIntervalSince1970: 300)
         let recoveryValidatedAt = Date(timeIntervalSince1970: 400)
+        let interruptedAt = Date(timeIntervalSince1970: 500)
+        let draftUpdatedAt = Date(timeIntervalSince1970: 510)
         let session = RecordingSession(
             kind: .quickDictation,
             phase: .failed,
@@ -23,7 +25,11 @@ final class LongVoiceNotePersistenceTests: XCTestCase {
             lastTranscriptionAttemptAt: attemptedAt,
             lastTranscriptionFailureReason: .timeout,
             scratchpadText: "Remember the second point",
-            longFormRecoveryValidatedAt: recoveryValidatedAt
+            longFormRecoveryValidatedAt: recoveryValidatedAt,
+            captureInterruptionReason: .appSuspended,
+            captureInterruptedAt: interruptedAt,
+            draftTranscriptText: "A durable partial transcript",
+            draftTranscriptUpdatedAt: draftUpdatedAt
         )
 
         try store.saveSession(session)
@@ -39,6 +45,10 @@ final class LongVoiceNotePersistenceTests: XCTestCase {
         XCTAssertEqual(recovered.lastTranscriptionFailureReason, .timeout)
         XCTAssertEqual(recovered.scratchpadText, "Remember the second point")
         XCTAssertEqual(recovered.longFormRecoveryValidatedAt, recoveryValidatedAt)
+        XCTAssertEqual(recovered.captureInterruptionReason, .appSuspended)
+        XCTAssertEqual(recovered.captureInterruptedAt, interruptedAt)
+        XCTAssertEqual(recovered.draftTranscriptText, "A durable partial transcript")
+        XCTAssertEqual(recovered.draftTranscriptUpdatedAt, draftUpdatedAt)
         XCTAssertEqual(recovered.voiceNoteDurabilityEvidence, .durableCheckpoint)
     }
 
@@ -50,7 +60,8 @@ final class LongVoiceNotePersistenceTests: XCTestCase {
             "isLongForm", "longFormActivatedAt", "longFormThresholdSeconds",
             "hasDurableAudioCheckpoint", "protectedAudioUntilTranscriptCompletes", "transcriptionRetryCount",
             "lastTranscriptionAttemptAt", "lastTranscriptionFailureReason", "scratchpadText",
-            "longFormRecoveryValidatedAt"
+            "longFormRecoveryValidatedAt", "captureInterruptionReason", "captureInterruptedAt",
+            "draftTranscriptText", "draftTranscriptUpdatedAt"
         ] {
             payload.removeValue(forKey: key)
         }
@@ -69,6 +80,10 @@ final class LongVoiceNotePersistenceTests: XCTestCase {
         XCTAssertNil(decoded.lastTranscriptionFailureReason)
         XCTAssertNil(decoded.scratchpadText)
         XCTAssertNil(decoded.longFormRecoveryValidatedAt)
+        XCTAssertNil(decoded.captureInterruptionReason)
+        XCTAssertNil(decoded.captureInterruptedAt)
+        XCTAssertNil(decoded.draftTranscriptText)
+        XCTAssertNil(decoded.draftTranscriptUpdatedAt)
         XCTAssertEqual(decoded.voiceNoteDurabilityEvidence, .unavailable)
     }
 
@@ -82,19 +97,18 @@ final class LongVoiceNotePersistenceTests: XCTestCase {
         XCTAssertEqual(referencedOnly.voiceNoteDurabilityEvidence, .audioReferenceOnly)
     }
 
-    func testTranscriptionRetryRequiresAFailedSessionWithDurableCheckpoint() {
+    func testTranscriptionRetryRequiresVerifiedProtectedAudio() {
         let retryable = RecordingSession(
             kind: .quickDictation,
             phase: .failed,
             audioFileName: "voice-note.wav",
-            isLongForm: true,
-            hasDurableAudioCheckpoint: true
+            protectedAudioUntilTranscriptCompletes: true
         )
         XCTAssertTrue(retryable.canRetryVoiceNoteTranscription)
 
-        var referenceOnly = retryable
-        referenceOnly.hasDurableAudioCheckpoint = false
-        XCTAssertFalse(referenceOnly.canRetryVoiceNoteTranscription)
+        var unverified = retryable
+        unverified.protectedAudioUntilTranscriptCompletes = false
+        XCTAssertFalse(unverified.canRetryVoiceNoteTranscription)
 
         var missingAudio = retryable
         missingAudio.audioFileName = nil
@@ -103,6 +117,18 @@ final class LongVoiceNotePersistenceTests: XCTestCase {
         var completed = retryable
         completed.phase = .completed
         XCTAssertFalse(completed.canRetryVoiceNoteTranscription)
+    }
+
+    func testInterruptedVoiceNoteStillOwnsActiveWork() {
+        let session = RecordingSession(
+            kind: .keyboardDictation,
+            phase: .interrupted,
+            source: "keyboard",
+            captureInterruptionReason: .appSuspended
+        )
+
+        XCTAssertTrue(session.hasActiveVoiceNoteWork)
+        XCTAssertTrue(session.isKeyboardOwnedVoiceNote)
     }
 
     func testVoiceNoteWorkOwnershipDistinguishesAppAndKeyboardSessions() {

--- a/Tests/MuesliTests/SharedStoreTests.swift
+++ b/Tests/MuesliTests/SharedStoreTests.swift
@@ -519,6 +519,226 @@ final class SharedStoreTests: XCTestCase {
         XCTAssertNil(try store.pendingCommand())
     }
 
+    func testLegacyPendingCommandHasStableIdentityAndCanBeCASCleared() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = SharedStore(containerURL: directory)
+        _ = try store.status() // Initialize the SQLite schema.
+
+        let legacy = LegacyKeyboardCommandPayload(
+            requestID: UUID(),
+            action: .stop,
+            createdAt: Date(timeIntervalSinceReferenceDate: 12_345.625)
+        )
+        let payload = try JSONEncoder().encode(legacy)
+        let database = try openSQLiteDatabase(in: directory)
+        try sqliteInsertBlob(
+            "INSERT OR REPLACE INTO key_values (key, payload, updated_at) VALUES (?, ?, ?)",
+            database,
+            values: [
+                .text("pending_command"),
+                .blob(payload),
+                .double(Date().timeIntervalSince1970)
+            ]
+        )
+        sqlite3_close(database)
+
+        let first = try XCTUnwrap(store.pendingCommand())
+        let secondStore = SharedStore(containerURL: directory)
+        let second = try XCTUnwrap(secondStore.pendingCommand())
+        XCTAssertEqual(first.id, second.id)
+        XCTAssertEqual(first.requestID, legacy.requestID)
+        XCTAssertTrue(try secondStore.clearPendingCommand(id: first.id))
+        XCTAssertNil(try store.pendingCommand())
+    }
+
+    func testRapidStartThenStopPersistsTerminalDesiredIntentAtomically() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = SharedStore(containerURL: directory)
+        let request = DictationRequest(createdAt: Date(timeIntervalSince1970: 100))
+        let start = DictationCommand(
+            requestID: request.id,
+            action: .start,
+            createdAt: Date(timeIntervalSince1970: 101)
+        )
+        let starting = KeyboardHandoffState(
+            requestID: request.id,
+            phase: .startRequested,
+            createdAt: request.createdAt,
+            updatedAt: start.createdAt
+        )
+        XCTAssertTrue(try store.submitKeyboardIntent(
+            request: request,
+            command: start,
+            handoffState: starting
+        ))
+
+        let stop = DictationCommand(
+            requestID: request.id,
+            action: .stop,
+            createdAt: Date(timeIntervalSince1970: 102)
+        )
+        let stopping = starting.advanced(
+            to: .stopRequested,
+            message: "Stopping",
+            updatedAt: stop.createdAt
+        )
+        XCTAssertTrue(try store.submitKeyboardIntent(
+            request: nil,
+            command: stop,
+            handoffState: stopping
+        ))
+        XCTAssertEqual(try store.pendingCommand(), stop)
+        XCTAssertEqual(try store.pendingRequest(), request)
+        XCTAssertEqual(try store.keyboardHandoffState(), stopping)
+
+        let staleStartRetry = DictationCommand(
+            requestID: request.id,
+            action: .start,
+            createdAt: Date(timeIntervalSince1970: 103)
+        )
+        XCTAssertFalse(try store.saveCommand(staleStartRetry))
+        XCTAssertEqual(try store.pendingCommand(), stop)
+
+        let terminal = stopping.advanced(
+            to: .cancelled,
+            message: "Stopped before recording began",
+            updatedAt: Date(timeIntervalSince1970: 104)
+        )
+        XCTAssertTrue(try store.resolveKeyboardIntent(
+            commandID: stop.id,
+            requestID: request.id,
+            handoffState: terminal,
+            clearsPendingRequest: true
+        ))
+        XCTAssertNil(try store.pendingCommand())
+        XCTAssertNil(try store.pendingRequest())
+        XCTAssertEqual(try store.keyboardHandoffState(), terminal)
+    }
+
+    func testResultInsertionClaimRequiresPresentationLeaseAndFinalizesAtomically() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = SharedStore(containerURL: directory)
+        let requestID = UUID()
+        let result = DictationResult(
+            requestID: requestID,
+            text: "Claimed once",
+            engineIdentifier: "test"
+        )
+        let ready = KeyboardHandoffState(requestID: requestID, phase: .resultReady)
+        try store.saveResult(result)
+        XCTAssertTrue(try store.saveKeyboardHandoffState(ready))
+
+        let ownerID = UUID()
+        XCTAssertTrue(try store.acquireKeyboardPresentationLease(ownerID: ownerID))
+        let claim = KeyboardResultInsertionClaim(
+            id: UUID(),
+            requestID: requestID,
+            ownerID: ownerID,
+            claimedAt: .now
+        )
+        XCTAssertEqual(
+            try store.claimKeyboardResultInsertion(claim: claim),
+            .acquired
+        )
+        XCTAssertEqual(
+            try store.claimKeyboardResultInsertion(claim: .init(
+                id: UUID(),
+                requestID: requestID,
+                ownerID: ownerID,
+                claimedAt: .now
+            )),
+            .busy
+        )
+
+        let inserted = ready.advanced(to: .inserted, message: "Inserted")
+        XCTAssertTrue(try store.finalizeKeyboardResultInsertion(
+            claim: claim,
+            handoffState: inserted
+        ))
+        XCTAssertNil(try store.result(for: requestID))
+        XCTAssertEqual(try store.keyboardHandoffState().phase, .inserted)
+    }
+
+    func testAbandonedResultClaimRequiresExplicitRecovery() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = SharedStore(containerURL: directory)
+        let requestID = UUID()
+        try store.saveResult(.init(
+            requestID: requestID,
+            text: "Recover explicitly",
+            engineIdentifier: "test"
+        ))
+        XCTAssertTrue(try store.saveKeyboardHandoffState(.init(
+            requestID: requestID,
+            phase: .resultReady
+        )))
+
+        let firstOwner = UUID()
+        let startedAt = Date(timeIntervalSince1970: 100)
+        XCTAssertTrue(try store.acquireKeyboardPresentationLease(
+            ownerID: firstOwner,
+            now: startedAt
+        ))
+        XCTAssertEqual(try store.claimKeyboardResultInsertion(
+            claim: .init(
+                id: UUID(),
+                requestID: requestID,
+                ownerID: firstOwner,
+                claimedAt: startedAt
+            ),
+            now: startedAt
+        ), .acquired)
+
+        let recoveryTime = Date(timeIntervalSince1970: 140)
+        let recoveryOwner = UUID()
+        XCTAssertTrue(try store.acquireKeyboardPresentationLease(
+            ownerID: recoveryOwner,
+            now: recoveryTime
+        ))
+        let recoveryClaim = KeyboardResultInsertionClaim(
+            id: UUID(),
+            requestID: requestID,
+            ownerID: recoveryOwner,
+            claimedAt: recoveryTime
+        )
+        XCTAssertEqual(try store.claimKeyboardResultInsertion(
+            claim: recoveryClaim,
+            now: recoveryTime
+        ), .recoveryRequired)
+        XCTAssertEqual(try store.claimKeyboardResultInsertion(
+            claim: recoveryClaim,
+            now: recoveryTime,
+            allowsAbandonedClaimRecovery: true
+        ), .acquired)
+    }
+
+    func testConditionalPendingRequestClearPreservesNewerRequest() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let store = SharedStore(containerURL: directory)
+        let completedRequest = DictationRequest(
+            id: UUID(),
+            createdAt: Date(timeIntervalSince1970: 100)
+        )
+        let newerRequest = DictationRequest(
+            id: UUID(),
+            createdAt: Date(timeIntervalSince1970: 200)
+        )
+
+        try store.saveRequest(completedRequest)
+        try store.saveRequest(newerRequest)
+
+        XCTAssertFalse(try store.clearPendingRequest(id: completedRequest.id))
+        XCTAssertEqual(try store.pendingRequest(), newerRequest)
+        XCTAssertTrue(try store.clearPendingRequest(id: newerRequest.id))
+        XCTAssertNil(try store.pendingRequest())
+    }
+
     func testKeyboardRuntimeStatusRoundTripsAndClears() throws {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent("muesli-store-\(UUID().uuidString)", isDirectory: true)
@@ -563,6 +783,123 @@ final class SharedStoreTests: XCTestCase {
         try store.clearKeyboardLiveTranscript()
 
         XCTAssertNil(try store.keyboardLiveTranscript())
+    }
+
+    func testKeyboardPresentationSnapshotReadsSharedStateAndPrefersRequestedResult() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let store = SharedStore(containerURL: directory)
+        let preferredRequestID = UUID()
+        let handoffRequestID = UUID()
+        let statusRequestID = UUID()
+        let runtimeRequestID = UUID()
+        let preferredResult = DictationResult(
+            requestID: preferredRequestID,
+            text: "preferred result",
+            engineIdentifier: "test"
+        )
+        let handoffResult = DictationResult(
+            requestID: handoffRequestID,
+            text: "handoff result",
+            engineIdentifier: "test"
+        )
+        let runtimeStatus = KeyboardRuntimeStatus(
+            isActive: true,
+            activeRequestID: runtimeRequestID,
+            phase: .recording,
+            message: "Listening",
+            inputLevel: 0.4
+        )
+        let status = DictationStatus(
+            requestID: statusRequestID,
+            phase: .transcribing,
+            message: "Transcribing"
+        )
+        let handoff = KeyboardHandoffState(
+            requestID: handoffRequestID,
+            phase: .startRequested,
+            message: "Starting"
+        )
+        let transcript = KeyboardLiveTranscript(
+            requestID: handoffRequestID,
+            text: "live words"
+        )
+
+        try store.saveResult(preferredResult)
+        try store.saveResult(handoffResult)
+        try store.saveStatus(status)
+        try store.saveKeyboardRuntimeStatus(runtimeStatus)
+        try store.saveKeyboardHandoffState(handoff)
+        try store.saveKeyboardLiveTranscript(transcript)
+
+        let preferredSnapshot = try store.keyboardPresentationSnapshot(
+            preferredRequestID: preferredRequestID
+        )
+        XCTAssertEqual(preferredSnapshot.runtimeStatus, runtimeStatus)
+        XCTAssertEqual(preferredSnapshot.status, status)
+        XCTAssertEqual(preferredSnapshot.handoffState, handoff)
+        XCTAssertEqual(preferredSnapshot.liveTranscript, transcript)
+        XCTAssertEqual(preferredSnapshot.targetRequestID, preferredRequestID)
+        XCTAssertEqual(preferredSnapshot.result, preferredResult)
+
+        let inferredSnapshot = try store.keyboardPresentationSnapshot()
+        XCTAssertEqual(inferredSnapshot.targetRequestID, handoffRequestID)
+        XCTAssertEqual(inferredSnapshot.result, handoffResult)
+    }
+
+    func testKeyboardPresentationSnapshotFallsBackFromStatusToRuntimeRequest() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let store = SharedStore(containerURL: directory)
+        let statusRequestID = UUID()
+        let runtimeRequestID = UUID()
+        let statusResult = DictationResult(
+            requestID: statusRequestID,
+            text: "status result",
+            engineIdentifier: "test"
+        )
+        let runtimeResult = DictationResult(
+            requestID: runtimeRequestID,
+            text: "runtime result",
+            engineIdentifier: "test"
+        )
+        let runtimeStatus = KeyboardRuntimeStatus(
+            isActive: true,
+            activeRequestID: runtimeRequestID,
+            phase: .recording
+        )
+
+        try store.saveResult(statusResult)
+        try store.saveResult(runtimeResult)
+        try store.saveKeyboardRuntimeStatus(runtimeStatus)
+        try store.saveStatus(.init(requestID: statusRequestID, phase: .finished))
+
+        let statusSnapshot = try store.keyboardPresentationSnapshot()
+        XCTAssertEqual(statusSnapshot.handoffState, .idle)
+        XCTAssertEqual(statusSnapshot.targetRequestID, statusRequestID)
+        XCTAssertEqual(statusSnapshot.result, statusResult)
+
+        try store.saveStatus(.idle)
+
+        let runtimeSnapshot = try store.keyboardPresentationSnapshot()
+        XCTAssertEqual(runtimeSnapshot.targetRequestID, runtimeRequestID)
+        XCTAssertEqual(runtimeSnapshot.result, runtimeResult)
+    }
+
+    func testKeyboardPresentationSnapshotReturnsIdleDefaultsWhenStoreIsEmpty() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let snapshot = try SharedStore(containerURL: directory).keyboardPresentationSnapshot()
+
+        XCTAssertNil(snapshot.runtimeStatus)
+        XCTAssertEqual(snapshot.status, .idle)
+        XCTAssertEqual(snapshot.handoffState, .idle)
+        XCTAssertNil(snapshot.liveTranscript)
+        XCTAssertNil(snapshot.targetRequestID)
+        XCTAssertNil(snapshot.result)
     }
 
     func testSavingPendingRequestDoesNotOverwriteStatus() throws {
@@ -769,6 +1106,298 @@ final class SharedStoreTests: XCTestCase {
             }
         )
         XCTAssertEqual(transitioned?.phase, .transcriptionQueued)
+    }
+
+    func testVoiceNoteTransitionCompareAndSetRequiresExpectedPhaseAndNonMeetingKind() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = SharedStore(containerURL: directory)
+        let voiceNote = RecordingSession(kind: .keyboardDictation, phase: .recording)
+        let meeting = RecordingSession(kind: .meeting, phase: .recording)
+        try store.saveSession(voiceNote)
+        try store.saveSession(meeting)
+
+        XCTAssertNil(try store.transitionVoiceNoteSession(
+            id: voiceNote.id,
+            expectedPhases: [.interrupted],
+            update: { $0.phase = .transcriptionQueued }
+        ))
+        XCTAssertEqual(try store.recordingSession(id: voiceNote.id)?.phase, .recording)
+
+        XCTAssertNil(try store.transitionVoiceNoteSession(
+            id: meeting.id,
+            expectedPhases: [.recording],
+            update: { $0.phase = .transcriptionQueued }
+        ))
+        XCTAssertEqual(try store.recordingSession(id: meeting.id)?.phase, .recording)
+
+        let transitioned = try store.transitionVoiceNoteSession(
+            id: voiceNote.id,
+            expectedPhases: [.recording],
+            update: {
+                $0.audioFileName = "durable.wav"
+                $0.phase = .transcriptionQueued
+            }
+        )
+        XCTAssertEqual(transitioned?.audioFileName, "durable.wav")
+        XCTAssertEqual(transitioned?.phase, .transcriptionQueued)
+        XCTAssertEqual(try store.recordingSession(id: voiceNote.id), transitioned)
+    }
+
+    func testLateDraftWriteCannotRegressCompletedVoiceNoteSession() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = SharedStore(containerURL: directory)
+        let completed = RecordingSession(
+            kind: .keyboardDictation,
+            phase: .completed,
+            source: "keyboard"
+        )
+        try store.saveSession(completed)
+
+        let staleDraftWrite = try store.transitionVoiceNoteSession(
+            id: completed.id,
+            expectedPhases: [.recording, .interrupted],
+            update: { session in
+                session.phase = .transcribing
+                session.draftTranscriptText = "Late realtime callback"
+            }
+        )
+
+        XCTAssertNil(staleDraftWrite)
+        let persisted = try XCTUnwrap(try store.recordingSession(id: completed.id))
+        XCTAssertEqual(persisted.phase, .completed)
+        XCTAssertNil(persisted.draftTranscriptText)
+        XCTAssertNil(persisted.draftTranscriptUpdatedAt)
+    }
+
+    func testCompleteVoiceNoteSessionAtomicallyPersistsTranscriptSessionResultAndStatus() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = SharedStore(containerURL: directory)
+        let requestID = UUID()
+        var current = RecordingSession(
+            requestID: requestID,
+            kind: .keyboardDictation,
+            phase: .transcribing,
+            audioFileName: "protected.wav",
+            keepsAudioRecording: true,
+            source: "keyboard",
+            scratchpadText: "Keep this concurrently edited note"
+        )
+        current.cloudRecordName = "voice-note-cloud-record"
+        try store.saveSession(current)
+        let persistedBeforeCompletion = try XCTUnwrap(try store.recordingSession(id: current.id))
+
+        let transcript = Transcript(
+            sessionID: current.id,
+            text: "Recovered words",
+            engineIdentifier: "test-engine"
+        )
+        var completed = current
+        completed.phase = .completed
+        completed.transcriptID = transcript.id
+        completed.engineIdentifier = transcript.engineIdentifier
+        completed.audioFileName = "stale-caller.wav"
+        completed.keepsAudioRecording = false
+        completed.scratchpadText = "stale caller value"
+        let result = DictationResult(
+            requestID: requestID,
+            sessionID: current.id,
+            text: transcript.text,
+            engineIdentifier: transcript.engineIdentifier,
+            source: "keyboard"
+        )
+
+        XCTAssertTrue(try store.completeVoiceNoteSession(
+            completed,
+            transcript: transcript,
+            result: result
+        ))
+
+        let persistedSession = try XCTUnwrap(try store.recordingSession(id: current.id))
+        XCTAssertEqual(persistedSession.phase, .completed)
+        XCTAssertEqual(persistedSession.transcriptID, transcript.id)
+        XCTAssertEqual(persistedSession.cloudRecordName, persistedBeforeCompletion.cloudRecordName)
+        XCTAssertEqual(persistedSession.scratchpadText, persistedBeforeCompletion.scratchpadText)
+        XCTAssertEqual(persistedSession.audioFileName, persistedBeforeCompletion.audioFileName)
+        XCTAssertTrue(persistedSession.keepsAudioRecording)
+        XCTAssertEqual(try store.transcript(for: current.id), transcript)
+        XCTAssertEqual(try store.result(for: requestID), result)
+        XCTAssertTrue(try store.resultsHistory().contains(result))
+        let status = try XCTUnwrap(try store.status())
+        XCTAssertEqual(status.requestID, requestID)
+        XCTAssertEqual(status.phase, .finished)
+    }
+
+    func testKeyboardCompletionHandoffCannotRegressAfterInsertion() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = SharedStore(containerURL: directory)
+        let requestID = UUID()
+        var session = RecordingSession(
+            requestID: requestID,
+            kind: .keyboardDictation,
+            phase: .transcribing,
+            source: "keyboard"
+        )
+        try store.saveSession(session)
+        let currentHandoff = KeyboardHandoffState(
+            requestID: requestID,
+            phase: .transcribingStarted,
+            updatedAt: Date(timeIntervalSince1970: 100)
+        )
+        XCTAssertTrue(try store.saveKeyboardHandoffState(currentHandoff))
+
+        let transcript = Transcript(
+            sessionID: session.id,
+            text: "Lock-safe result",
+            engineIdentifier: "test-engine"
+        )
+        session.phase = .completed
+        session.transcriptID = transcript.id
+        let result = DictationResult(
+            requestID: requestID,
+            sessionID: session.id,
+            text: transcript.text,
+            engineIdentifier: transcript.engineIdentifier,
+            source: "keyboard"
+        )
+        let resultReady = currentHandoff.advanced(
+            to: .resultReady,
+            message: "Ready to insert",
+            updatedAt: Date(timeIntervalSince1970: 200)
+        )
+
+        XCTAssertTrue(try store.completeVoiceNoteSession(
+            session,
+            transcript: transcript,
+            result: result,
+            keyboardHandoffState: resultReady
+        ))
+        XCTAssertEqual(try store.keyboardHandoffState().phase, .resultReady)
+
+        let inserted = resultReady.advanced(
+            to: .inserted,
+            message: "Inserted",
+            updatedAt: Date(timeIntervalSince1970: 300)
+        )
+        XCTAssertTrue(try store.saveKeyboardHandoffState(inserted))
+
+        let lateResultReady = resultReady.advanced(
+            to: .resultReady,
+            message: "Late container write",
+            updatedAt: Date(timeIntervalSince1970: 400)
+        )
+        XCTAssertFalse(try store.saveKeyboardHandoffState(lateResultReady))
+        XCTAssertEqual(try store.keyboardHandoffState().phase, .inserted)
+    }
+
+    func testCompleteVoiceNoteSessionRejectsStalePhaseWithoutPartialWrites() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = SharedStore(containerURL: directory)
+        let requestID = UUID()
+        let current = RecordingSession(
+            requestID: requestID,
+            kind: .quickDictation,
+            phase: .transcriptionQueued
+        )
+        try store.saveSession(current)
+        let persistedBeforeAttempt = try XCTUnwrap(try store.recordingSession(id: current.id))
+        let transcript = Transcript(
+            sessionID: current.id,
+            text: "Must not leak through a stale completion",
+            engineIdentifier: "test-engine"
+        )
+        var completed = current
+        completed.phase = .completed
+        completed.transcriptID = transcript.id
+        let result = DictationResult(
+            requestID: requestID,
+            sessionID: current.id,
+            text: transcript.text,
+            engineIdentifier: transcript.engineIdentifier
+        )
+
+        XCTAssertFalse(try store.completeVoiceNoteSession(
+            completed,
+            transcript: transcript,
+            result: result,
+            expectedPhase: .transcribing
+        ))
+        XCTAssertEqual(try store.recordingSession(id: current.id), persistedBeforeAttempt)
+        XCTAssertNil(try store.transcript(for: current.id))
+        XCTAssertNil(try store.result(for: requestID))
+        XCTAssertTrue(try store.resultsHistory().isEmpty)
+    }
+
+    func testCompleteVoiceNoteSessionRollsBackEveryWriteWhenLateHistoryInsertFails() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = SharedStore(containerURL: directory)
+        let requestID = UUID()
+        let current = RecordingSession(
+            requestID: requestID,
+            kind: .keyboardDictation,
+            phase: .transcribing,
+            audioFileName: "protected.wav",
+            source: "keyboard",
+            scratchpadText: "Preserve this note"
+        )
+        try store.saveSession(current)
+        let statusBeforeAttempt = DictationStatus(
+            requestID: requestID,
+            phase: .transcribing,
+            message: "Transcribing"
+        )
+        try store.saveStatus(statusBeforeAttempt)
+        let persistedStatusBeforeAttempt = try store.status()
+
+        do {
+            let database = try openSQLiteDatabase(in: directory)
+            defer { sqlite3_close(database) }
+            try sqliteExec(
+                """
+                CREATE TRIGGER fail_voice_note_result_history_insert
+                BEFORE INSERT ON result_history
+                BEGIN
+                    SELECT RAISE(ABORT, 'injected result history failure');
+                END;
+                """,
+                database
+            )
+        }
+
+        let persistedBeforeAttempt = try XCTUnwrap(try store.recordingSession(id: current.id))
+        let transcript = Transcript(
+            sessionID: current.id,
+            text: "Must roll back",
+            engineIdentifier: "test-engine"
+        )
+        var completed = current
+        completed.phase = .completed
+        completed.transcriptID = transcript.id
+        completed.engineIdentifier = transcript.engineIdentifier
+        let result = DictationResult(
+            requestID: requestID,
+            sessionID: current.id,
+            text: transcript.text,
+            engineIdentifier: transcript.engineIdentifier,
+            source: "keyboard"
+        )
+
+        XCTAssertThrowsError(try store.completeVoiceNoteSession(
+            completed,
+            transcript: transcript,
+            result: result
+        ))
+
+        XCTAssertEqual(try store.recordingSession(id: current.id), persistedBeforeAttempt)
+        XCTAssertNil(try store.transcript(for: current.id))
+        XCTAssertNil(try store.result(for: requestID))
+        XCTAssertTrue(try store.resultsHistory().isEmpty)
+        XCTAssertEqual(try store.status(), persistedStatusBeforeAttempt)
     }
 
     func testMeetingDraftTranscriptPersistsWithoutChangingRecordingLifecycle() throws {
@@ -1622,6 +2251,14 @@ private enum SQLiteValue {
     case double(Double)
     case int(Int)
     case blob(Data)
+}
+
+/// Mirrors the pre-command-ID payload so the migration test exercises the
+/// decoder that has to synthesize a stable compare-and-set identity.
+private struct LegacyKeyboardCommandPayload: Encodable {
+    let requestID: UUID
+    let action: DictationCommandAction
+    let createdAt: Date
 }
 
 private enum SQLiteTestError: Error {

--- a/Tests/MuesliTests/VoiceNoteCheckpointStoreTests.swift
+++ b/Tests/MuesliTests/VoiceNoteCheckpointStoreTests.swift
@@ -35,6 +35,7 @@ final class VoiceNoteCheckpointStoreTests: XCTestCase {
 
         let file = try AVAudioFile(forReading: output)
         XCTAssertEqual(file.length, 3_200, accuracy: 2)
+        try assertReopenableProtection(at: output)
     }
 
     func testRecoveryStopsAtMissingChunkInsteadOfAppendingLaterAudio() async throws {
@@ -60,7 +61,8 @@ final class VoiceNoteCheckpointStoreTests: XCTestCase {
         defer { try? FileManager.default.removeItem(at: fixture.root) }
 
         let corruptURL = fixture.directory.appendingPathComponent("chunk-0000.wav")
-        try Data("not audio".utf8).write(to: corruptURL)
+        let corruptBytes = Data("not audio".utf8)
+        try corruptBytes.write(to: corruptURL)
         let corrupt = Muesli.MeetingAudioChunk(index: 0, url: corruptURL, startTime: 0, duration: 0.1)
 
         do {
@@ -69,6 +71,7 @@ final class VoiceNoteCheckpointStoreTests: XCTestCase {
         } catch Muesli.VoiceNoteCheckpointStore.StoreError.invalidCheckpoint {
             let manifest = try await fixture.checkpoints.manifest(sessionID: fixture.sessionID)
             XCTAssertTrue(manifest.entries.isEmpty)
+            XCTAssertEqual(try Data(contentsOf: corruptURL), corruptBytes)
         }
     }
 
@@ -104,6 +107,101 @@ final class VoiceNoteCheckpointStoreTests: XCTestCase {
 
         XCTAssertEqual(salvaged.entries.map(\.index), [0, 1])
         XCTAssertTrue(salvaged.entries.allSatisfy { $0.frameCount > 0 })
+    }
+
+    func testRecoveryRepairsZeroSizedTrailingPCMWAVHeader() async throws {
+        let fixture = try await makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        let chunk = try writeChunk(index: 0, duration: 0.1, directory: fixture.directory)
+        let original = try Data(contentsOf: chunk.url)
+        let payloadOffset = try XCTUnwrap(wavDataPayloadOffset(in: original))
+        let originalPayload = original[payloadOffset...]
+        var unfinalized = original
+        writeUInt32(0, to: &unfinalized, at: 4)
+        writeUInt32(0, to: &unfinalized, at: payloadOffset - 4)
+        try unfinalized.write(to: chunk.url, options: .atomic)
+
+        let unreadable = try? AVAudioFile(forReading: chunk.url)
+        XCTAssertTrue(unreadable == nil || unreadable?.length == 0)
+
+        let salvaged = try await fixture.checkpoints.salvageTrailingCheckpoint(
+            sessionID: fixture.sessionID
+        )
+
+        XCTAssertEqual(salvaged.entries.map(\.index), [0])
+        XCTAssertEqual(salvaged.entries.first?.frameCount, 1_600)
+        let repaired = try Data(contentsOf: chunk.url)
+        XCTAssertNotEqual(readUInt32(from: repaired, at: 4), 0)
+        XCTAssertNotEqual(readUInt32(from: repaired, at: payloadOffset - 4), 0)
+        XCTAssertEqual(repaired[payloadOffset...], originalPayload)
+        XCTAssertEqual(try AVAudioFile(forReading: chunk.url).length, 1_600)
+    }
+
+    func testPrimaryContinuousAudioRecoversStaleHeaderBeforeFirstCheckpoint() async throws {
+        let fixture = try await makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        let manifestBeforeRecovery = try await fixture.checkpoints.manifest(sessionID: fixture.sessionID)
+        XCTAssertTrue(manifestBeforeRecovery.entries.isEmpty)
+
+        let primaryURL = fixture.root.appendingPathComponent("continuous-primary.wav")
+        let sampleRate = 16_000.0
+        let frameCount: AVAudioFrameCount = 1_600
+        let format = try XCTUnwrap(AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: sampleRate,
+            channels: 1,
+            interleaved: false
+        ))
+        let buffer = try makeBuffer(format: format, frameCount: frameCount)
+        do {
+            let file = try AVAudioFile(forWriting: primaryURL, settings: format.settings)
+            try file.write(from: buffer)
+        }
+
+        let original = try Data(contentsOf: primaryURL)
+        let payloadOffset = try XCTUnwrap(wavDataPayloadOffset(in: original))
+        let originalPayload = original[payloadOffset...]
+        var unfinalized = original
+        writeUInt32(0, to: &unfinalized, at: 4)
+        writeUInt32(0, to: &unfinalized, at: payloadOffset - 4)
+        try unfinalized.write(to: primaryURL, options: .atomic)
+
+        let unreadable = try? AVAudioFile(forReading: primaryURL)
+        XCTAssertTrue(unreadable == nil || unreadable?.length == 0)
+
+        let recovered = await fixture.checkpoints.isReadableAudio(at: primaryURL)
+
+        XCTAssertTrue(recovered)
+        let manifestAfterRecovery = try await fixture.checkpoints.manifest(sessionID: fixture.sessionID)
+        XCTAssertTrue(manifestAfterRecovery.entries.isEmpty)
+        let repaired = try Data(contentsOf: primaryURL)
+        XCTAssertNotEqual(readUInt32(from: repaired, at: 4), 0)
+        XCTAssertNotEqual(readUInt32(from: repaired, at: payloadOffset - 4), 0)
+        XCTAssertEqual(repaired[payloadOffset...], originalPayload)
+        XCTAssertEqual(try AVAudioFile(forReading: primaryURL).length, AVAudioFramePosition(frameCount))
+    }
+
+    func testSalvageLeavesIrrecoverableTrailingCheckpointAndManifestUntouched() async throws {
+        let fixture = try await makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        let first = try writeChunk(index: 0, duration: 0.1, directory: fixture.directory)
+        let originalManifest = try await fixture.checkpoints.record(first, sessionID: fixture.sessionID)
+        let manifestURL = fixture.directory.appendingPathComponent("manifest.json")
+        let manifestBytes = try Data(contentsOf: manifestURL)
+        let corruptURL = fixture.directory.appendingPathComponent("chunk-0001.wav")
+        let corruptBytes = Data("irrecoverable trailing checkpoint".utf8)
+        try corruptBytes.write(to: corruptURL)
+
+        let salvaged = try await fixture.checkpoints.salvageTrailingCheckpoint(
+            sessionID: fixture.sessionID
+        )
+
+        XCTAssertEqual(salvaged, originalManifest)
+        XCTAssertEqual(try Data(contentsOf: manifestURL), manifestBytes)
+        XCTAssertEqual(try Data(contentsOf: corruptURL), corruptBytes)
     }
 
     func testConcurrentRecordAndSalvageRemainOrderedAndDeduplicated() async throws {
@@ -142,11 +240,43 @@ final class VoiceNoteCheckpointStoreTests: XCTestCase {
         writer.append(try makeBuffer(format: format, frameCount: 1_600))
         let rotated = try XCTUnwrap(writer.rotateCheckpoint())
         XCTAssertTrue(FileManager.default.fileExists(atPath: rotated.url.path))
+        try assertReopenableProtection(at: rotated.url)
+        try assertReopenableProtection(at: continuousURL)
 
         writer.cancel()
 
         XCTAssertFalse(FileManager.default.fileExists(atPath: checkpointDirectory.path))
         XCTAssertFalse(FileManager.default.fileExists(atPath: continuousURL.path))
+    }
+
+    func testCheckpointWriterAcknowledgesOnlyAfterAudioIsAccepted() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("muesli-writer-ack-\(UUID().uuidString)", isDirectory: true)
+        let checkpointDirectory = root.appendingPathComponent("checkpoints", isDirectory: true)
+        let continuousURL = root.appendingPathComponent("continuous.wav")
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let format = try XCTUnwrap(AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: 16_000,
+            channels: 1,
+            interleaved: false
+        ))
+        let writer = try Muesli.CheckpointingAudioWriter(
+            continuousAudioURL: continuousURL,
+            checkpointDirectory: checkpointDirectory,
+            format: format
+        )
+        let accepted = DispatchSemaphore(value: 0)
+
+        writer.append(try makeBuffer(format: format, frameCount: 1_600)) {
+            accepted.signal()
+        }
+
+        XCTAssertEqual(accepted.wait(timeout: .now() + 1), .success)
+        let result = writer.finish()
+        XCTAssertEqual(result.totalFrames, 1_600)
+        XCTAssertNil(result.failure)
     }
 
     private func makeFixture() async throws -> (
@@ -200,5 +330,55 @@ final class VoiceNoteCheckpointStoreTests: XCTestCase {
             }
         }
         return buffer
+    }
+
+    private func wavDataPayloadOffset(in data: Data) -> Int? {
+        guard data.count >= 12,
+              String(decoding: data[0..<4], as: UTF8.self) == "RIFF",
+              String(decoding: data[8..<12], as: UTF8.self) == "WAVE"
+        else { return nil }
+        var cursor = 12
+        while cursor + 8 <= data.count {
+            let identifier = String(decoding: data[cursor..<(cursor + 4)], as: UTF8.self)
+            let size = Int(readUInt32(from: data, at: cursor + 4))
+            if identifier == "data" {
+                return cursor + 8
+            }
+            let next = cursor + 8 + size + (size % 2)
+            guard next > cursor, next <= data.count else { return nil }
+            cursor = next
+        }
+        return nil
+    }
+
+    private func readUInt32(from data: Data, at offset: Int) -> UInt32 {
+        UInt32(data[offset])
+            | (UInt32(data[offset + 1]) << 8)
+            | (UInt32(data[offset + 2]) << 16)
+            | (UInt32(data[offset + 3]) << 24)
+    }
+
+    private func writeUInt32(_ value: UInt32, to data: inout Data, at offset: Int) {
+        data[offset] = UInt8(truncatingIfNeeded: value)
+        data[offset + 1] = UInt8(truncatingIfNeeded: value >> 8)
+        data[offset + 2] = UInt8(truncatingIfNeeded: value >> 16)
+        data[offset + 3] = UInt8(truncatingIfNeeded: value >> 24)
+    }
+
+    private func fileProtection(at url: URL) throws -> FileProtectionType? {
+        try FileManager.default.attributesOfItem(atPath: url.path)[.protectionKey]
+            as? FileProtectionType
+    }
+
+    private func assertReopenableProtection(at url: URL) throws {
+        XCTAssertEqual(
+            SharedFileProtection.reopenableAudio,
+            .completeUntilFirstUserAuthentication
+        )
+        // CoreSimulator does not surface NSFileProtectionKey. When the host does
+        // expose it (including device-hosted tests), verify the applied attribute.
+        if let protection = try fileProtection(at: url) {
+            XCTAssertEqual(protection, SharedFileProtection.reopenableAudio)
+        }
     }
 }

--- a/Tests/MuesliTests/VoiceNoteLifecycleTests.swift
+++ b/Tests/MuesliTests/VoiceNoteLifecycleTests.swift
@@ -1,3 +1,4 @@
+import AVFoundation
 import XCTest
 @testable import Muesli
 
@@ -66,6 +67,99 @@ final class VoiceNoteLifecycleTests: XCTestCase {
             VoiceNoteLifecycleReducer.reduce(state, event: .longFormActivated(stale)),
             state
         )
+        XCTAssertEqual(
+            VoiceNoteLifecycleReducer.reduce(state, event: .captureInterrupted(stale)),
+            state
+        )
+    }
+
+    func testShortCaptureCanInterruptResumeAndThenStop() {
+        let id = UUID()
+        var state = VoiceNoteLifecycleReducer.reduce(.init(), event: .recordingStarted(id))
+
+        state = VoiceNoteLifecycleReducer.reduce(state, event: .captureInterrupted(id))
+        XCTAssertEqual(state.phase, .interruptedShort(id))
+        XCTAssertFalse(state.isRecording)
+        XCTAssertTrue(state.isWorkActive)
+        XCTAssertFalse(state.isLongFormVisible)
+
+        state = VoiceNoteLifecycleReducer.reduce(state, event: .captureResumed(id))
+        XCTAssertEqual(state.phase, .recordingShort(id))
+        XCTAssertTrue(state.isRecording)
+
+        state = VoiceNoteLifecycleReducer.reduce(state, event: .stopRequested(id))
+        XCTAssertEqual(state.phase, .stopping(id))
+    }
+
+    func testLongCaptureCanInterruptResumeAndThenCancel() {
+        let id = UUID()
+        var state = VoiceNoteLifecycleReducer.reduce(.init(), event: .recordingStarted(id))
+        state = VoiceNoteLifecycleReducer.reduce(state, event: .longFormActivated(id))
+
+        state = VoiceNoteLifecycleReducer.reduce(state, event: .captureInterrupted(id))
+        XCTAssertEqual(state.phase, .interruptedLongProtected(id))
+        XCTAssertFalse(state.isRecording)
+        XCTAssertTrue(state.isWorkActive)
+        XCTAssertTrue(state.isLongFormVisible)
+
+        state = VoiceNoteLifecycleReducer.reduce(state, event: .captureResumed(id))
+        XCTAssertEqual(state.phase, .recordingLongProtected(id))
+
+        state = VoiceNoteLifecycleReducer.reduce(state, event: .captureInterrupted(id))
+        state = VoiceNoteLifecycleReducer.reduce(state, event: .cancelRequested(id))
+        XCTAssertEqual(state.phase, .cancelling(id))
+    }
+
+    func testLongFormActivationWhileInterruptedPreservesInterruption() {
+        let id = UUID()
+        var state = VoiceNoteLifecycleReducer.reduce(.init(), event: .recordingStarted(id))
+        state = VoiceNoteLifecycleReducer.reduce(state, event: .captureInterrupted(id))
+
+        state = VoiceNoteLifecycleReducer.reduce(state, event: .longFormActivated(id))
+
+        XCTAssertEqual(state.phase, .interruptedLongProtected(id))
+        XCTAssertFalse(state.isRecording)
+        XCTAssertTrue(state.isLongFormVisible)
+        XCTAssertTrue(state.isWorkActive)
+    }
+
+    func testInterruptedLifecycleRejectsStaleResumeStopAndCancel() {
+        let id = UUID()
+        let stale = UUID()
+        var state = VoiceNoteLifecycleReducer.reduce(.init(), event: .recordingStarted(id))
+        state = VoiceNoteLifecycleReducer.reduce(state, event: .captureInterrupted(id))
+
+        for event in [
+            VoiceNoteLifecycleEvent.captureResumed(stale),
+            .longFormActivated(stale),
+            .stopRequested(stale),
+            .cancelRequested(stale),
+        ] {
+            let transition = VoiceNoteLifecycleReducer.transition(state, event: event)
+            XCTAssertFalse(transition.accepted)
+            XCTAssertEqual(transition.state, state)
+        }
+    }
+
+    func testDuplicateInterruptionAndResumeAreIdempotent() {
+        let id = UUID()
+        var state = VoiceNoteLifecycleReducer.reduce(.init(), event: .recordingStarted(id))
+        state = VoiceNoteLifecycleReducer.reduce(state, event: .captureInterrupted(id))
+
+        let duplicateInterruption = VoiceNoteLifecycleReducer.transition(
+            state,
+            event: .captureInterrupted(id)
+        )
+        XCTAssertTrue(duplicateInterruption.accepted)
+        XCTAssertEqual(duplicateInterruption.state, state)
+
+        state = VoiceNoteLifecycleReducer.reduce(state, event: .captureResumed(id))
+        let duplicateResume = VoiceNoteLifecycleReducer.transition(
+            state,
+            event: .captureResumed(id)
+        )
+        XCTAssertTrue(duplicateResume.accepted)
+        XCTAssertEqual(duplicateResume.state, state)
     }
 
     func testLifecycleRejectsLongFormActivationAfterStop() {
@@ -251,6 +345,8 @@ final class VoiceNoteLifecycleTests: XCTestCase {
             ("idle", .init()),
             ("recordingShort", .init(phase: .recordingShort(id))),
             ("recordingLongProtected", .init(phase: .recordingLongProtected(id))),
+            ("interruptedShort", .init(phase: .interruptedShort(id))),
+            ("interruptedLongProtected", .init(phase: .interruptedLongProtected(id))),
             ("stopping", .init(phase: .stopping(id))),
             ("audioSaved", .init(phase: .audioSaved(id))),
             ("transcriptionQueued", .init(phase: .transcriptionQueued(id))),
@@ -261,6 +357,8 @@ final class VoiceNoteLifecycleTests: XCTestCase {
         let events: [(name: String, event: VoiceNoteLifecycleEvent)] = [
             ("recordingStarted", .recordingStarted(id)),
             ("longFormActivated", .longFormActivated(id)),
+            ("captureInterrupted", .captureInterrupted(id)),
+            ("captureResumed", .captureResumed(id)),
             ("stopRequested", .stopRequested(id)),
             ("audioFinalized", .audioFinalized(id)),
             ("transcriptionQueued", .transcriptionQueued(id)),
@@ -275,12 +373,27 @@ final class VoiceNoteLifecycleTests: XCTestCase {
             "idle.retryRequested",
             "recordingShort.recordingStarted",
             "recordingShort.longFormActivated",
+            "recordingShort.captureInterrupted",
+            "recordingShort.captureResumed",
             "recordingShort.stopRequested",
             "recordingShort.cancelRequested",
             "recordingShort.finished",
             "recordingLongProtected.stopRequested",
+            "recordingLongProtected.captureInterrupted",
+            "recordingLongProtected.captureResumed",
             "recordingLongProtected.cancelRequested",
             "recordingLongProtected.finished",
+            "interruptedShort.longFormActivated",
+            "interruptedShort.captureInterrupted",
+            "interruptedShort.captureResumed",
+            "interruptedShort.stopRequested",
+            "interruptedShort.cancelRequested",
+            "interruptedShort.finished",
+            "interruptedLongProtected.captureInterrupted",
+            "interruptedLongProtected.captureResumed",
+            "interruptedLongProtected.stopRequested",
+            "interruptedLongProtected.cancelRequested",
+            "interruptedLongProtected.finished",
             "stopping.audioFinalized",
             "stopping.transcriptionStarted",
             "stopping.transcriptionFailed",
@@ -434,7 +547,7 @@ final class VoiceNoteLifecycleTests: XCTestCase {
         XCTAssertEqual(schedule.nextDeadlineSeconds, 90)
     }
 
-    func testCheckpointRetentionPolicyKeepsOnlyRecoverableAudio() {
+    func testCheckpointRetentionPolicyDeletesOnlyTerminalOrOrphanedAudio() {
         let protectedFailure = Muesli.RecordingSession(
             kind: .quickDictation,
             phase: .failed,
@@ -445,24 +558,39 @@ final class VoiceNoteLifecycleTests: XCTestCase {
             VoiceNoteCheckpointRetentionPolicy.shouldDeleteCheckpoints(for: protectedFailure)
         )
 
-        let explicitlyDeleted = Muesli.RecordingSession(
+        let failedWithoutPersistedEvidence = Muesli.RecordingSession(
             kind: .quickDictation,
             phase: .failed,
             audioFileName: nil,
             protectedAudioUntilTranscriptCompletes: false
         )
-        XCTAssertTrue(
-            VoiceNoteCheckpointRetentionPolicy.shouldDeleteCheckpoints(for: explicitlyDeleted)
+        XCTAssertFalse(
+            VoiceNoteCheckpointRetentionPolicy.shouldDeleteCheckpoints(
+                for: failedWithoutPersistedEvidence
+            )
         )
 
         let failedShortNote = Muesli.RecordingSession(
             kind: .keyboardDictation,
             phase: .failed,
             audioFileName: "short.wav",
+            longFormThresholdSeconds: 60,
+            hasDurableAudioCheckpoint: true
+        )
+        XCTAssertFalse(
+            VoiceNoteCheckpointRetentionPolicy.shouldDeleteCheckpoints(for: failedShortNote)
+        )
+
+        let unverifiedFailedShortNote = Muesli.RecordingSession(
+            kind: .keyboardDictation,
+            phase: .failed,
+            audioFileName: "short.wav",
             longFormThresholdSeconds: 60
         )
-        XCTAssertTrue(
-            VoiceNoteCheckpointRetentionPolicy.shouldDeleteCheckpoints(for: failedShortNote)
+        XCTAssertFalse(
+            VoiceNoteCheckpointRetentionPolicy.shouldDeleteCheckpoints(
+                for: unverifiedFailedShortNote
+            )
         )
 
         let activeShortNote = Muesli.RecordingSession(
@@ -472,6 +600,15 @@ final class VoiceNoteLifecycleTests: XCTestCase {
         )
         XCTAssertFalse(
             VoiceNoteCheckpointRetentionPolicy.shouldDeleteCheckpoints(for: activeShortNote)
+        )
+
+        let interruptedShortNote = Muesli.RecordingSession(
+            kind: .keyboardDictation,
+            phase: .interrupted,
+            longFormThresholdSeconds: 60
+        )
+        XCTAssertFalse(
+            VoiceNoteCheckpointRetentionPolicy.shouldDeleteCheckpoints(for: interruptedShortNote)
         )
 
         let completed = Muesli.RecordingSession(kind: .quickDictation, phase: .completed)
@@ -493,12 +630,26 @@ final class VoiceNoteLifecycleTests: XCTestCase {
         XCTAssertFalse(VoiceNoteAudioRetentionPolicy.shouldDeleteAudioAfterSuccess(retained))
     }
 
-    func testFailureDispositionKeepsOnlyLongNotesRetryable() {
-        let short = Muesli.RecordingSession(kind: .quickDictation, isLongForm: false)
-        let long = Muesli.RecordingSession(kind: .quickDictation, isLongForm: true)
+    func testFailureDispositionUsesDurabilityInsteadOfLongFormThreshold() {
+        let recoverableShort = Muesli.RecordingSession(
+            kind: .quickDictation,
+            isLongForm: false,
+            hasDurableAudioCheckpoint: true,
+            protectedAudioUntilTranscriptCompletes: true
+        )
+        let unavailableLong = Muesli.RecordingSession(
+            kind: .quickDictation,
+            isLongForm: true
+        )
 
-        XCTAssertEqual(VoiceNoteFailureLifecycleDisposition.resolve(for: short), .finished)
-        XCTAssertEqual(VoiceNoteFailureLifecycleDisposition.resolve(for: long), .retryable)
+        XCTAssertEqual(
+            VoiceNoteFailureLifecycleDisposition.resolve(for: recoverableShort),
+            .retryable
+        )
+        XCTAssertEqual(
+            VoiceNoteFailureLifecycleDisposition.resolve(for: unavailableLong),
+            .finished
+        )
     }
 
     func testRecordingTerminationCausePreservesSpecificFailureReason() {
@@ -512,7 +663,7 @@ final class VoiceNoteLifecycleTests: XCTestCase {
         )
     }
 
-    func testFailureSessionPolicyProtectsOnlyRecoverableLongFormAudio() {
+    func testFailureSessionPolicyProtectsAnyRecoverableVoiceNoteAudio() {
         let shortSession = Muesli.RecordingSession(
             kind: .keyboardDictation,
             phase: .transcribing,
@@ -527,7 +678,7 @@ final class VoiceNoteLifecycleTests: XCTestCase {
 
         XCTAssertEqual(failedShortSession.phase, .failed)
         XCTAssertEqual(failedShortSession.lastTranscriptionFailureReason, .timeout)
-        XCTAssertFalse(failedShortSession.protectedAudioUntilTranscriptCompletes)
+        XCTAssertTrue(failedShortSession.protectedAudioUntilTranscriptCompletes)
 
         let longSession = Muesli.RecordingSession(
             kind: .keyboardDictation,
@@ -552,6 +703,24 @@ final class VoiceNoteLifecycleTests: XCTestCase {
         XCTAssertFalse(unavailableLongSession.protectedAudioUntilTranscriptCompletes)
     }
 
+    func testFailureSessionPolicyDoesNotClearExistingAudioProtectionOnAProbeFailure() {
+        let protectedSession = Muesli.RecordingSession(
+            kind: .keyboardDictation,
+            phase: .transcribing,
+            audioFileName: "protected.wav",
+            protectedAudioUntilTranscriptCompletes: true
+        )
+
+        let failedSession = VoiceNoteFailureSessionPolicy.prepare(
+            protectedSession,
+            reason: .engineFailure,
+            message: "Try again later",
+            hasRecoverableAudio: false
+        )
+
+        XCTAssertTrue(failedSession.protectedAudioUntilTranscriptCompletes)
+    }
+
     func testFailureTelemetryPolicyPreservesTimeoutStageNames() {
         XCTAssertEqual(
             VoiceNoteFailureTelemetryPolicy.stage(
@@ -569,5 +738,58 @@ final class VoiceNoteLifecycleTests: XCTestCase {
             ),
             "transcription"
         )
+    }
+
+    func testAudioInterruptionPolicyClassifiesRealSystemReasons() {
+        XCTAssertEqual(
+            VoiceNoteAudioInterruptionPolicy.captureReason(
+                interruptionReason: nil,
+                rawReason: 1
+            ),
+            .appSuspended
+        )
+        XCTAssertEqual(
+            VoiceNoteAudioInterruptionPolicy.captureReason(
+                interruptionReason: .routeDisconnected,
+                rawReason: nil
+            ),
+            .routeDisconnected
+        )
+        XCTAssertEqual(
+            VoiceNoteAudioInterruptionPolicy.captureReason(
+                interruptionReason: .builtInMicMuted,
+                rawReason: nil
+            ),
+            .microphoneMuted
+        )
+        XCTAssertEqual(
+            VoiceNoteAudioInterruptionPolicy.captureReason(
+                interruptionReason: nil,
+                rawReason: nil
+            ),
+            .system
+        )
+    }
+
+    func testRouteChangePolicyOnlyTreatsRemovedInputAsDisconnected() {
+        XCTAssertEqual(
+            VoiceNoteAudioInterruptionPolicy.captureReason(
+                routeChangeReason: .oldDeviceUnavailable
+            ),
+            .routeDisconnected
+        )
+        for reason: AVAudioSession.RouteChangeReason? in [
+            .newDeviceAvailable,
+            .categoryChange,
+            .routeConfigurationChange,
+            nil,
+        ] {
+            XCTAssertEqual(
+                VoiceNoteAudioInterruptionPolicy.captureReason(
+                    routeChangeReason: reason
+                ),
+                .engineConfigurationChanged
+            )
+        }
     }
 }

--- a/Tests/MuesliTests/VoiceNotePresentationPerformanceTests.swift
+++ b/Tests/MuesliTests/VoiceNotePresentationPerformanceTests.swift
@@ -89,8 +89,10 @@ final class VoiceNotePresentationPerformanceTests: XCTestCase {
             kind: .quickDictation,
             createdAt: Date(timeIntervalSinceReferenceDate: 200),
             phase: .failed,
+            audioFileName: "recoverable.wav",
             source: "ios",
-            isLongForm: true
+            isLongForm: true,
+            protectedAudioUntilTranscriptCompletes: true
         )
 
         let items = VoiceNoteTimelineBuilder.build(
@@ -106,6 +108,29 @@ final class VoiceNotePresentationPerformanceTests: XCTestCase {
             return XCTFail("The newest recoverable session should lead the timeline")
         }
         XCTAssertEqual(first.id, recoverable.id)
+    }
+
+    func testTimelineBuilderKeepsInterruptedShortNoteWithOnlyDraftEvidence() {
+        let session = Muesli.RecordingSession(
+            kind: .keyboardDictation,
+            createdAt: Date(timeIntervalSinceReferenceDate: 250),
+            phase: .interrupted,
+            source: "keyboard",
+            isLongForm: false,
+            captureInterruptionReason: .appSuspended,
+            draftTranscriptText: "Words captured before the screen locked",
+            draftTranscriptUpdatedAt: Date(timeIntervalSinceReferenceDate: 251)
+        )
+
+        let items = VoiceNoteTimelineBuilder.build(
+            from: VoiceNoteTimelineInput(
+                history: [],
+                sessions: [session],
+                sourceFilter: .all
+            )
+        )
+
+        XCTAssertEqual(items, [.recoverable(session)])
     }
 
     func testTranscriptPreviewIsBoundedAndPreservesTheNewestText() {

--- a/project.yml
+++ b/project.yml
@@ -90,6 +90,7 @@ targets:
     sources:
       - path: Tests/MuesliTests
       - path: Shared
+      - path: MuesliKeyboard/KeyboardController.swift
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.phequals7.muesli.ios.tests


### PR DESCRIPTION
## Summary

Makes keyboard dictation resilient to screen lock, auto-lock, route changes, and extension suspension.

A dictation can now survive lock/unlock, restore the keyboard's live state and waveform, finish from the keyboard, and deliver the resulting transcript safely without requiring an app hop.

## Root cause

This was not one isolated UI bug:

- iOS suspends and later recreates or reattaches the keyboard extension, leaving its observers, animation timeline, and in-memory presentation stale.
- The container app and keyboard extension used last-writer-wins shared state, allowing delayed Start, Stop, and result updates to arrive out of order.
- `AVAudioEngine.isRunning` was treated as capture health even when no input buffers were reaching durable storage.
- Audio-session configuration, file protection, and incomplete WAV headers could make recoverable audio appear unavailable after lock.
- A hidden or preloaded keyboard instance could race the visible keyboard to consume and insert a result.

## What changed

### Durable capture recovery

- Adds an explicit interrupted voice-note phase and interruption reason.
- Detects health from recent, durably accepted audio buffers rather than engine-running state.
- Rebuilds or recreates audio graphs after interruption, route change, media-services reset, or configuration change.
- Persists draft transcript state and rotates an audio checkpoint before recovery.
- Makes audio and SQLite metadata reopenable after first device unlock.
- Repairs recoverable trailing-PCM WAV headers and preserves evidence unless completion, cancellation, or explicit deletion authorizes cleanup.
- Falls back to retained audio whenever realtime transcription becomes lossy.

### Cross-process state safety

- Treats keyboard commands as durable desired state instead of lossy event edges.
- Adds monotonic handoff transitions and compare-and-set clearing.
- Atomically commits request, command, handoff, transcript, result, and completion boundaries in SQLite.
- Adds a coalescing runtime-status writer so waveform updates cannot overwrite terminal lifecycle state.
- Periodically reconciles the visible keyboard from one coherent SQLite snapshot.

### Safe result insertion

- Adds a renewable visible-keyboard presentation lease.
- Adds an atomic insertion claim so hidden or preloaded controllers cannot paste text.
- Finalizes result consumption transactionally after insertion.
- Uses a two-step **Review recovered text** → **Insert if missing** flow when insertion outcome is ambiguous.

### UI recovery

- Rehydrates keyboard state on actual extension-host reattachment.
- Recreates the waveform timeline after unlock.
- Shows a bounded resuming state until fresh audio is proven.
- Preserves the existing fixed-height keyboard geometry and transition-flash fix.

### Shared audio infrastructure

Meeting capture uses the same generation fencing, durable-input health checks, and graph-recovery rules so the voice-note changes do not regress meeting lifecycle behavior.

## User impact

After locking and unlocking during keyboard dictation:

- Audio captured before and after lock remains recoverable.
- The waveform resumes automatically once fresh input returns.
- Stop and Cancel remain available from the keyboard.
- The completed transcript is inserted once into the owning field.
- Ambiguous recovery never silently inserts into a stale field.
- Interrupted audio appears as recoverable evidence instead of an empty **Audio unavailable** entry.

The keyboard extension cannot prevent a host app from initiating auto-lock; this change makes dictation survive it correctly.

## Validation

- Full project compile passed.
- 216/216 unit and integration tests passed.
- 12/12 UI tests passed.
- Independent lifecycle, audio, and ownership audits found no remaining P1/P2 issue.
- The signed build was installed and launched on picophone with existing app data preserved for physical lock/unlock stress testing.

## Physical test focus

- Manual lock and natural auto-lock during active keyboard dictation.
- Lock during Start, active speech, silence, and Transcribing.
- Repeated lock/unlock cycles without opening the container app.
- Exactly-once insertion and safe recovery after switching fields, apps, or keyboards.
- Regression check for keyboard transition flash or cumulative height growth.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli-ios/pr/25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787007965&installation_id=136549638&pr_number=25&repository=Muesli-HQ%2Fmuesli-ios&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli-ios%2Fpull%2F25&signature=a332951f237b036da2ba46c37e47e6f0ca31f7445e5081dd2bd2cf07c33017d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added recovery support for interrupted voice notes, including saved audio and draft transcripts.
  * Added clearer recovery statuses and messaging for interrupted recordings and resumed capture.
  * Improved keyboard dictation recovery, result insertion, and protection against stale or duplicate actions.

* **Bug Fixes**
  * Improved audio capture health checks and recovery after interruptions or system audio resets.
  * Added protection and repair for recorded audio files, including damaged WAV headers.
  * Improved persistence to prevent lost drafts, incomplete handoffs, and inconsistent recording states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->