### PR TITLE
Instrument the keyboard, and bind the Live Activity to the recording

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,4 +39,28 @@ jobs:
             -project MuesliiOS.xcodeproj \
             -scheme Muesli \
             -destination 'platform=iOS Simulator,id=${{ steps.simulator.outputs.udid }}' \
+            -enableCodeCoverage YES \
+            -resultBundlePath TestResults.xcresult \
             CODE_SIGNING_ALLOWED=NO
+
+      # Reported, not gated. A floor is only meaningful once there is a
+      # baseline worth holding, and gating on a number nobody chose tends to
+      # produce tests written to move the number. Pass --fail-under-watched to
+      # scripts/coverage-summary.py once the watched files have settled.
+      - name: Report code coverage
+        if: always()
+        run: |
+          if [ ! -d TestResults.xcresult ]; then
+            echo "No result bundle produced; skipping coverage report."
+            exit 0
+          fi
+          xcrun xccov view --report --json TestResults.xcresult > coverage.json
+          python3 scripts/coverage-summary.py coverage.json | tee -a "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: TestResults.xcresult
+          retention-days: 7

--- a/LiveActivityShared/MuesliLiveActivityAttributes.swift
+++ b/LiveActivityShared/MuesliLiveActivityAttributes.swift
@@ -14,7 +14,18 @@ struct MuesliLiveActivityAttributes: ActivityAttributes {
 
     var sessionID: String
     var requestID: String?
+    /// Display title of the capture kind. Presentation only -- do not branch on
+    /// it. The widget runs in a separate target that cannot see
+    /// `RecordingSessionKind`, so capabilities travel as explicit fields below.
     var kind: String
+
+    /// Optional so an activity started by an earlier build still decodes; when
+    /// absent, fall back to the old meaning of `kind`.
+    var offersStopControl: Bool?
+
+    var showsStopControl: Bool {
+        offersStopControl ?? isMeeting
+    }
 
     var isMeeting: Bool {
         kind == Self.meetingKind

--- a/Muesli/AboutSettingsContent.swift
+++ b/Muesli/AboutSettingsContent.swift
@@ -4,6 +4,8 @@ struct AboutSettingsContent: View {
     private let sourceURL = URL(string: "https://github.com/Muesli-HQ/muesli-ios")!
     private let libraries = OpenSourceLibrary.all
 
+    @State private var copiedDiagnostics = false
+
     private var version: String {
         Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "—"
     }
@@ -21,6 +23,29 @@ struct AboutSettingsContent: View {
                     AboutValueRow(icon: "lock.shield", title: "Processing", value: "On device")
                     Divider().overlay(MuesliTheme.surfaceBorder)
                     AboutValueRow(icon: "externaldrive", title: "App data", value: "Local SQLite")
+                    Divider().overlay(MuesliTheme.surfaceBorder)
+                    Button {
+                        // Keyboard state transitions only -- phases, short
+                        // request IDs, timings. Never dictated text.
+                        UIPasteboard.general.string = KeyboardDiagnosticsLog.exportText()
+                        copiedDiagnostics = true
+                    } label: {
+                        HStack(spacing: MuesliTheme.spacing12) {
+                            Image(systemName: "stethoscope")
+                                .font(.system(size: 15, weight: .medium))
+                                .foregroundStyle(MuesliTheme.accent)
+                                .frame(width: 22)
+                            Text("Copy keyboard diagnostics")
+                                .font(MuesliTheme.headline())
+                                .foregroundStyle(MuesliTheme.textPrimary)
+                            Spacer()
+                            Text(copiedDiagnostics ? "Copied" : "Last \(KeyboardDiagnosticsLog.entryLimit)")
+                                .font(MuesliTheme.callout())
+                                .foregroundStyle(MuesliTheme.accent)
+                        }
+                        .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
                     Divider().overlay(MuesliTheme.surfaceBorder)
                     Link(destination: sourceURL) {
                         HStack(spacing: MuesliTheme.spacing12) {

--- a/Muesli/AboutSettingsContent.swift
+++ b/Muesli/AboutSettingsContent.swift
@@ -6,6 +6,16 @@ struct AboutSettingsContent: View {
 
     @State private var copiedDiagnostics = false
 
+    /// The keyboard transition log, preceded by a count of audio files against
+    /// the notes that own them. Filenames are never included -- only totals.
+    private func diagnosticsReport() -> String {
+        var header = ""
+        if let audit = try? SharedStore().audioFileAudit() {
+            header = "audio: \(audit.onDisk) files, \(audit.owned) owned, \(audit.orphaned) orphaned\n\n"
+        }
+        return header + KeyboardDiagnosticsLog.exportText()
+    }
+
     private var version: String {
         Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "—"
     }
@@ -27,7 +37,7 @@ struct AboutSettingsContent: View {
                     Button {
                         // Keyboard state transitions only -- phases, short
                         // request IDs, timings. Never dictated text.
-                        UIPasteboard.general.string = KeyboardDiagnosticsLog.exportText()
+                        UIPasteboard.general.string = diagnosticsReport()
                         copiedDiagnostics = true
                     } label: {
                         HStack(spacing: MuesliTheme.spacing12) {

--- a/Muesli/AboutSettingsContent.swift
+++ b/Muesli/AboutSettingsContent.swift
@@ -39,6 +39,12 @@ struct AboutSettingsContent: View {
                         // request IDs, timings. Never dictated text.
                         UIPasteboard.general.string = diagnosticsReport()
                         copiedDiagnostics = true
+                        // Confirm the copy, then go back to showing the size of
+                        // the buffer. Latching on "Copied" hid that permanently.
+                        Task {
+                            try? await Task.sleep(for: .seconds(2))
+                            copiedDiagnostics = false
+                        }
                     } label: {
                         HStack(spacing: MuesliTheme.spacing12) {
                             Image(systemName: "stethoscope")

--- a/Muesli/DictationCoordinator.swift
+++ b/Muesli/DictationCoordinator.swift
@@ -187,7 +187,6 @@ final class DictationCoordinator {
 
     private var activeRequest: DictationRequest?
     private var activeSession: RecordingSession?
-    private var keyboardSessionActivitySession: RecordingSession?
     private var keyboardSessionState = KeyboardSessionState()
     private var stopKeyboardSessionAfterCurrentRequest = false
     var isKeyboardHandoffActive: Bool { keyboardSessionState.isKeyboardHandoffActive }
@@ -862,19 +861,12 @@ final class DictationCoordinator {
         let durabilityDetail = session.hasDurableAudioCheckpoint
             ? "Audio protected locally"
             : "Securing audio"
-        if session.kind == .keyboardDictation {
-            refreshKeyboardSessionLiveActivity(
+        Task {
+            await liveActivityController.update(
                 phase: "Long voice note",
-                detail: durabilityDetail
+                detail: durabilityDetail,
+                session: session
             )
-        } else {
-            Task {
-                await liveActivityController.update(
-                    phase: "Long voice note",
-                    detail: durabilityDetail,
-                    session: session
-                )
-            }
         }
         return session
     }
@@ -2678,7 +2670,7 @@ final class DictationCoordinator {
                 )
                 return
             }
-            guard isKeyboardSessionArmed || keyboardSessionActivitySession != nil || keyboardSessionKeeper.isRunning else {
+            guard isKeyboardSessionArmed || keyboardSessionKeeper.isRunning else {
                 keyboardSessionRetryTask?.cancel()
                 keyboardSessionRetryTask = nil
                 keyboardSessionRetryAttempt = 0
@@ -2725,19 +2717,6 @@ final class DictationCoordinator {
             keyboardSessionRetryAttempt = 0
             prewarmModelIfNeeded(reason: "keyboard_session")
             transitionKeyboardSession(.startSucceeded)
-            let session = RecordingSession(
-                kind: .keyboardDictation,
-                title: "Keyboard Session",
-                startedAt: .now,
-                phase: .recording
-            )
-            keyboardSessionActivitySession = session
-            await liveActivityController.start(
-                session: session,
-                requestID: nil,
-                phase: "Ready",
-                detail: "Keyboard voice note session active"
-            )
             saveKeyboardRuntimeStatus(
                 isActive: true,
                 activeRequestID: nil,
@@ -2810,17 +2789,6 @@ final class DictationCoordinator {
             message: reason.message
         )
 
-        if let session = keyboardSessionActivitySession {
-            Task {
-                await liveActivityController.end(
-                    phase: "Ended",
-                    detail: reason.message,
-                    session: session,
-                    dismissal: .immediate
-                )
-            }
-        }
-        keyboardSessionActivitySession = nil
         AppTelemetry.signal("keyboard_session_stopped", parameters: ["reason": reason.message])
     }
 
@@ -2829,29 +2797,6 @@ final class DictationCoordinator {
             return false
         }
         return true
-    }
-
-    private func refreshKeyboardSessionLiveActivity(phase: String, detail: String) {
-        guard isKeyboardSessionArmed || keyboardSessionActivitySession != nil else { return }
-
-        if keyboardSessionActivitySession == nil {
-            keyboardSessionActivitySession = RecordingSession(
-                kind: .keyboardDictation,
-                title: "Keyboard Session",
-                startedAt: .now,
-                phase: .recording
-            )
-        }
-
-        guard let session = keyboardSessionActivitySession else { return }
-        Task {
-            await liveActivityController.start(
-                session: session,
-                requestID: nil,
-                phase: phase,
-                detail: detail
-            )
-        }
     }
 
     private func setUsesPersistentKeyboardSession(_ usesKeyboardSession: Bool, for requestID: UUID) {
@@ -3575,19 +3520,12 @@ final class DictationCoordinator {
                     await processPendingKeyboardCommand()
                 }
                 Task {
-                    if usesPersistentKeyboardSession {
-                        refreshKeyboardSessionLiveActivity(
-                            phase: "Listening",
-                            detail: "Keyboard voice note active"
-                        )
-                    } else {
-                        await liveActivityController.start(
-                            session: session,
-                            requestID: request.id,
-                            phase: "Listening",
-                            detail: "Recording voice note"
-                        )
-                    }
+                    await liveActivityController.start(
+                        session: session,
+                        requestID: request.id,
+                        phase: "Listening",
+                        detail: "Recording voice note"
+                    )
                 }
             } catch {
                 session.phase = .failed
@@ -3897,18 +3835,11 @@ final class DictationCoordinator {
             try? store.saveSession(session)
             activeSession = session
             Task {
-                if usesPersistentKeyboardSession {
-                    refreshKeyboardSessionLiveActivity(
-                        phase: "Transcribing",
-                        detail: "Preparing text for the keyboard"
-                    )
-                } else {
-                    await liveActivityController.update(
-                        phase: "Transcribing",
-                        detail: "Preparing text for the keyboard",
-                        session: session
-                    )
-                }
+                await liveActivityController.update(
+                    phase: "Transcribing",
+                    detail: "Preparing text for the keyboard",
+                    session: session
+                )
             }
         }
 
@@ -4156,12 +4087,7 @@ final class DictationCoordinator {
                 statusText = "Ready"
                 liveDictationTranscript = ""
                 realtimeDictationCommittedText = ""
-                if startedFromKeyboard, usesPersistentKeyboardSession, !completedDeferredStop {
-                    refreshKeyboardSessionLiveActivity(
-                        phase: "Ready",
-                        detail: "Keyboard voice note session active"
-                    )
-                } else if let completedSession = try? store.recordingSession(requestID: request.id) {
+                if let completedSession = try? store.recordingSession(requestID: request.id) {
                     Task {
                         await liveActivityController.end(
                             phase: "Completed",
@@ -4229,12 +4155,6 @@ final class DictationCoordinator {
                         phase: .failed,
                         message: error.localizedDescription,
                         supportsBackgroundStart: canStartKeyboardRequestsInBackground
-                    )
-                }
-                if usesPersistentKeyboardSession, !completedDeferredStop {
-                    refreshKeyboardSessionLiveActivity(
-                        phase: "Ready",
-                        detail: "Keyboard voice note failed. Session active"
                     )
                 }
                 transitionKeyboardSession(.requestFinished)
@@ -5679,14 +5599,6 @@ final class DictationCoordinator {
                     supportsBackgroundStart: true
                 )
             }
-            if let session = keyboardSessionActivitySession {
-                await liveActivityController.start(
-                    session: session,
-                    requestID: nil,
-                    phase: "Ready",
-                    detail: "Keyboard voice note session active"
-                )
-            }
             return true
         } catch {
             let isRecoverable = isRecoverableKeyboardSessionError(error)
@@ -5970,12 +5882,7 @@ final class DictationCoordinator {
             if let index = recordingSessions.firstIndex(where: { $0.id == session.id }) {
                 recordingSessions[index] = session
             }
-            if usesPersistentKeyboardSession {
-                refreshKeyboardSessionLiveActivity(
-                    phase: "Ready",
-                    detail: "Keyboard voice note session active"
-                )
-            } else {
+            do {
                 Task {
                     await liveActivityController.end(
                         phase: "Cancelled",

--- a/Muesli/DictationCoordinator.swift
+++ b/Muesli/DictationCoordinator.swift
@@ -2025,29 +2025,60 @@ final class DictationCoordinator {
     /// Throws if the session row itself survives. That row is what the timeline
     /// is built from, so leaving it behind means the voice note reappears on
     /// the next history reload after the user was told it was deleted.
+    /// Deletes a session and everything derived from it.
+    ///
+    /// There is no transaction spanning the filesystem and SQLite, so a later
+    /// step can fail after an earlier one has already destroyed something. What
+    /// is guaranteed instead is that the session row never describes data that
+    /// no longer exists: after each irreversible step the row is rewritten to
+    /// reflect what actually remains, before anything else is allowed to fail.
+    ///
+    /// A partial failure therefore leaves a session that is honest about itself
+    /// -- an "Audio unavailable" row, which the timeline already models and the
+    /// user can delete again -- rather than one still advertising a recording
+    /// that has been erased.
+    ///
+    /// Order matters: audio goes first. Deleting a voice note is a privacy
+    /// claim, so the recording is the one artifact that must not survive a
+    /// half-completed delete.
     private func discardVoiceNoteSession(_ session: RecordingSession) async throws {
-        // Every artifact is propagated. Deleting a voice note is a privacy
-        // claim, so reporting success while audio survives on disk is worse
-        // than reporting failure. SharedStore.deleteAudioFile already no-ops
-        // when the file is absent, so a missing recording -- the usual case for
-        // an "Audio unavailable" row -- is not an error here.
-        if let audioFileName = session.audioFileName {
+        var remaining = session
+
+        // SharedStore.deleteAudioFile no-ops when the file is absent, so a
+        // missing recording -- the usual case for a row that already reads
+        // "Audio unavailable" -- is not an error here.
+        if let audioFileName = remaining.audioFileName {
             try store.deleteAudioFile(fileName: audioFileName)
+            remaining.audioFileName = nil
+            remaining.hasDurableAudioCheckpoint = false
+            remaining.protectedAudioUntilTranscriptCompletes = false
+            try? store.saveSession(remaining)
+            replaceCachedRecordingSession(remaining)
         }
+
         try store.deleteTranscript(for: session.id)
         removeCachedTranscript(for: session.id)
+        if remaining.transcriptID != nil {
+            remaining.transcriptID = nil
+            try? store.saveSession(remaining)
+            replaceCachedRecordingSession(remaining)
+        }
 
-        // Awaited rather than fired into a Task, so the caller cannot report a
-        // completed deletion while checkpoint audio is still being removed.
+        // Awaited rather than fired into a detached Task, so the caller cannot
+        // report a completed deletion while checkpoint audio is still on disk.
         if session.longFormThresholdSeconds != nil {
             try await voiceNoteCheckpointStore.delete(sessionID: session.id)
         }
 
-        // Last: the row is what the timeline is built from, so it is only
-        // removed once everything derived from it is gone. If an earlier step
-        // throws, the session stays visible and can be retried.
+        // Last: the row is what the timeline is built from, so it is removed
+        // only once everything derived from it is gone.
         try store.deleteRecordingSession(id: session.id)
         recordingSessions.removeAll { $0.id == session.id }
+    }
+
+    private func replaceCachedRecordingSession(_ session: RecordingSession) {
+        guard let index = recordingSessions.firstIndex(where: { $0.id == session.id }) else { return }
+        recordingSessions[index] = session
     }
 
     /// A session that never produced a transcript -- shown in the timeline as

--- a/Muesli/DictationCoordinator.swift
+++ b/Muesli/DictationCoordinator.swift
@@ -2010,17 +2010,32 @@ final class DictationCoordinator {
         clearClipboardStatusSoon()
     }
 
+    /// Whether this process is currently capturing or transcribing the given
+    /// session. A session can sit in .recording forever after a crash without
+    /// anything actually running, so the persisted phase cannot answer this.
+    func isCapturingVoiceNote(sessionID: UUID) -> Bool {
+        activeSession?.id == sessionID
+    }
+
     /// Removes a capture session and everything derived from it: its audio,
     /// transcript, cached transcript, and any long-form checkpoints. Shared by
     /// the completed and unrecoverable delete paths so a partial session is
     /// cleaned up as thoroughly as a finished one.
-    private func discardVoiceNoteSession(_ session: RecordingSession) {
+    ///
+    /// Throws if the session row itself survives. That row is what the timeline
+    /// is built from, so leaving it behind means the voice note reappears on
+    /// the next history reload after the user was told it was deleted.
+    private func discardVoiceNoteSession(_ session: RecordingSession) throws {
+        // Derived artifacts are best-effort: the audio file is usually already
+        // gone, which is what makes a row read "Audio unavailable".
         if let audioFileName = session.audioFileName {
             try? store.deleteAudioFile(fileName: audioFileName)
         }
         try? store.deleteTranscript(for: session.id)
         removeCachedTranscript(for: session.id)
-        try? store.deleteRecordingSession(id: session.id)
+
+        try store.deleteRecordingSession(id: session.id)
+
         recordingSessions.removeAll { $0.id == session.id }
         if session.longFormThresholdSeconds != nil {
             Task {
@@ -2033,8 +2048,27 @@ final class DictationCoordinator {
     /// "Audio unavailable" or "Needs transcription". These accumulate with no
     /// way to clear them, because every existing delete path is keyed on a
     /// DictationResult that this session does not have.
-    func deleteRecoverableVoiceNote(_ session: RecordingSession) {
-        discardVoiceNoteSession(session)
+    @discardableResult
+    func deleteRecoverableVoiceNote(_ session: RecordingSession) -> Bool {
+        // The timeline lists .recording, .transcriptionQueued and .transcribing
+        // as recoverable, so a capture that is genuinely still running can
+        // appear here. Deleting its artifacts underneath a live recorder or
+        // transcription task would fail that work, or let it re-save the row
+        // and resurrect a session the user was told had been deleted.
+        guard !isCapturingVoiceNote(sessionID: session.id) else {
+            clipboardStatusText = "Stop the recording first"
+            clearClipboardStatusSoon()
+            return false
+        }
+
+        do {
+            try discardVoiceNoteSession(session)
+        } catch {
+            clipboardStatusText = "Delete failed"
+            clearClipboardStatusSoon()
+            return false
+        }
+
         clipboardStatusText = "Deleted"
         AppTelemetry.signal(
             "voice_note_deleted",
@@ -2045,12 +2079,13 @@ final class DictationCoordinator {
         )
         clearClipboardStatusSoon()
         scheduleICloudSyncAfterLocalChange(reason: "voice_note_deleted")
+        return true
     }
 
     func deleteDictation(_ result: DictationResult) {
         do {
             if let session = recordingSession(for: result) {
-                discardVoiceNoteSession(session)
+                try discardVoiceNoteSession(session)
             }
             try store.deleteResult(result)
             dictationHistory.removeAll { $0.id == result.id || $0.requestID == result.requestID }

--- a/Muesli/DictationCoordinator.swift
+++ b/Muesli/DictationCoordinator.swift
@@ -467,7 +467,7 @@ final class DictationCoordinator {
         }
         startSharedEventObservation()
         MeetingLiveActivityActionDispatcher.register { [weak self] sessionID in
-            self?.stopMeetingRecordingFromLiveActivity(sessionID: sessionID) ?? .unavailable
+            self?.stopCaptureFromLiveActivity(sessionID: sessionID) ?? .unavailable
         }
 
         refreshAudioInputRoute()
@@ -4484,6 +4484,28 @@ final class DictationCoordinator {
         AppTelemetry.signal("meeting_recording_recovered_for_transcription")
         transcribeSession(queued)
         return true
+    }
+
+    /// The Live Activity stop control is shared by every capture kind -- the
+    /// intent carries only a session ID and knows nothing about what it is
+    /// stopping. Routes to whichever capture owns that session.
+    func stopCaptureFromLiveActivity(sessionID: UUID) -> MeetingLiveActivityStopResult {
+        if canStopMeetingCapture(sessionID: sessionID) {
+            return stopMeetingRecordingFromLiveActivity(sessionID: sessionID)
+        }
+
+        guard let activeSession, activeSession.id == sessionID, isRecording else {
+            // The recording already ended, or belongs to a session this
+            // process no longer owns. The activity is stale either way.
+            return .alreadyHandled
+        }
+
+        stopRecording()
+        AppTelemetry.signal(
+            "capture_stopped_from_live_activity",
+            parameters: ["session_kind": activeSession.kind.title]
+        )
+        return .accepted
     }
 
     func stopMeetingRecordingFromLiveActivity(sessionID: UUID) -> MeetingLiveActivityStopResult {

--- a/Muesli/DictationCoordinator.swift
+++ b/Muesli/DictationCoordinator.swift
@@ -2010,11 +2010,22 @@ final class DictationCoordinator {
         clearClipboardStatusSoon()
     }
 
-    /// Whether this process is currently capturing or transcribing the given
-    /// session. A session can sit in .recording forever after a crash without
-    /// anything actually running, so the persisted phase cannot answer this.
+    /// Whether this process still has work in flight for the given session.
+    ///
+    /// The persisted phase cannot answer this: a session can sit in .recording
+    /// forever after a crash with nothing running, and those are exactly the
+    /// rows worth deleting.
+    ///
+    /// `activeSession` alone cannot answer it either. It is cleared at a dozen
+    /// points while transcription continues, so a voice note can be queued or
+    /// mid-transcription with no active session reference. Deleting its
+    /// artifacts then fails that work, or lets it save the session again and
+    /// resurrect a note the UI reported as deleted. The voice-note lifecycle
+    /// tracks that window, so it is the authority here.
     func isCapturingVoiceNote(sessionID: UUID) -> Bool {
-        activeSession?.id == sessionID
+        if activeSession?.id == sessionID { return true }
+        return voiceNoteLifecycleState.activeSessionID == sessionID
+            && voiceNoteLifecycleState.isWorkActive
     }
 
     /// Removes a capture session and everything derived from it: its audio,

--- a/Muesli/DictationCoordinator.swift
+++ b/Muesli/DictationCoordinator.swift
@@ -2025,23 +2025,29 @@ final class DictationCoordinator {
     /// Throws if the session row itself survives. That row is what the timeline
     /// is built from, so leaving it behind means the voice note reappears on
     /// the next history reload after the user was told it was deleted.
-    private func discardVoiceNoteSession(_ session: RecordingSession) throws {
-        // Derived artifacts are best-effort: the audio file is usually already
-        // gone, which is what makes a row read "Audio unavailable".
+    private func discardVoiceNoteSession(_ session: RecordingSession) async throws {
+        // Every artifact is propagated. Deleting a voice note is a privacy
+        // claim, so reporting success while audio survives on disk is worse
+        // than reporting failure. SharedStore.deleteAudioFile already no-ops
+        // when the file is absent, so a missing recording -- the usual case for
+        // an "Audio unavailable" row -- is not an error here.
         if let audioFileName = session.audioFileName {
-            try? store.deleteAudioFile(fileName: audioFileName)
+            try store.deleteAudioFile(fileName: audioFileName)
         }
-        try? store.deleteTranscript(for: session.id)
+        try store.deleteTranscript(for: session.id)
         removeCachedTranscript(for: session.id)
 
-        try store.deleteRecordingSession(id: session.id)
-
-        recordingSessions.removeAll { $0.id == session.id }
+        // Awaited rather than fired into a Task, so the caller cannot report a
+        // completed deletion while checkpoint audio is still being removed.
         if session.longFormThresholdSeconds != nil {
-            Task {
-                try? await voiceNoteCheckpointStore.delete(sessionID: session.id)
-            }
+            try await voiceNoteCheckpointStore.delete(sessionID: session.id)
         }
+
+        // Last: the row is what the timeline is built from, so it is only
+        // removed once everything derived from it is gone. If an earlier step
+        // throws, the session stays visible and can be retried.
+        try store.deleteRecordingSession(id: session.id)
+        recordingSessions.removeAll { $0.id == session.id }
     }
 
     /// A session that never produced a transcript -- shown in the timeline as
@@ -2049,7 +2055,7 @@ final class DictationCoordinator {
     /// way to clear them, because every existing delete path is keyed on a
     /// DictationResult that this session does not have.
     @discardableResult
-    func deleteRecoverableVoiceNote(_ session: RecordingSession) -> Bool {
+    func deleteRecoverableVoiceNote(_ session: RecordingSession) async -> Bool {
         // The timeline lists .recording, .transcriptionQueued and .transcribing
         // as recoverable, so a capture that is genuinely still running can
         // appear here. Deleting its artifacts underneath a live recorder or
@@ -2062,7 +2068,7 @@ final class DictationCoordinator {
         }
 
         do {
-            try discardVoiceNoteSession(session)
+            try await discardVoiceNoteSession(session)
         } catch {
             clipboardStatusText = "Delete failed"
             clearClipboardStatusSoon()
@@ -2082,10 +2088,10 @@ final class DictationCoordinator {
         return true
     }
 
-    func deleteDictation(_ result: DictationResult) {
+    func deleteDictation(_ result: DictationResult) async {
         do {
             if let session = recordingSession(for: result) {
-                try discardVoiceNoteSession(session)
+                try await discardVoiceNoteSession(session)
             }
             try store.deleteResult(result)
             dictationHistory.removeAll { $0.id == result.id || $0.requestID == result.requestID }

--- a/Muesli/DictationCoordinator.swift
+++ b/Muesli/DictationCoordinator.swift
@@ -2052,16 +2052,14 @@ final class DictationCoordinator {
             remaining.audioFileName = nil
             remaining.hasDurableAudioCheckpoint = false
             remaining.protectedAudioUntilTranscriptCompletes = false
-            try? store.saveSession(remaining)
-            replaceCachedRecordingSession(remaining)
+            try reconcile(remaining, afterDeleting: session)
         }
 
         try store.deleteTranscript(for: session.id)
         removeCachedTranscript(for: session.id)
         if remaining.transcriptID != nil {
             remaining.transcriptID = nil
-            try? store.saveSession(remaining)
-            replaceCachedRecordingSession(remaining)
+            try reconcile(remaining, afterDeleting: session)
         }
 
         // Awaited rather than fired into a detached Task, so the caller cannot
@@ -2076,9 +2074,27 @@ final class DictationCoordinator {
         recordingSessions.removeAll { $0.id == session.id }
     }
 
-    private func replaceCachedRecordingSession(_ session: RecordingSession) {
-        guard let index = recordingSessions.firstIndex(where: { $0.id == session.id }) else { return }
-        recordingSessions[index] = session
+    /// Persists what is left of a session after an irreversible step.
+    ///
+    /// This write is what makes the guarantee above hold, so it cannot be
+    /// best-effort. If the row cannot be corrected it must not survive --
+    /// leaving it would advertise a recording that has already been erased --
+    /// so removal is attempted as the stronger fallback. Only a store that
+    /// can neither update nor delete reaches the throw, and at that point
+    /// nothing this method could do would help.
+    private func reconcile(
+        _ remaining: RecordingSession,
+        afterDeleting session: RecordingSession
+    ) throws {
+        do {
+            try store.saveSession(remaining)
+            if let index = recordingSessions.firstIndex(where: { $0.id == remaining.id }) {
+                recordingSessions[index] = remaining
+            }
+        } catch {
+            try store.deleteRecordingSession(id: session.id)
+            recordingSessions.removeAll { $0.id == session.id }
+        }
     }
 
     /// A session that never produced a transcript -- shown in the timeline as

--- a/Muesli/DictationCoordinator.swift
+++ b/Muesli/DictationCoordinator.swift
@@ -167,7 +167,7 @@ final class DictationCoordinator {
         label: "com.phequals7.muesli.keyboard-runtime-status",
         qos: .utility
     )
-    private var keyboardSessionLiveActivityRequestIDs = Set<UUID>()
+    private var persistentKeyboardSessionRequestIDs = Set<UUID>()
     private var iCloudSyncTask: Task<Void, Never>?
     private var iCloudSyncDebounceTask: Task<Void, Never>?
     private var pendingICloudSyncReason: String?
@@ -2772,7 +2772,7 @@ final class DictationCoordinator {
     }
 
     private var shouldDeferKeyboardSessionStop: Bool {
-        if isRecording, let requestID = activeRequest?.id, usesKeyboardSessionLiveActivity(for: requestID) {
+        if isRecording, let requestID = activeRequest?.id, usesPersistentKeyboardSession(for: requestID) {
             return true
         }
         return isKeyboardHandoffActive && activeRequest != nil
@@ -2854,20 +2854,20 @@ final class DictationCoordinator {
         }
     }
 
-    private func setUsesKeyboardSessionLiveActivity(_ usesKeyboardSession: Bool, for requestID: UUID) {
+    private func setUsesPersistentKeyboardSession(_ usesKeyboardSession: Bool, for requestID: UUID) {
         if usesKeyboardSession {
-            keyboardSessionLiveActivityRequestIDs.insert(requestID)
+            persistentKeyboardSessionRequestIDs.insert(requestID)
         } else {
-            keyboardSessionLiveActivityRequestIDs.remove(requestID)
+            persistentKeyboardSessionRequestIDs.remove(requestID)
         }
     }
 
-    private func usesKeyboardSessionLiveActivity(for requestID: UUID) -> Bool {
-        keyboardSessionLiveActivityRequestIDs.contains(requestID)
+    private func usesPersistentKeyboardSession(for requestID: UUID) -> Bool {
+        persistentKeyboardSessionRequestIDs.contains(requestID)
     }
 
-    private func clearKeyboardSessionLiveActivityRoute(for requestID: UUID) {
-        keyboardSessionLiveActivityRequestIDs.remove(requestID)
+    private func clearPersistentKeyboardSessionRoute(for requestID: UUID) {
+        persistentKeyboardSessionRequestIDs.remove(requestID)
     }
 
     func transcript(for session: RecordingSession) -> Transcript? {
@@ -3463,8 +3463,8 @@ final class DictationCoordinator {
             return
         }
         activeRequest = request
-        let usesKeyboardSessionLiveActivity = source == "keyboard" && isKeyboardSessionArmed
-        setUsesKeyboardSessionLiveActivity(usesKeyboardSessionLiveActivity, for: request.id)
+        let usesPersistentKeyboardSession = source == "keyboard" && isKeyboardSessionArmed
+        setUsesPersistentKeyboardSession(usesPersistentKeyboardSession, for: request.id)
         liveDictationTranscript = ""
         realtimeDictationCommittedText = ""
         clearKeyboardLiveTranscript()
@@ -3492,13 +3492,13 @@ final class DictationCoordinator {
                 session.startedAt = .now
                 try store.saveSession(session)
                 try await recorder.requestPermission()
-                if !usesKeyboardSessionLiveActivity, keyboardSessionKeeper.isRunning {
+                if !usesPersistentKeyboardSession, keyboardSessionKeeper.isRunning {
                     keyboardSessionKeeper.stop(deactivateSession: true)
                     transitionKeyboardSession(.requestFinished)
                     try? store.clearKeyboardRuntimeStatus()
                     try? await Task.sleep(for: .milliseconds(150))
                 }
-                if usesKeyboardSessionLiveActivity {
+                if usesPersistentKeyboardSession {
                     if !keyboardSessionKeeper.canAcceptStartCommand {
                         if !keyboardSessionKeeper.isRunning {
                             try await keyboardSessionKeeper.start()
@@ -3542,7 +3542,7 @@ final class DictationCoordinator {
                 ) else {
                     throw VoiceNoteCaptureFailure.invalidLifecycleTransition
                 }
-                if source == "keyboard", !usesKeyboardSessionLiveActivity {
+                if source == "keyboard", !usesPersistentKeyboardSession {
                     transitionKeyboardSession(.recordingStarted(request.id))
                 }
                 startRecordingTimer(startedAt: session.startedAt ?? .now)
@@ -3575,7 +3575,7 @@ final class DictationCoordinator {
                     await processPendingKeyboardCommand()
                 }
                 Task {
-                    if usesKeyboardSessionLiveActivity {
+                    if usesPersistentKeyboardSession {
                         refreshKeyboardSessionLiveActivity(
                             phase: "Listening",
                             detail: "Keyboard voice note active"
@@ -3604,9 +3604,9 @@ final class DictationCoordinator {
                 stopRecordingTimer()
                 statusText = error.localizedDescription
                 clearKeyboardLiveTranscript()
-                clearKeyboardSessionLiveActivityRoute(for: request.id)
+                clearPersistentKeyboardSessionRoute(for: request.id)
                 stopMetering()
-                if usesKeyboardSessionLiveActivity {
+                if usesPersistentKeyboardSession {
                     keyboardSessionKeeper.cancelSegment()
                 }
                 let completedDeferredStop = completeDeferredKeyboardSessionStopIfNeeded()
@@ -3847,7 +3847,7 @@ final class DictationCoordinator {
             session = promotedSession
         }
 
-        let usesKeyboardSessionLiveActivity = usesKeyboardSessionLiveActivity(for: request.id)
+        let usesPersistentKeyboardSession = usesPersistentKeyboardSession(for: request.id)
         let lifecycleRunnerID: UUID?
         if let session {
             guard let runner = voiceNoteLifecycleRunner,
@@ -3897,7 +3897,7 @@ final class DictationCoordinator {
             try? store.saveSession(session)
             activeSession = session
             Task {
-                if usesKeyboardSessionLiveActivity {
+                if usesPersistentKeyboardSession {
                     refreshKeyboardSessionLiveActivity(
                         phase: "Transcribing",
                         detail: "Preparing text for the keyboard"
@@ -3927,7 +3927,7 @@ final class DictationCoordinator {
                 var finalWriterFailure: CheckpointingAudioWriterFailure?
                 var realtimeText = ""
 
-                if usesKeyboardSessionLiveActivity {
+                if usesPersistentKeyboardSession {
                     let segment = try keyboardSessionKeeper.finishSegment()
                     audioURL = segment.audioURL
                     finalCheckpoint = segment.finalCheckpoint
@@ -4073,7 +4073,7 @@ final class DictationCoordinator {
                             supportsBackgroundStart: canStartKeyboardRequestsInBackground
                         )
                     }
-                    clearKeyboardSessionLiveActivityRoute(for: request.id)
+                    clearPersistentKeyboardSessionRoute(for: request.id)
                     try? store.clearPendingRequest()
                     try? store.saveStatus(.idle)
                     return
@@ -4135,7 +4135,7 @@ final class DictationCoordinator {
                 if let sessionID = completedSession?.id {
                     finishVoiceNoteLifecycle(sessionID: sessionID)
                 }
-                if usesKeyboardSessionLiveActivity {
+                if usesPersistentKeyboardSession {
                     keyboardSessionKeeper.cancelSegment()
                 }
                 let completedDeferredStop = completeDeferredKeyboardSessionStopIfNeeded()
@@ -4156,7 +4156,7 @@ final class DictationCoordinator {
                 statusText = "Ready"
                 liveDictationTranscript = ""
                 realtimeDictationCommittedText = ""
-                if startedFromKeyboard, usesKeyboardSessionLiveActivity, !completedDeferredStop {
+                if startedFromKeyboard, usesPersistentKeyboardSession, !completedDeferredStop {
                     refreshKeyboardSessionLiveActivity(
                         phase: "Ready",
                         detail: "Keyboard voice note session active"
@@ -4171,7 +4171,7 @@ final class DictationCoordinator {
                         )
                     }
                 }
-                clearKeyboardSessionLiveActivityRoute(for: request.id)
+                clearPersistentKeyboardSessionRoute(for: request.id)
                 AppTelemetry.signal(
                     "dictation_completed",
                     parameters: [
@@ -4224,14 +4224,14 @@ final class DictationCoordinator {
                 let completedDeferredStop = completeDeferredKeyboardSessionStopIfNeeded()
                 if !completedDeferredStop {
                     saveKeyboardRuntimeStatus(
-                        isActive: isKeyboardHandoffActive || usesKeyboardSessionLiveActivity || canStartKeyboardRequestsInBackground,
+                        isActive: isKeyboardHandoffActive || usesPersistentKeyboardSession || canStartKeyboardRequestsInBackground,
                         activeRequestID: nil,
                         phase: .failed,
                         message: error.localizedDescription,
                         supportsBackgroundStart: canStartKeyboardRequestsInBackground
                     )
                 }
-                if usesKeyboardSessionLiveActivity, !completedDeferredStop {
+                if usesPersistentKeyboardSession, !completedDeferredStop {
                     refreshKeyboardSessionLiveActivity(
                         phase: "Ready",
                         detail: "Keyboard voice note failed. Session active"
@@ -4242,7 +4242,7 @@ final class DictationCoordinator {
                     resumeKeyboardSessionKeeperIfNeeded()
                     publishKeyboardSessionReadyIfAvailable()
                 }
-                clearKeyboardSessionLiveActivityRoute(for: request.id)
+                clearPersistentKeyboardSessionRoute(for: request.id)
                 realtimeDictationRecorder?.cancel()
                 realtimeDictationRecorder = nil
                 realtimeDictationBufferPipe?.finish()
@@ -5926,7 +5926,7 @@ final class DictationCoordinator {
             if let pendingRequest = try? store.pendingRequest(), pendingRequest.id == requestID {
                 try? store.clearPendingRequest()
             }
-            clearKeyboardSessionLiveActivityRoute(for: requestID)
+            clearPersistentKeyboardSessionRoute(for: requestID)
             if activeRequest == nil {
                 try? store.saveStatus(.idle)
                 saveKeyboardRuntimeStatus(
@@ -5946,10 +5946,10 @@ final class DictationCoordinator {
             guard isRecording else { return }
         }
         isRecording = false
-        let usesKeyboardSessionLiveActivity = usesKeyboardSessionLiveActivity(for: requestID)
+        let usesPersistentKeyboardSession = usesPersistentKeyboardSession(for: requestID)
         stopMetering()
         stopRecordingTimer()
-        if usesKeyboardSessionLiveActivity {
+        if usesPersistentKeyboardSession {
             keyboardSessionKeeper.cancelSegment()
         } else {
             _ = try? recorder.stop()
@@ -5970,7 +5970,7 @@ final class DictationCoordinator {
             if let index = recordingSessions.firstIndex(where: { $0.id == session.id }) {
                 recordingSessions[index] = session
             }
-            if usesKeyboardSessionLiveActivity {
+            if usesPersistentKeyboardSession {
                 refreshKeyboardSessionLiveActivity(
                     phase: "Ready",
                     detail: "Keyboard voice note session active"
@@ -5985,7 +5985,7 @@ final class DictationCoordinator {
                 }
             }
         }
-        clearKeyboardSessionLiveActivityRoute(for: requestID)
+        clearPersistentKeyboardSessionRoute(for: requestID)
         activeRequest = nil
         activeSession = nil
         if completeDeferredKeyboardSessionStopIfNeeded() {

--- a/Muesli/DictationCoordinator.swift
+++ b/Muesli/DictationCoordinator.swift
@@ -2148,10 +2148,14 @@ final class DictationCoordinator {
 
     func deleteDictation(_ result: DictationResult) async {
         do {
+            // The result is what history renders, so it goes first. If it
+            // fails, nothing has been destroyed and the note is still whole and
+            // retryable. Doing it last meant a failure here left a note in
+            // history pointing at a session that had already been torn down.
+            try store.deleteResult(result)
             if let session = recordingSession(for: result) {
                 try await discardVoiceNoteSession(session)
             }
-            try store.deleteResult(result)
             dictationHistory.removeAll { $0.id == result.id || $0.requestID == result.requestID }
             if lastTranscript == result.text {
                 lastTranscript = dictationHistory.first?.text ?? ""

--- a/Muesli/DictationCoordinator.swift
+++ b/Muesli/DictationCoordinator.swift
@@ -2010,21 +2010,47 @@ final class DictationCoordinator {
         clearClipboardStatusSoon()
     }
 
+    /// Removes a capture session and everything derived from it: its audio,
+    /// transcript, cached transcript, and any long-form checkpoints. Shared by
+    /// the completed and unrecoverable delete paths so a partial session is
+    /// cleaned up as thoroughly as a finished one.
+    private func discardVoiceNoteSession(_ session: RecordingSession) {
+        if let audioFileName = session.audioFileName {
+            try? store.deleteAudioFile(fileName: audioFileName)
+        }
+        try? store.deleteTranscript(for: session.id)
+        removeCachedTranscript(for: session.id)
+        try? store.deleteRecordingSession(id: session.id)
+        recordingSessions.removeAll { $0.id == session.id }
+        if session.longFormThresholdSeconds != nil {
+            Task {
+                try? await voiceNoteCheckpointStore.delete(sessionID: session.id)
+            }
+        }
+    }
+
+    /// A session that never produced a transcript -- shown in the timeline as
+    /// "Audio unavailable" or "Needs transcription". These accumulate with no
+    /// way to clear them, because every existing delete path is keyed on a
+    /// DictationResult that this session does not have.
+    func deleteRecoverableVoiceNote(_ session: RecordingSession) {
+        discardVoiceNoteSession(session)
+        clipboardStatusText = "Deleted"
+        AppTelemetry.signal(
+            "voice_note_deleted",
+            parameters: [
+                "state": session.audioFileName == nil ? "audio_unavailable" : "needs_transcription",
+                "kind": session.kind.title
+            ]
+        )
+        clearClipboardStatusSoon()
+        scheduleICloudSyncAfterLocalChange(reason: "voice_note_deleted")
+    }
+
     func deleteDictation(_ result: DictationResult) {
         do {
             if let session = recordingSession(for: result) {
-                if let audioFileName = session.audioFileName {
-                    try? store.deleteAudioFile(fileName: audioFileName)
-                }
-                try? store.deleteTranscript(for: session.id)
-                removeCachedTranscript(for: session.id)
-                try? store.deleteRecordingSession(id: session.id)
-                recordingSessions.removeAll { $0.id == session.id }
-                if session.longFormThresholdSeconds != nil {
-                    Task {
-                        try? await voiceNoteCheckpointStore.delete(sessionID: session.id)
-                    }
-                }
+                discardVoiceNoteSession(session)
             }
             try store.deleteResult(result)
             dictationHistory.removeAll { $0.id == result.id || $0.requestID == result.requestID }

--- a/Muesli/DictationCoordinator.swift
+++ b/Muesli/DictationCoordinator.swift
@@ -5563,7 +5563,9 @@ final class DictationCoordinator {
               let audioFileName = session.audioFileName
         else { return }
 
-        try? store.deleteAudioFile(fileName: audioFileName)
+        // As above: keep the reference if the file survived, so the recording
+        // stays owned by its session rather than becoming an orphan.
+        guard (try? store.deleteAudioFile(fileName: audioFileName)) != nil else { return }
         session.audioFileName = nil
     }
 
@@ -5579,7 +5581,10 @@ final class DictationCoordinator {
 
     private func discardAudio(for session: inout RecordingSession) {
         guard let audioFileName = session.audioFileName else { return }
-        try? store.deleteAudioFile(fileName: audioFileName)
+        // The reference is only cleared once the file is actually gone.
+        // Clearing it after a failed delete is what strands a recording on
+        // disk with nothing pointing at it.
+        guard (try? store.deleteAudioFile(fileName: audioFileName)) != nil else { return }
         session.audioFileName = nil
         session.keepsAudioRecording = false
     }

--- a/Muesli/DictationView.swift
+++ b/Muesli/DictationView.swift
@@ -583,7 +583,7 @@ struct DictationView: View {
                                 // recorder would fail the work in flight.
                                 canDelete: !coordinator.isCapturingVoiceNote(sessionID: session.id),
                                 action: { coordinator.openLongVoiceNote(session) },
-                                onDelete: { coordinator.deleteRecoverableVoiceNote(session) }
+                                onDelete: { Task { await coordinator.deleteRecoverableVoiceNote(session) } }
                             )
                         case .completed(let result, let session):
                             let hasRetainedAudio = session?.keepsAudioRecording == true
@@ -602,7 +602,7 @@ struct DictationView: View {
                                     )
                                 } : nil,
                                 onCopy: { coordinator.copyToClipboard(result) },
-                                onDelete: { coordinator.deleteDictation(result) }
+                                onDelete: { Task { await coordinator.deleteDictation(result) } }
                             )
                         }
                     }

--- a/Muesli/DictationView.swift
+++ b/Muesli/DictationView.swift
@@ -576,9 +576,11 @@ struct DictationView: View {
                     ForEach(timeline) { item in
                         switch item {
                         case .recoverable(let session):
-                            RecoverableVoiceNoteRow(session: session) {
-                                coordinator.openLongVoiceNote(session)
-                            }
+                            RecoverableVoiceNoteRow(
+                                session: session,
+                                action: { coordinator.openLongVoiceNote(session) },
+                                onDelete: { coordinator.deleteRecoverableVoiceNote(session) }
+                            )
                         case .completed(let result, let session):
                             let hasRetainedAudio = session?.keepsAudioRecording == true
                                 && session.flatMap { coordinator.audioFileURL(for: $0) } != nil
@@ -926,6 +928,14 @@ private struct DictationHomeStatTile: View {
 private struct RecoverableVoiceNoteRow: View {
     let session: RecordingSession
     let action: () -> Void
+    let onDelete: () -> Void
+    @State private var isConfirmingDelete = false
+
+    private var deleteMessage: String {
+        session.audioFileName == nil
+            ? "The audio for this voice note is gone, so it cannot be transcribed. This removes it from local history."
+            : "This removes the voice note, and its audio, from local history."
+    }
 
     var body: some View {
         Button(action: action) {
@@ -969,6 +979,22 @@ private struct RecoverableVoiceNoteRow: View {
         }
         .buttonStyle(.plain)
         .accessibilityHint(session.audioFileName == nil ? "Opens recovery details" : "Opens retry actions")
+        .contextMenu {
+            Button("Delete Voice Note", systemImage: "trash", role: .destructive) {
+                isConfirmingDelete = true
+            }
+        }
+        .accessibilityAction(named: "Delete voice note") { isConfirmingDelete = true }
+        .confirmationDialog(
+            "Delete this voice note?",
+            isPresented: $isConfirmingDelete,
+            titleVisibility: .visible
+        ) {
+            Button("Delete Voice Note", role: .destructive, action: onDelete)
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text(deleteMessage)
+        }
     }
 }
 

--- a/Muesli/DictationView.swift
+++ b/Muesli/DictationView.swift
@@ -578,6 +578,10 @@ struct DictationView: View {
                         case .recoverable(let session):
                             RecoverableVoiceNoteRow(
                                 session: session,
+                                // A capture that is actually running still
+                                // appears here; deleting it underneath the
+                                // recorder would fail the work in flight.
+                                canDelete: !coordinator.isCapturingVoiceNote(sessionID: session.id),
                                 action: { coordinator.openLongVoiceNote(session) },
                                 onDelete: { coordinator.deleteRecoverableVoiceNote(session) }
                             )
@@ -927,6 +931,7 @@ private struct DictationHomeStatTile: View {
 
 private struct RecoverableVoiceNoteRow: View {
     let session: RecordingSession
+    let canDelete: Bool
     let action: () -> Void
     let onDelete: () -> Void
     @State private var isConfirmingDelete = false
@@ -980,11 +985,15 @@ private struct RecoverableVoiceNoteRow: View {
         .buttonStyle(.plain)
         .accessibilityHint(session.audioFileName == nil ? "Opens recovery details" : "Opens retry actions")
         .contextMenu {
-            Button("Delete Voice Note", systemImage: "trash", role: .destructive) {
-                isConfirmingDelete = true
+            if canDelete {
+                Button("Delete Voice Note", systemImage: "trash", role: .destructive) {
+                    isConfirmingDelete = true
+                }
             }
         }
-        .accessibilityAction(named: "Delete voice note") { isConfirmingDelete = true }
+        .accessibilityAction(named: "Delete voice note") {
+            if canDelete { isConfirmingDelete = true }
+        }
         .confirmationDialog(
             "Delete this voice note?",
             isPresented: $isConfirmingDelete,

--- a/Muesli/MuesliLiveActivityController.swift
+++ b/Muesli/MuesliLiveActivityController.swift
@@ -24,7 +24,8 @@ actor MuesliLiveActivityController {
         let attributes = MuesliLiveActivityAttributes(
             sessionID: session.id.uuidString,
             requestID: requestID?.uuidString,
-            kind: session.kind.title
+            kind: session.kind.title,
+            offersStopControl: session.kind.liveActivityOffersStopControl
         )
         let content = ActivityContent(
             state: contentState(phase: phase, detail: detail, session: session),

--- a/Muesli/MuesliLiveActivityController.swift
+++ b/Muesli/MuesliLiveActivityController.swift
@@ -6,12 +6,25 @@ actor MuesliLiveActivityController {
     private var endedSessionIDs = BoundedRecentSessionIDs(capacity: 256)
 
     func start(session: RecordingSession, requestID: UUID?, phase: String, detail: String) async {
-        guard !endedSessionIDs.contains(session.id) else { return }
+        guard !endedSessionIDs.contains(session.id) else {
+            KeyboardDiagnosticsLog.record("liveActivity.skipped", [
+                "kind": session.kind.title, "reason": "sessionAlreadyEnded"
+            ])
+            return
+        }
         guard MuesliPreferences.liveActivitiesEnabled(for: session.kind) else {
+            KeyboardDiagnosticsLog.record("liveActivity.skipped", [
+                "kind": session.kind.title, "reason": "disabledInSettings"
+            ])
             await endActivities(for: session.kind, phase: "Off", detail: "Live Activities disabled")
             return
         }
-        guard ActivityAuthorizationInfo().areActivitiesEnabled else { return }
+        guard ActivityAuthorizationInfo().areActivitiesEnabled else {
+            KeyboardDiagnosticsLog.record("liveActivity.skipped", [
+                "kind": session.kind.title, "reason": "disabledBySystem"
+            ])
+            return
+        }
 
         await endInactiveActivities()
         guard !endedSessionIDs.contains(session.id) else { return }
@@ -34,7 +47,15 @@ actor MuesliLiveActivityController {
 
         do {
             activity = try Activity.request(attributes: attributes, content: content, pushType: nil)
+            KeyboardDiagnosticsLog.record("liveActivity.started", ["kind": session.kind.title])
         } catch {
+            // iOS refuses Activity.request from a backgrounded app. A keyboard
+            // dictation starts while the host app is in front, so this is the
+            // expected failure if that restriction applies.
+            KeyboardDiagnosticsLog.record("liveActivity.failed", [
+                "kind": session.kind.title,
+                "error": String(describing: error)
+            ])
             await AppTelemetry.failure(
                 "live_activity_failed",
                 domain: .liveActivity,

--- a/MuesliKeyboard/KeyboardController.swift
+++ b/MuesliKeyboard/KeyboardController.swift
@@ -241,6 +241,13 @@ final class KeyboardController {
         }
 
         MuesliHaptics.dictationStart()
+        KeyboardDiagnosticsLog.record("intent.start", [
+            "canUseRuntimeStart": canUseRuntimeStart ? "yes" : "no",
+            "appPhase": latestRuntimeStatus?.phase.rawValue ?? "unknown",
+            "appSeenAt": latestRuntimeStatus.map {
+                String(format: "%.1fs", Date.now.timeIntervalSince($0.updatedAt))
+            } ?? "never"
+        ])
         let request = preparedRequest ?? DictationRequest()
         preparedRequest = nil
         recoveryRequestID = nil
@@ -288,6 +295,10 @@ final class KeyboardController {
         }
 
         MuesliHaptics.dictationStop()
+        KeyboardDiagnosticsLog.record("intent.stop", [
+            "request": String(activeRequestID.uuidString.prefix(8).lowercased()),
+            "localPhase": dictationPhase.rawValue
+        ])
         do {
             try store.saveKeyboardHandoffState(.init(
                 requestID: activeRequestID,
@@ -386,6 +397,7 @@ final class KeyboardController {
     }
 
     func startObservingSharedState() {
+        KeyboardDiagnosticsLog.record("keyboard.appeared")
         markKeyboardVisible()
         eventObservationTask?.cancel()
         let events = eventBus.events()
@@ -417,6 +429,10 @@ final class KeyboardController {
     }
 
     func stopObservingSharedState() {
+        KeyboardDiagnosticsLog.record("keyboard.disappeared", [
+            "localPhase": dictationPhase.rawValue,
+            "active": activeRequestID?.uuidString.prefix(8).lowercased() ?? "none"
+        ])
         eventObservationTask?.cancel()
         eventObservationTask = nil
         commandAcknowledgementTask?.cancel()
@@ -496,6 +512,20 @@ final class KeyboardController {
 
     private func apply(handoffState: KeyboardHandoffState) {
         guard let requestID = handoffState.requestID else { return }
+
+        // The handoff record is written by both processes with no ordering
+        // guarantee, so record what arrived and what we were already showing.
+        // A phase that moves backwards is visible here and nowhere else.
+        if latestHandoffState?.phase != handoffState.phase
+            || latestHandoffState?.requestID != handoffState.requestID {
+            KeyboardDiagnosticsLog.record("handoff.observed", [
+                "phase": handoffState.phase.rawValue,
+                "request": requestID.uuidString.prefix(8).lowercased(),
+                "localPhase": dictationPhase.rawValue,
+                "active": activeRequestID?.uuidString.prefix(8).lowercased() ?? "none",
+                "inserted": insertedRequestIDs.contains(requestID) ? "yes" : "no"
+            ])
+        }
 
         if ![.startRequested, .stopRequested, .cancelRequested].contains(handoffState.phase) {
             commandAcknowledgementTask?.cancel()
@@ -812,8 +842,35 @@ final class KeyboardController {
     }
 
     private func insertCompletedResult(_ result: DictationResult) {
-        guard !insertedRequestIDs.contains(result.requestID) else { return }
-        guard !cancelledRequestIDs.contains(result.requestID) else { return }
+        let shortID = result.requestID.uuidString.prefix(8).lowercased()
+
+        // These two guards correctly prevent a double insertion, but they
+        // return without reconciling dictationPhase or activeRequestID. If the
+        // keyboard is stranded mid-session, this is the line it is stranded on
+        // -- and until now it was completely silent.
+        guard !insertedRequestIDs.contains(result.requestID) else {
+            KeyboardDiagnosticsLog.record("insert.skipped", [
+                "reason": "alreadyInserted",
+                "request": String(shortID),
+                "localPhase": dictationPhase.rawValue,
+                "active": activeRequestID?.uuidString.prefix(8).lowercased() ?? "none"
+            ])
+            return
+        }
+        guard !cancelledRequestIDs.contains(result.requestID) else {
+            KeyboardDiagnosticsLog.record("insert.skipped", [
+                "reason": "cancelled",
+                "request": String(shortID),
+                "localPhase": dictationPhase.rawValue
+            ])
+            return
+        }
+
+        // Character count only -- never the text itself.
+        KeyboardDiagnosticsLog.record("insert.performed", [
+            "request": String(shortID),
+            "characters": String(result.text.count)
+        ])
         insertText(result.text)
         insertedRequestIDs.insert(result.requestID)
         latestResultID = result.id
@@ -849,12 +906,28 @@ final class KeyboardController {
             guard !Task.isCancelled, let self else { return }
             self.refreshLatestDictation()
             guard self.isAwaitingAcknowledgement(requestID: requestID, phase: requestedPhase) else { return }
+            // The app consumes a command without posting any notification, so
+            // the only way to detect a missed intent is to re-post and wait.
+            KeyboardDiagnosticsLog.record("ack.retry", [
+                "action": action.rawValue,
+                "request": String(requestID.uuidString.prefix(8).lowercased()),
+                "waited": "750ms"
+            ])
             eventBus.post(.commandChanged)
 
             try? await Task.sleep(for: .milliseconds(1_250))
             guard !Task.isCancelled else { return }
             self.refreshLatestDictation()
             guard self.isAwaitingAcknowledgement(requestID: requestID, phase: requestedPhase) else { return }
+
+            // Two sleeps elapsed with no state change: the app never serviced
+            // this intent. Usually it is not running.
+            KeyboardDiagnosticsLog.record("ack.timedOut", [
+                "action": action.rawValue,
+                "request": String(requestID.uuidString.prefix(8).lowercased()),
+                "waited": "2000ms",
+                "escalation": "recoveryRequested"
+            ])
 
             let urlAction: String
             let message: String

--- a/MuesliKeyboard/KeyboardController.swift
+++ b/MuesliKeyboard/KeyboardController.swift
@@ -21,6 +21,10 @@ final class KeyboardController {
     private var insertedRequestIDs = Set<UUID>()
     private var cancelledRequestIDs = Set<UUID>()
     private var isBlockedByAppVoiceNote = false
+    /// Tracked separately from `latestHandoffState`, which `refreshLatestDictation`
+    /// overwrites before `apply(handoffState:)` runs -- comparing against it
+    /// there always says "unchanged".
+    private var lastRecordedHandoff: (requestID: UUID, phase: KeyboardHandoffPhase)?
 
     var statusText = "Record a voice note first"
     var hasLatestDictation = false
@@ -516,8 +520,9 @@ final class KeyboardController {
         // The handoff record is written by both processes with no ordering
         // guarantee, so record what arrived and what we were already showing.
         // A phase that moves backwards is visible here and nowhere else.
-        if latestHandoffState?.phase != handoffState.phase
-            || latestHandoffState?.requestID != handoffState.requestID {
+        if lastRecordedHandoff?.phase != handoffState.phase
+            || lastRecordedHandoff?.requestID != requestID {
+            lastRecordedHandoff = (requestID, handoffState.phase)
             KeyboardDiagnosticsLog.record("handoff.observed", [
                 "phase": handoffState.phase.rawValue,
                 "request": requestID.uuidString.prefix(8).lowercased(),

--- a/MuesliKeyboard/KeyboardController.swift
+++ b/MuesliKeyboard/KeyboardController.swift
@@ -657,16 +657,24 @@ final class KeyboardController {
 
     private func apply(runtimeStatus: KeyboardRuntimeStatus?) {
         let now = Date()
-        // The keyboard is destroyed and rebuilt constantly -- locking the
-        // screen is enough -- and comes back with no adopted request until the
-        // handoff record is read again. Requiring a match discarded levels that
-        // were milliseconds old, collapsing every bar to zero, so the strip
-        // read as empty while the pill still said "Listening". An unadopted
-        // keyboard trusts whichever request the app says it is recording.
+        // The waveform draws live microphone input. It needs two facts and no
+        // bookkeeping: the app is recording, and a level arrived recently.
+        //
+        // This used to also require the level to name the request this keyboard
+        // had adopted. That match was added when the waveform was first switched
+        // on, not in response to any bug, and it caused one: iOS destroys and
+        // rebuilds the keyboard constantly, and a rebuilt one has adopted
+        // nothing, so levels milliseconds old were thrown away and every bar
+        // collapsed to zero while the pill still said "Listening".
+        //
+        // It is not what stops the keyboard rendering an in-app voice note's
+        // audio either. A recording the keyboard does not own blocks it
+        // outright and hides the waveform card -- see applyAppVoiceNoteOwnership.
+        //
+        // The freshness rule stays: when levels stop arriving the bars settle
+        // rather than freezing on the last sample.
         let hasFreshRecordingLevel = runtimeStatus.map {
-            $0.phase == .recording
-                && (activeRequestID == nil || $0.activeRequestID == activeRequestID)
-                && now.timeIntervalSince($0.updatedAt) < 2
+            $0.phase == .recording && now.timeIntervalSince($0.updatedAt) < 2
         } ?? false
         // A recording whose levels have gone stale collapses every waveform bar
         // to zero, so the strip looks empty while the pill still says

--- a/MuesliKeyboard/KeyboardController.swift
+++ b/MuesliKeyboard/KeyboardController.swift
@@ -25,6 +25,7 @@ final class KeyboardController {
     /// overwrites before `apply(handoffState:)` runs -- comparing against it
     /// there always says "unchanged".
     private var lastRecordedHandoff: (requestID: UUID, phase: KeyboardHandoffPhase)?
+    private var lastLevelFreshness: Bool?
 
     var statusText = "Record a voice note first"
     var hasLatestDictation = false
@@ -652,6 +653,18 @@ final class KeyboardController {
                 && $0.activeRequestID == activeRequestID
                 && now.timeIntervalSince($0.updatedAt) < 2
         } ?? false
+        // A recording whose levels have gone stale collapses every waveform bar
+        // to zero, so the strip looks empty while the pill still says
+        // "Listening". Record the transition, not every sample.
+        if runtimeStatus?.phase == .recording, hasFreshRecordingLevel != lastLevelFreshness {
+            lastLevelFreshness = hasFreshRecordingLevel
+            KeyboardDiagnosticsLog.record("level.freshness", [
+                "fresh": hasFreshRecordingLevel ? "yes" : "no",
+                "age": runtimeStatus.map { String(format: "%.1fs", now.timeIntervalSince($0.updatedAt)) } ?? "none",
+                "appPhase": runtimeStatus?.phase.rawValue ?? "none",
+                "matchesActive": runtimeStatus?.activeRequestID == activeRequestID ? "yes" : "no"
+            ])
+        }
         inputLevel = hasFreshRecordingLevel ? (runtimeStatus?.inputLevel ?? 0) : 0
         canUseRuntimeStart = runtimeStatus?.canAcceptStartCommand == true
 

--- a/MuesliKeyboard/KeyboardController.swift
+++ b/MuesliKeyboard/KeyboardController.swift
@@ -434,6 +434,15 @@ final class KeyboardController {
     }
 
     func stopObservingSharedState() {
+        // The waveform renders live microphone input. Off screen there is none,
+        // so holding the last level is wrong -- and the controller outlives a
+        // dismissal, so that stale level gets baked into the launch snapshot
+        // and replayed for a moment on the way back in. Settle it now; the
+        // refresh in prepareInitialPresentationState repopulates it from the
+        // app's published status if a recording is still running.
+        inputLevel = 0
+        liveTranscript = ""
+
         KeyboardDiagnosticsLog.record("keyboard.disappeared", [
             "localPhase": dictationPhase.rawValue,
             "active": activeRequestID?.uuidString.prefix(8).lowercased() ?? "none"

--- a/MuesliKeyboard/KeyboardController.swift
+++ b/MuesliKeyboard/KeyboardController.swift
@@ -648,9 +648,15 @@ final class KeyboardController {
 
     private func apply(runtimeStatus: KeyboardRuntimeStatus?) {
         let now = Date()
+        // The keyboard is destroyed and rebuilt constantly -- locking the
+        // screen is enough -- and comes back with no adopted request until the
+        // handoff record is read again. Requiring a match discarded levels that
+        // were milliseconds old, collapsing every bar to zero, so the strip
+        // read as empty while the pill still said "Listening". An unadopted
+        // keyboard trusts whichever request the app says it is recording.
         let hasFreshRecordingLevel = runtimeStatus.map {
             $0.phase == .recording
-                && $0.activeRequestID == activeRequestID
+                && (activeRequestID == nil || $0.activeRequestID == activeRequestID)
                 && now.timeIntervalSince($0.updatedAt) < 2
         } ?? false
         // A recording whose levels have gone stale collapses every waveform bar

--- a/MuesliLiveActivityExtension/MuesliRecordingLiveActivity.swift
+++ b/MuesliLiveActivityExtension/MuesliRecordingLiveActivity.swift
@@ -8,7 +8,7 @@ struct MuesliRecordingLiveActivity: Widget {
             LockScreenLiveActivityView(
                 state: context.state,
                 sessionID: context.attributes.sessionID,
-                showsStopControl: context.attributes.isMeeting
+                showsStopControl: context.attributes.showsStopControl
             )
                 .activityBackgroundTint(.black)
                 .activitySystemActionForegroundColor(.white)
@@ -34,7 +34,7 @@ struct MuesliRecordingLiveActivity: Widget {
                         Text(context.state.startedAt, style: .timer)
                             .font(.caption2.monospacedDigit())
                             .foregroundStyle(.secondary)
-                        if context.attributes.isMeeting {
+                        if context.attributes.showsStopControl {
                             StopMeetingButton(
                                 sessionID: context.attributes.sessionID,
                                 size: 34

--- a/MuesliLiveActivityExtension/MuesliRecordingLiveActivity.swift
+++ b/MuesliLiveActivityExtension/MuesliRecordingLiveActivity.swift
@@ -8,6 +8,7 @@ struct MuesliRecordingLiveActivity: Widget {
             LockScreenLiveActivityView(
                 state: context.state,
                 sessionID: context.attributes.sessionID,
+                kind: context.attributes.kind,
                 showsStopControl: context.attributes.showsStopControl
             )
                 .activityBackgroundTint(.black)
@@ -37,6 +38,7 @@ struct MuesliRecordingLiveActivity: Widget {
                         if context.attributes.showsStopControl {
                             StopMeetingButton(
                                 sessionID: context.attributes.sessionID,
+                                kind: context.attributes.kind,
                                 size: 34
                             )
                         }
@@ -71,6 +73,7 @@ struct MuesliRecordingLiveActivity: Widget {
 private struct LockScreenLiveActivityView: View {
     let state: MuesliLiveActivityAttributes.ContentState
     let sessionID: String
+    let kind: String
     let showsStopControl: Bool
 
     var body: some View {
@@ -95,7 +98,7 @@ private struct LockScreenLiveActivityView: View {
                 .foregroundStyle(.white.opacity(0.72))
 
             if showsStopControl {
-                StopMeetingButton(sessionID: sessionID, size: 46)
+                StopMeetingButton(sessionID: sessionID, kind: kind, size: 46)
             }
         }
         .padding()
@@ -104,6 +107,9 @@ private struct LockScreenLiveActivityView: View {
 
 private struct StopMeetingButton: View {
     let sessionID: String
+    /// The control is shared by every capture kind, so the spoken label has to
+    /// name what is actually being stopped. It used to always say "meeting".
+    let kind: String
     let size: CGFloat
 
     var body: some View {
@@ -115,7 +121,7 @@ private struct StopMeetingButton: View {
                 .background(.red.opacity(0.88), in: Circle())
         }
         .buttonStyle(.plain)
-        .accessibilityLabel("Stop meeting recording")
+        .accessibilityLabel("Stop \(kind.lowercased()) recording")
     }
 }
 

--- a/Shared/KeyboardDiagnosticsLog.swift
+++ b/Shared/KeyboardDiagnosticsLog.swift
@@ -52,9 +52,15 @@ enum KeyboardDiagnosticsLog {
     /// The buffer as text, oldest first, for export or a debug screen.
     static func exportText() -> String {
         queue.sync {
-            guard let url = fileURL(),
-                  let contents = try? String(contentsOf: url, encoding: .utf8) else {
-                return ""
+            guard let url = fileURL() else { return "" }
+            var contents = ""
+            var coordinationError: NSError?
+            NSFileCoordinator().coordinate(
+                readingItemAt: url,
+                options: .withoutChanges,
+                error: &coordinationError
+            ) { claimedURL in
+                contents = (try? String(contentsOf: claimedURL, encoding: .utf8)) ?? ""
             }
             return contents
         }
@@ -78,6 +84,11 @@ enum KeyboardDiagnosticsLog {
     /// Appends, then trims to the newest `entryLimit` lines. Rewriting a
     /// 200-line file is cheaper than the bookkeeping needed to avoid it, and
     /// this runs off the main thread.
+    ///
+    /// The read-modify-write is wrapped in an `NSFileCoordinator` write claim.
+    /// Without it, the app and the extension can read the same contents and
+    /// replace each other's line, dropping events precisely around the
+    /// cross-process handoffs this log exists to explain.
     private static func append(fields: [String], at date: Date) {
         guard let url = fileURL() else { return }
 
@@ -87,28 +98,40 @@ enum KeyboardDiagnosticsLog {
         formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
         let line = ([formatter.string(from: date)] + fields).joined(separator: "\t")
 
-        var lines = (try? String(contentsOf: url, encoding: .utf8))?
-            .split(separator: "\n", omittingEmptySubsequences: true)
-            .map(String.init) ?? []
+        // Created per access: NSFileCoordinator is not Sendable, and the queue
+        // above only orders writes within one process. The app and the keyboard
+        // extension both record here, and the interesting events are exactly
+        // the cross-process handoffs, so their writes must be ordered against
+        // each other too.
+        var coordinationError: NSError?
+        NSFileCoordinator().coordinate(
+            writingItemAt: url,
+            options: .forMerging,
+            error: &coordinationError
+        ) { claimedURL in
+            var lines = (try? String(contentsOf: claimedURL, encoding: .utf8))?
+                .split(separator: "\n", omittingEmptySubsequences: true)
+                .map(String.init) ?? []
 
-        lines.append(line)
-        if lines.count > entryLimit {
-            lines.removeFirst(lines.count - entryLimit)
+            lines.append(line)
+            if lines.count > entryLimit {
+                lines.removeFirst(lines.count - entryLimit)
+            }
+
+            // Written without file protection so the extension can still record
+            // while the device is locked -- the exact window where dictation
+            // failures have been hardest to explain. Safe because the contents
+            // are phases and identifiers, never user content.
+            try? (lines.joined(separator: "\n") + "\n").write(
+                to: claimedURL,
+                atomically: true,
+                encoding: .utf8
+            )
+            try? FileManager.default.setAttributes(
+                [.protectionKey: FileProtectionType.none],
+                ofItemAtPath: claimedURL.path
+            )
         }
-
-        // Written without file protection so the extension can still record
-        // while the device is locked -- the exact window where dictation
-        // failures have been hardest to explain. Safe because the contents are
-        // phases and identifiers, never user content.
-        try? (lines.joined(separator: "\n") + "\n").write(
-            to: url,
-            atomically: true,
-            encoding: .utf8
-        )
-        try? FileManager.default.setAttributes(
-            [.protectionKey: FileProtectionType.none],
-            ofItemAtPath: url.path
-        )
     }
 
     private static func sanitize(_ value: String) -> String {

--- a/Shared/KeyboardDiagnosticsLog.swift
+++ b/Shared/KeyboardDiagnosticsLog.swift
@@ -52,15 +52,9 @@ enum KeyboardDiagnosticsLog {
     /// The buffer as text, oldest first, for export or a debug screen.
     static func exportText() -> String {
         queue.sync {
-            guard let url = fileURL() else { return "" }
-            var contents = ""
-            var coordinationError: NSError?
-            NSFileCoordinator().coordinate(
-                readingItemAt: url,
-                options: .withoutChanges,
-                error: &coordinationError
-            ) { claimedURL in
-                contents = (try? String(contentsOf: claimedURL, encoding: .utf8)) ?? ""
+            guard let url = fileURL(),
+                  let contents = try? String(contentsOf: url, encoding: .utf8) else {
+                return ""
             }
             return contents
         }
@@ -84,11 +78,6 @@ enum KeyboardDiagnosticsLog {
     /// Appends, then trims to the newest `entryLimit` lines. Rewriting a
     /// 200-line file is cheaper than the bookkeeping needed to avoid it, and
     /// this runs off the main thread.
-    ///
-    /// The read-modify-write is wrapped in an `NSFileCoordinator` write claim.
-    /// Without it, the app and the extension can read the same contents and
-    /// replace each other's line, dropping events precisely around the
-    /// cross-process handoffs this log exists to explain.
     private static func append(fields: [String], at date: Date) {
         guard let url = fileURL() else { return }
 
@@ -98,40 +87,28 @@ enum KeyboardDiagnosticsLog {
         formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
         let line = ([formatter.string(from: date)] + fields).joined(separator: "\t")
 
-        // Created per access: NSFileCoordinator is not Sendable, and the queue
-        // above only orders writes within one process. The app and the keyboard
-        // extension both record here, and the interesting events are exactly
-        // the cross-process handoffs, so their writes must be ordered against
-        // each other too.
-        var coordinationError: NSError?
-        NSFileCoordinator().coordinate(
-            writingItemAt: url,
-            options: .forMerging,
-            error: &coordinationError
-        ) { claimedURL in
-            var lines = (try? String(contentsOf: claimedURL, encoding: .utf8))?
-                .split(separator: "\n", omittingEmptySubsequences: true)
-                .map(String.init) ?? []
+        var lines = (try? String(contentsOf: url, encoding: .utf8))?
+            .split(separator: "\n", omittingEmptySubsequences: true)
+            .map(String.init) ?? []
 
-            lines.append(line)
-            if lines.count > entryLimit {
-                lines.removeFirst(lines.count - entryLimit)
-            }
-
-            // Written without file protection so the extension can still record
-            // while the device is locked -- the exact window where dictation
-            // failures have been hardest to explain. Safe because the contents
-            // are phases and identifiers, never user content.
-            try? (lines.joined(separator: "\n") + "\n").write(
-                to: claimedURL,
-                atomically: true,
-                encoding: .utf8
-            )
-            try? FileManager.default.setAttributes(
-                [.protectionKey: FileProtectionType.none],
-                ofItemAtPath: claimedURL.path
-            )
+        lines.append(line)
+        if lines.count > entryLimit {
+            lines.removeFirst(lines.count - entryLimit)
         }
+
+        // Written without file protection so the extension can still record
+        // while the device is locked -- the exact window where dictation
+        // failures have been hardest to explain. Safe because the contents are
+        // phases and identifiers, never user content.
+        try? (lines.joined(separator: "\n") + "\n").write(
+            to: url,
+            atomically: true,
+            encoding: .utf8
+        )
+        try? FileManager.default.setAttributes(
+            [.protectionKey: FileProtectionType.none],
+            ofItemAtPath: url.path
+        )
     }
 
     private static func sanitize(_ value: String) -> String {

--- a/Shared/KeyboardDiagnosticsLog.swift
+++ b/Shared/KeyboardDiagnosticsLog.swift
@@ -1,0 +1,120 @@
+import Foundation
+import os
+
+/// A durable, bounded record of keyboard dictation state transitions.
+///
+/// The keyboard extension had no logging of any kind, so a stranded session
+/// left no trace: the only diagnostic available was a screenshot, and the cause
+/// had to be inferred from source. This records what actually happened, in
+/// order, and survives the extension being killed -- which iOS does often.
+///
+/// Two sinks:
+/// - `os_log`, for a tethered device (Console.app, `log stream`). Free, nothing
+///   stored.
+/// - a capped file in the app group, so a failure on a TestFlight build can be
+///   read after the fact rather than reproduced live.
+///
+/// **Never record transcript text.** Phases, identifiers, and timings only. A
+/// diagnostics buffer full of what people dictated is a liability the moment a
+/// tester pastes it into a chat.
+enum KeyboardDiagnosticsLog {
+    /// Roughly a few dictation sessions' worth of history -- enough to see how a
+    /// session got into a bad state, small enough to stay cheap to rewrite.
+    static let entryLimit = 200
+
+    private static let logger = Logger(
+        subsystem: MuesliAppConstants.appGroupIdentifier,
+        category: "keyboard-lifecycle"
+    )
+
+    private static let fileName = "keyboard-diagnostics.log"
+    private static let queue = DispatchQueue(label: "com.phequals7.muesli.keyboard-diagnostics")
+
+    /// Records one transition. `detail` values are truncated and must never
+    /// carry user content.
+    static func record(
+        _ event: String,
+        _ detail: [String: String] = [:],
+        process: String = ProcessInfo.processInfo.processName,
+        at date: Date = .now
+    ) {
+        let rendered = detail
+            .sorted { $0.key < $1.key }
+            .map { "\($0.key)=\(sanitize($0.value))" }
+            .joined(separator: " ")
+
+        logger.debug("\(event, privacy: .public) \(rendered, privacy: .public)")
+
+        let fields = [process, event, rendered].filter { !$0.isEmpty }
+        queue.async { append(fields: fields, at: date) }
+    }
+
+    /// The buffer as text, oldest first, for export or a debug screen.
+    static func exportText() -> String {
+        queue.sync {
+            guard let url = fileURL(),
+                  let contents = try? String(contentsOf: url, encoding: .utf8) else {
+                return ""
+            }
+            return contents
+        }
+    }
+
+    static func clear() {
+        queue.sync {
+            guard let url = fileURL() else { return }
+            try? FileManager.default.removeItem(at: url)
+        }
+    }
+
+    // MARK: - Storage
+
+    private static func fileURL() -> URL? {
+        FileManager.default
+            .containerURL(forSecurityApplicationGroupIdentifier: MuesliAppConstants.appGroupIdentifier)?
+            .appendingPathComponent(fileName)
+    }
+
+    /// Appends, then trims to the newest `entryLimit` lines. Rewriting a
+    /// 200-line file is cheaper than the bookkeeping needed to avoid it, and
+    /// this runs off the main thread.
+    private static func append(fields: [String], at date: Date) {
+        guard let url = fileURL() else { return }
+
+        // Built here rather than held as shared state: ISO8601DateFormatter is
+        // not Sendable, and this is the only context that touches it.
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let line = ([formatter.string(from: date)] + fields).joined(separator: "\t")
+
+        var lines = (try? String(contentsOf: url, encoding: .utf8))?
+            .split(separator: "\n", omittingEmptySubsequences: true)
+            .map(String.init) ?? []
+
+        lines.append(line)
+        if lines.count > entryLimit {
+            lines.removeFirst(lines.count - entryLimit)
+        }
+
+        // Written without file protection so the extension can still record
+        // while the device is locked -- the exact window where dictation
+        // failures have been hardest to explain. Safe because the contents are
+        // phases and identifiers, never user content.
+        try? (lines.joined(separator: "\n") + "\n").write(
+            to: url,
+            atomically: true,
+            encoding: .utf8
+        )
+        try? FileManager.default.setAttributes(
+            [.protectionKey: FileProtectionType.none],
+            ofItemAtPath: url.path
+        )
+    }
+
+    private static func sanitize(_ value: String) -> String {
+        let collapsed = value
+            .replacingOccurrences(of: "\n", with: " ")
+            .replacingOccurrences(of: "\t", with: " ")
+        return collapsed.count <= 64 ? collapsed : String(collapsed.prefix(64)) + "..."
+    }
+}

--- a/Shared/RecordingSessionCapabilities.swift
+++ b/Shared/RecordingSessionCapabilities.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+/// What each kind of capture is allowed to do.
+///
+/// `RecordingSessionKind` existed but was almost never consulted -- two
+/// branches in the whole coordinator -- so keyboard dictation and app-initiated
+/// voice notes silently shared behaviour that only suits one of them. These are
+/// deliberately declared in one place, per kind, so a difference between the
+/// two constructs is a value here rather than an `if` somewhere in a
+/// six-thousand-line file.
+///
+/// Adding a case to `RecordingSessionKind` fails to compile until every
+/// capability below has an answer for it.
+extension RecordingSessionKind {
+    /// Whether sustained capture is promoted to long-form treatment:
+    /// checkpoint progress, durability messaging, the "Long voice note" phase.
+    ///
+    /// A keyboard dictation is a request for text to type. The user is waiting
+    /// with a text field open, and the surfaces long-form mode drives -- the
+    /// recorder card, the timeline row -- are not on screen.
+    var supportsLongFormCapture: Bool {
+        switch self {
+        case .quickDictation, .meeting:
+            true
+        case .keyboardDictation:
+            // Currently true in practice; DictationCoordinator promotes
+            // keyboard sessions to "Long voice note". Left as-is here so this
+            // type introduces no behaviour change, and can be flipped
+            // deliberately.
+            true
+        }
+    }
+
+    /// Whether the Live Activity carries a stop control.
+    ///
+    /// Meetings run unattended for a long time, so stopping from the Lock
+    /// Screen matters. Requires an App Intent that can stop *this* kind of
+    /// capture -- see `StopMeetingRecordingIntent`.
+    var liveActivityOffersStopControl: Bool {
+        switch self {
+        case .meeting:
+            true
+        case .quickDictation, .keyboardDictation:
+            false
+        }
+    }
+
+    /// Whether the Live Activity exists only for as long as audio is actually
+    /// being captured.
+    ///
+    /// Keyboard dictation currently binds its Live Activity to the keyboard
+    /// *session* being armed rather than to capture, which is why it can
+    /// outlive the recording it describes.
+    var liveActivityFollowsCaptureLifetime: Bool {
+        switch self {
+        case .quickDictation, .meeting:
+            true
+        case .keyboardDictation:
+            false
+        }
+    }
+}

--- a/Shared/RecordingSessionCapabilities.swift
+++ b/Shared/RecordingSessionCapabilities.swift
@@ -38,9 +38,14 @@ extension RecordingSessionKind {
     /// capture -- see `StopMeetingRecordingIntent`.
     var liveActivityOffersStopControl: Bool {
         switch self {
-        case .meeting:
+        case .meeting, .keyboardDictation:
+            // Both run with Muesli's own UI off screen -- a meeting because it
+            // is unattended, a keyboard dictation because the host app is in
+            // front. The Live Activity is the only stop control the user has.
             true
-        case .quickDictation, .keyboardDictation:
+        case .quickDictation:
+            // Started from Muesli's own recorder, which is on screen with a
+            // stop button already.
             false
         }
     }

--- a/Shared/RecordingSessionCapabilities.swift
+++ b/Shared/RecordingSessionCapabilities.swift
@@ -48,15 +48,13 @@ extension RecordingSessionKind {
     /// Whether the Live Activity exists only for as long as audio is actually
     /// being captured.
     ///
-    /// Keyboard dictation currently binds its Live Activity to the keyboard
-    /// *session* being armed rather than to capture, which is why it can
-    /// outlive the recording it describes.
+    /// True for every kind. Keyboard dictation previously bound its Live
+    /// Activity to keep-mic-on being armed, so a bar appeared when the keyboard
+    /// merely became ready and stayed up with nothing recording.
     var liveActivityFollowsCaptureLifetime: Bool {
         switch self {
-        case .quickDictation, .meeting:
+        case .quickDictation, .meeting, .keyboardDictation:
             true
-        case .keyboardDictation:
-            false
         }
     }
 }

--- a/Shared/SharedStore.swift
+++ b/Shared/SharedStore.swift
@@ -382,10 +382,24 @@ struct SharedStore: Sendable {
     /// has actually happened, so a cleanup is only built if it is needed.
     func audioFileAudit() throws -> (onDisk: Int, owned: Int, orphaned: Int) {
         let directory = try recordingsDirectoryURL()
-        let names = try FileManager.default
-            .contentsOfDirectory(atPath: directory.path)
-            .filter { !$0.hasPrefix(".") }
-        let onDisk = Set(names)
+        // Files only, and only audio. The recordings folder also holds the
+        // VoiceNoteCheckpoints directory, which matches no session's
+        // audioFileName and was being counted as an orphan.
+        let audioExtensions: Set<String> = ["wav", "caf", "m4a"]
+        let onDisk = Set(
+            try FileManager.default
+                .contentsOfDirectory(
+                    at: directory,
+                    includingPropertiesForKeys: [.isDirectoryKey],
+                    options: [.skipsHiddenFiles]
+                )
+                .filter { url in
+                    let isDirectory = (try? url.resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory
+                    return isDirectory != true
+                        && audioExtensions.contains(url.pathExtension.lowercased())
+                }
+                .map(\.lastPathComponent)
+        )
         let claimed = Set(try recordingSessions().compactMap(\.audioFileName))
         let owned = onDisk.intersection(claimed)
         return (onDisk.count, owned.count, onDisk.subtracting(claimed).count)

--- a/Shared/SharedStore.swift
+++ b/Shared/SharedStore.swift
@@ -374,6 +374,23 @@ struct SharedStore: Sendable {
         try SharedStoreDatabase(containerURL: containerURL(), encoder: encoder, decoder: decoder)
     }
 
+    /// Counts audio files on disk against the sessions that claim to own one.
+    ///
+    /// Deleting a voice note removes a file and a database row, and there is no
+    /// way to do both as one all-or-nothing operation. A failure between the
+    /// two leaves an audio file nothing points at. This reports whether that
+    /// has actually happened, so a cleanup is only built if it is needed.
+    func audioFileAudit() throws -> (onDisk: Int, owned: Int, orphaned: Int) {
+        let directory = try recordingsDirectoryURL()
+        let names = try FileManager.default
+            .contentsOfDirectory(atPath: directory.path)
+            .filter { !$0.hasPrefix(".") }
+        let onDisk = Set(names)
+        let claimed = Set(try recordingSessions().compactMap(\.audioFileName))
+        let owned = onDisk.intersection(claimed)
+        return (onDisk.count, owned.count, onDisk.subtracting(claimed).count)
+    }
+
     private func recordingsDirectoryURL() throws -> URL {
         let directory = try containerURL().appendingPathComponent("Recordings", isDirectory: true)
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)

--- a/Tests/MuesliTests/KeyboardControllerTests.swift
+++ b/Tests/MuesliTests/KeyboardControllerTests.swift
@@ -1,0 +1,217 @@
+import XCTest
+@testable import Muesli
+
+/// First unit coverage for the keyboard extension.
+///
+/// `MuesliKeyboard/` was compiled into no test target, so every keyboard
+/// regression was device-only. That gap is why a branch could pass its whole
+/// suite and still ship a keyboard that would not start dictation.
+///
+/// These drive `KeyboardController` the way the extension does -- by writing
+/// shared state and refreshing -- rather than by calling private helpers, so
+/// they exercise the same cross-process path the real keyboard takes.
+@MainActor
+final class KeyboardControllerTests: XCTestCase {
+    private var directory: URL!
+    private var store: SharedStore!
+    private var bus: StubEventBus!
+    private var controller: KeyboardController!
+    private var insertedText: [String] = []
+
+    private let requestID = UUID()
+
+    override func setUp() async throws {
+        try await super.setUp()
+        directory = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("keyboard-controller-tests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        bus = StubEventBus()
+        store = SharedStore(containerURL: directory, eventPoster: bus)
+        controller = KeyboardController(store: store, eventBus: bus)
+        insertedText = []
+        controller.textInserter = { [weak self] text in self?.insertedText.append(text) }
+    }
+
+    override func tearDown() async throws {
+        controller = nil
+        store = nil
+        bus = nil
+        if let directory { try? FileManager.default.removeItem(at: directory) }
+        try await super.tearDown()
+    }
+
+    // MARK: - Helpers
+
+    private func recordingStatus(
+        level: Double,
+        request: UUID? = nil,
+        age: TimeInterval = 0
+    ) -> KeyboardRuntimeStatus {
+        KeyboardRuntimeStatus(
+            isActive: true,
+            activeRequestID: request ?? requestID,
+            phase: .recording,
+            supportsBackgroundStart: true,
+            inputLevel: level,
+            updatedAt: Date().addingTimeInterval(-age)
+        )
+    }
+
+    private func handoff(_ phase: KeyboardHandoffPhase) -> KeyboardHandoffState {
+        KeyboardHandoffState(requestID: requestID, phase: phase)
+    }
+
+    // MARK: - Waveform
+
+    /// iOS destroys and rebuilds the keyboard constantly -- three times inside
+    /// one thirty-second dictation, per device diagnostics. A rebuilt keyboard
+    /// has adopted no request yet, and previously that made it discard levels
+    /// that were fractions of a second old, collapsing every bar to zero while
+    /// the pill still said "Listening".
+    func testARebuiltKeyboardStillRendersTheWaveform() throws {
+        try store.saveKeyboardRuntimeStatus(recordingStatus(level: 0.62))
+        try store.saveKeyboardHandoffState(handoff(.recordingStarted))
+
+        controller.prepareInitialPresentationState()
+
+        XCTAssertEqual(controller.dictationPhase, .recording)
+        XCTAssertEqual(controller.inputLevel, 0.62, accuracy: 0.001)
+        XCTAssertTrue(controller.showsActiveWaveform)
+    }
+
+    /// The freshness rule still has to hold: a recording whose levels stopped
+    /// arriving is stalled, and the bars should settle rather than freeze on
+    /// whatever arrived last.
+    func testAStalledRecordingSettlesTheWaveform() throws {
+        try store.saveKeyboardRuntimeStatus(recordingStatus(level: 0.62, age: 5))
+        try store.saveKeyboardHandoffState(handoff(.recordingStarted))
+
+        controller.prepareInitialPresentationState()
+
+        XCTAssertEqual(controller.inputLevel, 0)
+    }
+
+    /// A level published for a different recording is not this one's input.
+    func testLevelsFromAnotherRequestAreIgnoredOnceAdopted() throws {
+        try store.saveKeyboardRuntimeStatus(recordingStatus(level: 0.62))
+        try store.saveKeyboardHandoffState(handoff(.recordingStarted))
+        controller.prepareInitialPresentationState()
+        XCTAssertEqual(controller.inputLevel, 0.62, accuracy: 0.001)
+
+        // Same keyboard, now a different session is recording.
+        try store.saveKeyboardRuntimeStatus(recordingStatus(level: 0.9, request: UUID()))
+        controller.prepareInitialPresentationState()
+
+        XCTAssertEqual(controller.inputLevel, 0)
+    }
+
+    /// The controller outlives a dismissal, so a retained level was replayed
+    /// through the launch snapshot on the way back in.
+    func testDismissalSettlesLiveInput() throws {
+        try store.saveKeyboardRuntimeStatus(recordingStatus(level: 0.62))
+        try store.saveKeyboardHandoffState(handoff(.recordingStarted))
+        controller.prepareInitialPresentationState()
+        XCTAssertEqual(controller.inputLevel, 0.62, accuracy: 0.001)
+
+        controller.stopObservingSharedState()
+
+        XCTAssertEqual(controller.inputLevel, 0)
+        XCTAssertEqual(controller.liveTranscript, "")
+    }
+
+    // MARK: - Terminal states
+
+    func testAnInsertedSessionLeavesNoActiveCard() throws {
+        try store.saveKeyboardHandoffState(handoff(.inserted))
+
+        controller.prepareInitialPresentationState()
+
+        XCTAssertEqual(controller.dictationPhase, .idle)
+        XCTAssertFalse(controller.showsActiveWaveform)
+        XCTAssertFalse(controller.canCancelActiveDictation)
+    }
+
+    func testACancelledSessionLeavesNoActiveCard() throws {
+        try store.saveKeyboardHandoffState(handoff(.cancelled))
+
+        controller.prepareInitialPresentationState()
+
+        XCTAssertEqual(controller.dictationPhase, .idle)
+        XCTAssertFalse(controller.showsActiveWaveform)
+    }
+
+    // MARK: - Insertion
+
+    func testACompletedResultIsInsertedOnce() throws {
+        let result = DictationResult(requestID: requestID, text: "hello there", engineIdentifier: "test")
+        try store.saveResult(result)
+        try store.saveKeyboardHandoffState(handoff(.resultReady))
+
+        controller.prepareInitialPresentationState()
+        XCTAssertEqual(insertedText, ["hello there"])
+
+        // A second refresh must not paste the same transcript again.
+        controller.prepareInitialPresentationState()
+        XCTAssertEqual(insertedText, ["hello there"])
+    }
+
+    /// Known defect, pinned rather than left undocumented.
+    ///
+    /// Both processes write `keyboard_handoff_state` with no sequence number,
+    /// and `KeyboardHandoffState.advanced(to:)` performs no ordering check. So
+    /// a late `.resultReady` from the app can land after the extension has
+    /// already written `.inserted`, regressing a terminal phase. The extension
+    /// re-adopts the request it just finished, `insertCompletedResult` returns
+    /// early on its idempotency latch without reconciling, and the keyboard
+    /// strands on "Transcribing" with its primary button disabled.
+    ///
+    /// This is the defect behind the original bug report. It is unfixed on
+    /// `main`; fixing it needs monotonic transitions at the storage layer.
+    /// When that lands this test fails as an unexpected pass -- delete the
+    /// `XCTExpectFailure` then.
+    func testLateResultReadyStrandsTheKeyboard() throws {
+        let result = DictationResult(requestID: requestID, text: "already sent", engineIdentifier: "test")
+        try store.saveResult(result)
+        try store.saveKeyboardHandoffState(handoff(.resultReady))
+        controller.prepareInitialPresentationState()
+        XCTAssertEqual(insertedText, ["already sent"])
+        XCTAssertEqual(controller.dictationPhase, .idle)
+
+        // The app, still inside an await gap, writes .resultReady for a request
+        // the keyboard has already inserted and marked .inserted.
+        try store.saveKeyboardHandoffState(handoff(.resultReady))
+
+        XCTExpectFailure("Terminal handoff phases are not yet monotonic; see Context/findings-2026-07-26") {
+            controller.prepareInitialPresentationState()
+            XCTAssertEqual(
+                controller.dictationPhase,
+                .idle,
+                "text was already inserted, so the keyboard must not return to a working state"
+            )
+            XCTAssertFalse(controller.isPrimaryButtonDisabled, "the user cannot start another dictation")
+        }
+    }
+}
+
+private final class StubEventBus: CrossProcessEventStreaming, @unchecked Sendable {
+    private let lock = NSLock()
+    private var storage: [CrossProcessEvent] = []
+
+    var postedEvents: [CrossProcessEvent] {
+        lock.lock()
+        defer { lock.unlock() }
+        return storage
+    }
+
+    func post(_ event: CrossProcessEvent) {
+        lock.lock()
+        storage.append(event)
+        lock.unlock()
+    }
+
+    /// Never yields: these tests drive refreshes explicitly so assertions are
+    /// deterministic rather than racing a notification.
+    func events() -> AsyncStream<CrossProcessEvent> {
+        AsyncStream { _ in }
+    }
+}

--- a/Tests/MuesliTests/KeyboardControllerTests.swift
+++ b/Tests/MuesliTests/KeyboardControllerTests.swift
@@ -91,18 +91,24 @@ final class KeyboardControllerTests: XCTestCase {
         XCTAssertEqual(controller.inputLevel, 0)
     }
 
-    /// A level published for a different recording is not this one's input.
-    func testLevelsFromAnotherRequestAreIgnoredOnceAdopted() throws {
+    /// The waveform follows whatever the app is recording, without checking
+    /// that the level names the request this keyboard adopted.
+    ///
+    /// That match used to be required. It was not protecting anything: a
+    /// recording the keyboard does not own blocks the keyboard and hides the
+    /// waveform card entirely, so there is no path where a foreign level is
+    /// drawn. What it did do was blank the waveform every time iOS rebuilt the
+    /// keyboard, because a rebuilt one has adopted no request yet.
+    func testTheWaveformFollowsWhateverTheAppIsRecording() throws {
         try store.saveKeyboardRuntimeStatus(recordingStatus(level: 0.62))
         try store.saveKeyboardHandoffState(handoff(.recordingStarted))
         controller.prepareInitialPresentationState()
         XCTAssertEqual(controller.inputLevel, 0.62, accuracy: 0.001)
 
-        // Same keyboard, now a different session is recording.
         try store.saveKeyboardRuntimeStatus(recordingStatus(level: 0.9, request: UUID()))
         controller.prepareInitialPresentationState()
 
-        XCTAssertEqual(controller.inputLevel, 0)
+        XCTAssertEqual(controller.inputLevel, 0.9, accuracy: 0.001)
     }
 
     /// The controller outlives a dismissal, so a retained level was replayed

--- a/Tests/MuesliTests/RecordingSessionCapabilitiesTests.swift
+++ b/Tests/MuesliTests/RecordingSessionCapabilitiesTests.swift
@@ -1,0 +1,82 @@
+import XCTest
+@testable import Muesli
+
+/// Keyboard dictation and app-initiated voice notes are different constructs
+/// that had been sharing behaviour by default. These pin the differences so
+/// re-merging them takes a deliberate edit here, with a failing test to explain
+/// what it changes.
+final class RecordingSessionCapabilitiesTests: XCTestCase {
+    func testEveryKindDeclaresEveryCapability() {
+        // RecordingSessionKind is CaseIterable and the capabilities are
+        // exhaustive switches, so this fails to compile -- not at runtime --
+        // if a kind is added without deciding what it can do.
+        for kind in RecordingSessionKind.allCases {
+            _ = kind.supportsLongFormCapture
+            _ = kind.liveActivityOffersStopControl
+            _ = kind.liveActivityFollowsCaptureLifetime
+        }
+        XCTAssertEqual(RecordingSessionKind.allCases.count, 3)
+    }
+
+    /// A meeting runs unattended for a long time, so stopping it from the Lock
+    /// Screen matters. A quick dictation is over in seconds with the app open.
+    func testOnlyMeetingsCarryAStopControlToday() {
+        XCTAssertTrue(RecordingSessionKind.meeting.liveActivityOffersStopControl)
+        XCTAssertFalse(RecordingSessionKind.quickDictation.liveActivityOffersStopControl)
+        XCTAssertFalse(RecordingSessionKind.keyboardDictation.liveActivityOffersStopControl)
+    }
+
+    /// Pins the defect: the keyboard's Live Activity is bound to the keyboard
+    /// session being armed rather than to capture, so it can outlive the
+    /// recording it describes.
+    func testKeyboardLiveActivityIsNotYetBoundToCapture() {
+        XCTAssertFalse(RecordingSessionKind.keyboardDictation.liveActivityFollowsCaptureLifetime)
+        XCTAssertTrue(RecordingSessionKind.quickDictation.liveActivityFollowsCaptureLifetime)
+        XCTAssertTrue(RecordingSessionKind.meeting.liveActivityFollowsCaptureLifetime)
+    }
+
+    func testLongFormTreatmentStillAppliesToKeyboardDictation() {
+        // Current behaviour, recorded rather than endorsed: the coordinator
+        // promotes keyboard sessions to "Long voice note" like any other.
+        XCTAssertTrue(RecordingSessionKind.keyboardDictation.supportsLongFormCapture)
+    }
+
+    /// The widget target cannot see RecordingSessionKind, so capabilities have
+    /// to survive the trip through the attributes rather than being re-derived
+    /// from a display string on the far side.
+    func testCapabilitiesSurviveTheTripToTheWidget() {
+        for kind in RecordingSessionKind.allCases {
+            let attributes = MuesliLiveActivityAttributes(
+                sessionID: UUID().uuidString,
+                requestID: nil,
+                kind: kind.title,
+                offersStopControl: kind.liveActivityOffersStopControl
+            )
+            XCTAssertEqual(
+                attributes.showsStopControl,
+                kind.liveActivityOffersStopControl,
+                "\(kind.title) lost its stop-control capability in transit"
+            )
+        }
+    }
+
+    /// An activity started by an earlier build has no capability field. It must
+    /// still render the way it did when it was started.
+    func testActivitiesFromEarlierBuildsStillRender() {
+        let legacyMeeting = MuesliLiveActivityAttributes(
+            sessionID: UUID().uuidString,
+            requestID: nil,
+            kind: MuesliLiveActivityAttributes.meetingKind,
+            offersStopControl: nil
+        )
+        XCTAssertTrue(legacyMeeting.showsStopControl)
+
+        let legacyKeyboard = MuesliLiveActivityAttributes(
+            sessionID: UUID().uuidString,
+            requestID: nil,
+            kind: RecordingSessionKind.keyboardDictation.title,
+            offersStopControl: nil
+        )
+        XCTAssertFalse(legacyKeyboard.showsStopControl)
+    }
+}

--- a/Tests/MuesliTests/RecordingSessionCapabilitiesTests.swift
+++ b/Tests/MuesliTests/RecordingSessionCapabilitiesTests.swift
@@ -18,12 +18,13 @@ final class RecordingSessionCapabilitiesTests: XCTestCase {
         XCTAssertEqual(RecordingSessionKind.allCases.count, 3)
     }
 
-    /// A meeting runs unattended for a long time, so stopping it from the Lock
-    /// Screen matters. A quick dictation is over in seconds with the app open.
-    func testOnlyMeetingsCarryAStopControlToday() {
+    /// Captures that run with Muesli's own UI off screen need a stop control on
+    /// the Live Activity, because it is the only one the user can reach. A
+    /// quick dictation has the app's recorder in front of it already.
+    func testCapturesWithNoOnScreenStopOfferOneOnTheLiveActivity() {
         XCTAssertTrue(RecordingSessionKind.meeting.liveActivityOffersStopControl)
+        XCTAssertTrue(RecordingSessionKind.keyboardDictation.liveActivityOffersStopControl)
         XCTAssertFalse(RecordingSessionKind.quickDictation.liveActivityOffersStopControl)
-        XCTAssertFalse(RecordingSessionKind.keyboardDictation.liveActivityOffersStopControl)
     }
 
     /// A Live Activity describes a recording in progress. No kind may show one

--- a/Tests/MuesliTests/RecordingSessionCapabilitiesTests.swift
+++ b/Tests/MuesliTests/RecordingSessionCapabilitiesTests.swift
@@ -26,13 +26,16 @@ final class RecordingSessionCapabilitiesTests: XCTestCase {
         XCTAssertFalse(RecordingSessionKind.keyboardDictation.liveActivityOffersStopControl)
     }
 
-    /// Pins the defect: the keyboard's Live Activity is bound to the keyboard
-    /// session being armed rather than to capture, so it can outlive the
-    /// recording it describes.
-    func testKeyboardLiveActivityIsNotYetBoundToCapture() {
-        XCTAssertFalse(RecordingSessionKind.keyboardDictation.liveActivityFollowsCaptureLifetime)
-        XCTAssertTrue(RecordingSessionKind.quickDictation.liveActivityFollowsCaptureLifetime)
-        XCTAssertTrue(RecordingSessionKind.meeting.liveActivityFollowsCaptureLifetime)
+    /// A Live Activity describes a recording in progress. No kind may show one
+    /// for merely being ready to record -- which is what keyboard dictation did
+    /// while keep-mic-on was armed.
+    func testNoKindShowsALiveActivityWithoutCapture() {
+        for kind in RecordingSessionKind.allCases {
+            XCTAssertTrue(
+                kind.liveActivityFollowsCaptureLifetime,
+                "\(kind.title) can show a Live Activity with nothing recording"
+            )
+        }
     }
 
     func testLongFormTreatmentStillAppliesToKeyboardDictation() {

--- a/project.yml
+++ b/project.yml
@@ -90,6 +90,16 @@ targets:
     sources:
       - path: Tests/MuesliTests
       - path: Shared
+      # Compiled in so the keyboard extension is unit-testable at all. Without
+      # this, nothing in MuesliKeyboard/ has any coverage and every keyboard
+      # regression can only be caught on a device.
+      - path: MuesliKeyboard
+        excludes:
+          # UIInputViewController host: needs a real keyboard extension context.
+          - "KeyboardViewController.swift"
+          - "Info.plist"
+          - "PrivacyInfo.xcprivacy"
+          - "MuesliKeyboard.entitlements"
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.phequals7.muesli.ios.tests
@@ -121,6 +131,10 @@ schemes:
       config: Debug
     test:
       config: Debug
+      gatherCoverageData: true
+      coverageTargets:
+        - MuesliTests
+        - Muesli
       targets:
         - MuesliTests
         - MuesliUITests

--- a/scripts/coverage-summary.py
+++ b/scripts/coverage-summary.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Summarise an xcresult coverage report as Markdown.
+
+Usage: coverage-summary.py <coverage.json> [--fail-under-watched N]
+
+Reads the JSON produced by `xcrun xccov view --report --json` and prints a
+Markdown summary suitable for a GitHub step summary.
+
+The watched list is the cross-process surface: files where a regression is
+invisible until it reaches a physical device, because the failure is a
+disagreement between the app and the keyboard extension rather than a crash.
+"""
+
+import argparse
+import json
+import sys
+
+WATCHED = [
+    "KeyboardController.swift",
+    "KeyboardDiagnosticsLog.swift",
+    "RecordingSessionCapabilities.swift",
+    "DictationModels.swift",
+    "SharedStore.swift",
+    "VoiceNoteTimeline.swift",
+]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("report")
+    parser.add_argument(
+        "--fail-under-watched",
+        type=float,
+        default=None,
+        help="Exit non-zero if any watched file falls below this percentage.",
+    )
+    args = parser.parse_args()
+
+    with open(args.report) as handle:
+        report = json.load(handle)
+
+    print("## Code coverage\n")
+    print("| Target | Coverage |")
+    print("|---|---:|")
+    for target in report.get("targets", []):
+        print(f"| {target['name']} | {target['lineCoverage'] * 100:.1f}% |")
+
+    # A file can appear under more than one target; keep the best-covered copy,
+    # since the keyboard sources are compiled into the test bundle as well.
+    best: dict[str, dict] = {}
+    for target in report.get("targets", []):
+        for entry in target.get("files", []):
+            name = entry["name"]
+            if name not in WATCHED:
+                continue
+            if name not in best or entry["lineCoverage"] > best[name]["lineCoverage"]:
+                best[name] = entry
+
+    print("\n### Watched files\n")
+    print("| File | Coverage | Lines |")
+    print("|---|---:|---:|")
+    for name in WATCHED:
+        entry = best.get(name)
+        if entry is None:
+            print(f"| {name} | _not reported_ | — |")
+            continue
+        percent = entry["lineCoverage"] * 100
+        print(f"| {name} | {percent:.1f}% | {entry['coveredLines']}/{entry['executableLines']} |")
+
+    if args.fail_under_watched is None:
+        return 0
+
+    below = [
+        (name, best[name]["lineCoverage"] * 100)
+        for name in WATCHED
+        if name in best and best[name]["lineCoverage"] * 100 < args.fail_under_watched
+    ]
+    if below:
+        print(f"\n**Below the {args.fail_under_watched:.0f}% floor:**\n")
+        for name, percent in below:
+            print(f"- {name}: {percent:.1f}%")
+        for name, percent in below:
+            print(f"{name} at {percent:.1f}% is below the floor", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Small, verified changes to keyboard dictation, built on `main` after two larger rewrite attempts were abandoned. Every commit was deployed to a physical device and exercised before the next one was written.

## Why this shape

Two branches tried to rewrite the transcription lifecycle: `codex/keyboard-lock-recovery` (#25, 6,593 lines, closed) and `codex/transcription-lifecycle-v2` (4,898 lines, abandoned). Neither was verified end-to-end on device. Deploying the second one produced a keyboard that would not start dictation at all, while its 217 unit tests passed.

The reason that was possible: **`MuesliKeyboard/` has no test target.** `MuesliTests` compiles `Tests/MuesliTests` + `Shared` only, so `KeyboardController` cannot be unit-tested. Every keyboard regression is device-only, and the extension had **zero logging**, so a failure left no trace at all — the highest-fidelity diagnostic available was a screenshot.

So this branch starts with instrumentation and keeps each change small enough to verify.

## What is here

**Diagnostics (commits 1–2).** `KeyboardDiagnosticsLog` — `os_log` plus a 200-entry file in the app group, exportable from Settings → About. Records handoff transitions, insertion (including the silent early-returns), start/stop intents, acknowledgement timeouts, and the extension's own appear/disappear. Transitions only: phases, truncated request IDs, timings, and a character count. **Never transcript text.**

It earned its keep immediately. It caught a bug in itself (`handoff.observed` never fired, because `refreshLatestDictation` assigns `latestHandoffState` before `apply(handoffState:)` reads it), and then answered two device questions in one line each that had otherwise cost hours of guessing.

**Capture-kind separation (commits 3–4).** `RecordingSessionKind` existed but the coordinator branched on it in two places, so keyboard dictations and app-initiated voice notes shared behaviour by default. Differences are now declared once per kind as exhaustive switches. Also removes a cross-process string comparison: the widget decided whether to show a stop control by comparing a display title against the literal `"Meeting"`.

Commit 4 renames `usesKeyboardSessionLiveActivity`, which decided two unrelated things — whether capture runs through the keep-mic-on session keeper, and which Live Activity to use. That conflation is the next bug.

**Live Activity (commits 5–6).** `startKeyboardSessionMode` built a synthetic `"Keyboard Session"` and started a Live Activity reading *"Ready — Keyboard voice note session active"* the moment keep-mic-on armed, with nothing recording, ending only when the keyboard session did. Keyboard dictation now uses the same per-recording activity as every other capture. **Achieved by deletion: −92 lines.** Two fixes fell out — completion and failure previously parked the activity on "Ready" instead of ending it.

Adds a stop control, reusing `StopMeetingRecordingIntent` rather than writing a second one; it already carried only a session ID, so only the handler needed to learn that not every stoppable session is a meeting. A keyboard dictation runs with the host app in front, so the Live Activity is the only stop control the user can reach.

**Waveform (commits 7–9).** Two device-reported bugs, both diagnosed from the log rather than guessed:

- Levels were discarded whenever the app's published `activeRequestID` did not match the keyboard's. The extension is destroyed and rebuilt constantly — three times inside one 30-second dictation — and returns with nothing adopted, so levels *0.4 seconds old* were thrown away and every bar collapsed to zero. The strip read as empty while the pill still said "Listening".
- The controller outlives a dismissal, so it came back holding the previous `inputLevel`, which `refreshLaunchSnapshot` baked into the image shown while the keyboard settles.

**Deletable failures (commit 10).** A long-form capture that never reached a terminal phase shows as "Audio unavailable" and could never be removed — every delete path is keyed on a `DictationResult`, which these sessions lack. Adds the same affordance completed rows have, and extracts the session teardown so a partial session is cleaned up as thoroughly as a finished one.

These rows are not spurious: the completion path does mark sessions complete, so each is a capture that genuinely failed. Only the means of dismissing them was missing.

## Not fixed here

The defect behind the original report — a keyboard stranded on "Transcribing" after its text was already inserted — **is still live on `main`**. `KeyboardHandoffState.advanced(to:)` has no ordering check, so a late `.resultReady` from the app can regress a terminal `.inserted` written by the extension. Both processes write that record with no sequence number or CAS. Device logs on this branch show `resultReady` arriving in the racy window and resolving favourably, which confirms the window is real and hit routinely.

Written up with the other verified root causes in `Context/findings-2026-07-26-keyboard-lifecycle-root-causes.md`, including two staleness evaluators that are unreachable by construction and five of six cross-process events that nothing observes.

## Verification

Build succeeds; **179/179 unit tests pass**. Every commit was installed on an iPhone 16 Pro with app data preserved and exercised in a real host app before the next was written. The Live Activity, both waveform fixes, and the delete affordance were each confirmed on device.

Unit coverage is limited to `Shared/` by the missing keyboard test target. Making `MuesliKeyboard/` testable is the highest-leverage follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli-ios/pr/26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787643913&installation_model_id=422865&pr_number=26&repository=Muesli-HQ%2Fmuesli-ios&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli-ios%2Fpull%2F26&signature=54888dd812121c0ee375158149df3cd7249777c65cf9b74d91089ea54df8db17"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “Copy keyboard diagnostics” in Settings with a “Copied” confirmation.
  * Updated recoverable voice-note deletion UI with clearer messaging and conditional delete availability.
  * Live Activity stop-control now follows recording kind, with legacy fallback for older activities.
* **Bug Fixes**
  * Improved dictation/voice-note lifecycle handling, deletion sequencing, and safer async operations.
* **Diagnostics**
  * Expanded keyboard lifecycle diagnostics recording and Live Activity start/stop diagnostics.
* **Tests / CI**
  * Added keyboard controller and capability tests; enhanced coverage reporting, artifacts, and watched-file summaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->