### PR TITLE
Stop an unindexed legacy query from disabling iCloud sync

### DIFF
--- a/Muesli/ICloudTextSyncEngine.swift
+++ b/Muesli/ICloudTextSyncEngine.swift
@@ -185,6 +185,18 @@ enum MuesliBridgeDeviceIdentity {
     }
 }
 
+/// A query that delivered some records before failing.
+///
+/// Reports the underlying error's message verbatim so existing status text and
+/// telemetry are unchanged; it exists only so a caller can distinguish an empty
+/// result from an interrupted one.
+struct ICloudPartialQueryFailure: Error, LocalizedError {
+    let records: [CKRecord]
+    let underlying: Error
+
+    var errorDescription: String? { underlying.localizedDescription }
+}
+
 final class ICloudTextSyncEngine {
     static let containerIdentifier = "iCloud.com.mueslihq.muesli"
 
@@ -383,6 +395,13 @@ final class ICloudTextSyncEngine {
             records.append(contentsOf: firstPage.records)
             cursor = firstPage.cursor
         } catch {
+            // Records having arrived proves the type is queryable, so a
+            // tolerated code after that is not "no legacy records" -- it is a
+            // real failure over a set that exists. Propagate it so the caller
+            // leaves the migration unfinished and retries.
+            if let partial = error as? ICloudPartialQueryFailure, !partial.records.isEmpty {
+                throw partial
+            }
             guard Self.isMissingLegacyDefaultZoneRecords(error) else { throw error }
             return []
         }
@@ -410,6 +429,9 @@ final class ICloudTextSyncEngine {
     /// conditions. `invalidArguments` is the one that matters in practice: it
     /// is what a missing queryable index reports.
     static func isMissingLegacyDefaultZoneRecords(_ error: Error) -> Bool {
+        if let partial = error as? ICloudPartialQueryFailure {
+            return isMissingLegacyDefaultZoneRecords(partial.underlying)
+        }
         if let ckError = error as? CKError {
             if isIgnorableLegacyDefaultZoneCode(ckError.code) {
                 return true
@@ -549,7 +571,15 @@ final class ICloudTextSyncEngine {
                 lock.unlock()
                 continuation.resume(returning: (pageRecords, cursor))
             case .failure(let error):
-                continuation.resume(throwing: error)
+                // A query can deliver records and then fail. Carry what arrived
+                // alongside the error so callers can tell "nothing was there"
+                // from "something was there and the read broke".
+                lock.lock()
+                let pageRecords = records
+                lock.unlock()
+                continuation.resume(
+                    throwing: ICloudPartialQueryFailure(records: pageRecords, underlying: error)
+                )
             }
         }
     }

--- a/Muesli/ICloudTextSyncEngine.swift
+++ b/Muesli/ICloudTextSyncEngine.swift
@@ -6,6 +6,25 @@ struct ICloudTextSyncResult: Equatable {
     let downloaded: Int
 }
 
+/// Counts records handed over by a CKQueryOperation. `recordMatchedBlock` runs
+/// off the calling thread, so the count is guarded.
+private final class DeliveredRecordCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var count = 0
+
+    var isEmpty: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return count == 0
+    }
+
+    func increment() {
+        lock.lock()
+        count += 1
+        lock.unlock()
+    }
+}
+
 private struct ICloudTextZoneChangesPage {
     let records: [CKRecord]
     let serverChangeToken: CKServerChangeToken
@@ -185,17 +204,6 @@ enum MuesliBridgeDeviceIdentity {
     }
 }
 
-/// A query that delivered some records before failing.
-///
-/// Reports the underlying error's message verbatim so existing status text and
-/// telemetry are unchanged; it exists only so a caller can distinguish an empty
-/// result from an interrupted one.
-struct ICloudPartialQueryFailure: Error, LocalizedError {
-    let records: [CKRecord]
-    let underlying: Error
-
-    var errorDescription: String? { underlying.localizedDescription }
-}
 
 final class ICloudTextSyncEngine {
     static let containerIdentifier = "iCloud.com.mueslihq.muesli"
@@ -385,23 +393,24 @@ final class ICloudTextSyncEngine {
     private func fetchDefaultZoneTextRecords() async throws -> [CKRecord] {
         var records: [CKRecord] = []
         var cursor: CKQueryOperation.Cursor?
+        let delivered = DeliveredRecordCounter()
 
         // Tolerance applies to the opening query only. An unindexed or absent
         // legacy schema fails here, before any page is read, and means there is
         // nothing to migrate.
         do {
             let query = CKQuery(recordType: Schema.textRecordType, predicate: NSPredicate(value: true))
-            let firstPage = try await fetch(query: query)
+            let firstPage = try await fetch(query: query) {
+                delivered.increment()
+            }
             records.append(contentsOf: firstPage.records)
             cursor = firstPage.cursor
         } catch {
             // Records having arrived proves the type is queryable, so a
             // tolerated code after that is not "no legacy records" -- it is a
-            // real failure over a set that exists. Propagate it so the caller
-            // leaves the migration unfinished and retries.
-            if let partial = error as? ICloudPartialQueryFailure, !partial.records.isEmpty {
-                throw partial
-            }
+            // real failure over a set that exists. Propagate it unaltered so
+            // the caller retries and telemetry still sees a CloudKit error.
+            guard delivered.isEmpty else { throw error }
             guard Self.isMissingLegacyDefaultZoneRecords(error) else { throw error }
             return []
         }
@@ -429,9 +438,6 @@ final class ICloudTextSyncEngine {
     /// conditions. `invalidArguments` is the one that matters in practice: it
     /// is what a missing queryable index reports.
     static func isMissingLegacyDefaultZoneRecords(_ error: Error) -> Bool {
-        if let partial = error as? ICloudPartialQueryFailure {
-            return isMissingLegacyDefaultZoneRecords(partial.underlying)
-        }
         if let ckError = error as? CKError {
             if isIgnorableLegacyDefaultZoneCode(ckError.code) {
                 return true
@@ -532,12 +538,17 @@ final class ICloudTextSyncEngine {
 
     private func fetch(
         query: CKQuery,
-        zoneID: CKRecordZone.ID? = nil
+        zoneID: CKRecordZone.ID? = nil,
+        onRecordDelivered: (@Sendable () -> Void)? = nil
     ) async throws -> (records: [CKRecord], cursor: CKQueryOperation.Cursor?) {
         try await withCheckedThrowingContinuation { continuation in
             let operation = CKQueryOperation(query: query)
             operation.zoneID = zoneID
-            collect(operation: operation, continuation: continuation)
+            collect(
+                operation: operation,
+                continuation: continuation,
+                onRecordDelivered: onRecordDelivered
+            )
             database.add(operation)
         }
     }
@@ -552,7 +563,8 @@ final class ICloudTextSyncEngine {
 
     private func collect(
         operation: CKQueryOperation,
-        continuation: CheckedContinuation<(records: [CKRecord], cursor: CKQueryOperation.Cursor?), Error>
+        continuation: CheckedContinuation<(records: [CKRecord], cursor: CKQueryOperation.Cursor?), Error>,
+        onRecordDelivered: (@Sendable () -> Void)? = nil
     ) {
         let lock = NSLock()
         var records: [CKRecord] = []
@@ -561,6 +573,10 @@ final class ICloudTextSyncEngine {
                 lock.lock()
                 records.append(record)
                 lock.unlock()
+                // A query can deliver records and then fail, in which case the
+                // error carries no trace of them. Callers that need to tell an
+                // empty result from an interrupted one count them here.
+                onRecordDelivered?()
             }
         }
         operation.queryResultBlock = { result in
@@ -571,15 +587,7 @@ final class ICloudTextSyncEngine {
                 lock.unlock()
                 continuation.resume(returning: (pageRecords, cursor))
             case .failure(let error):
-                // A query can deliver records and then fail. Carry what arrived
-                // alongside the error so callers can tell "nothing was there"
-                // from "something was there and the read broke".
-                lock.lock()
-                let pageRecords = records
-                lock.unlock()
-                continuation.resume(
-                    throwing: ICloudPartialQueryFailure(records: pageRecords, underlying: error)
-                )
+                continuation.resume(throwing: error)
             }
         }
     }

--- a/Muesli/ICloudTextSyncEngine.swift
+++ b/Muesli/ICloudTextSyncEngine.swift
@@ -353,18 +353,77 @@ final class ICloudTextSyncEngine {
         return records
     }
 
+    /// Reads text records left in the default zone by builds that predate
+    /// `MuesliSyncZone`.
+    ///
+    /// This is a query, and CloudKit queries require the record type to carry a
+    /// queryable index. That index is not guaranteed to exist -- notably in the
+    /// Production environment, where schema cannot be created by the app -- so
+    /// a container that has never been indexed answers with
+    /// "Type is not marked indexable: MuesliTextRecord".
+    ///
+    /// A container with no legacy records to migrate is indistinguishable from
+    /// one that cannot answer the question, and neither is a reason to fail:
+    /// steady-state sync uses `CKFetchRecordZoneChangesOperation` on the custom
+    /// zone, which needs no index. Treat those errors as "no legacy records".
+    ///
+    /// macOS has carried this tolerance since June (`MuesliICloudSyncEngine`,
+    /// `isMissingLegacyDefaultZoneRecords`); iOS shipped the same migration
+    /// without it, so a TestFlight user saw every sync fail with that message.
     private func fetchDefaultZoneTextRecords() async throws -> [CKRecord] {
-        let query = CKQuery(recordType: Schema.textRecordType, predicate: NSPredicate(value: true))
-        var records: [CKRecord] = []
-        let firstPage = try await fetch(query: query)
-        records.append(contentsOf: firstPage.records)
-        var cursor = firstPage.cursor
-        while let nextCursor = cursor {
-            let page = try await fetch(cursor: nextCursor)
-            records.append(contentsOf: page.records)
-            cursor = page.cursor
+        do {
+            let query = CKQuery(recordType: Schema.textRecordType, predicate: NSPredicate(value: true))
+            var records: [CKRecord] = []
+            let firstPage = try await fetch(query: query)
+            records.append(contentsOf: firstPage.records)
+            var cursor = firstPage.cursor
+            while let nextCursor = cursor {
+                let page = try await fetch(cursor: nextCursor)
+                records.append(contentsOf: page.records)
+                cursor = page.cursor
+            }
+            return records
+        } catch {
+            guard Self.isMissingLegacyDefaultZoneRecords(error) else { throw error }
+            return []
         }
-        return records
+    }
+
+    /// Whether an error means the legacy default-zone records cannot be read,
+    /// as opposed to a genuine sync failure.
+    ///
+    /// Mirrors the macOS classifier so the two platforms tolerate the same
+    /// conditions. `invalidArguments` is the one that matters in practice: it
+    /// is what a missing queryable index reports.
+    static func isMissingLegacyDefaultZoneRecords(_ error: Error) -> Bool {
+        if let ckError = error as? CKError {
+            if isIgnorableLegacyDefaultZoneCode(ckError.code) {
+                return true
+            }
+            if ckError.code == .partialFailure,
+               ckError.partialErrorsByItemID?.values.contains(where: isMissingLegacyDefaultZoneRecords) == true {
+                return true
+            }
+        }
+
+        let nsError = error as NSError
+        if nsError.domain == CKError.errorDomain,
+           isIgnorableLegacyDefaultZoneCode(CKError.Code(rawValue: nsError.code)) {
+            return true
+        }
+        if let underlyingError = nsError.userInfo[NSUnderlyingErrorKey] as? Error {
+            return isMissingLegacyDefaultZoneRecords(underlyingError)
+        }
+        return false
+    }
+
+    static func isIgnorableLegacyDefaultZoneCode(_ code: CKError.Code?) -> Bool {
+        switch code {
+        case .unknownItem, .serverRejectedRequest, .invalidArguments, .zoneNotFound:
+            return true
+        default:
+            return false
+        }
     }
 
     private func fetchZoneChangesPage(previousServerChangeToken: CKServerChangeToken?) async throws -> ICloudTextZoneChangesPage {

--- a/Muesli/ICloudTextSyncEngine.swift
+++ b/Muesli/ICloudTextSyncEngine.swift
@@ -330,7 +330,38 @@ final class ICloudTextSyncEngine {
     private func migrateDefaultZoneIfNeeded(store: SharedStore) async throws {
         guard !defaults.bool(forKey: Schema.migratedDefaultZoneKey) else { return }
 
-        let legacyDefaultZoneRecords = try await fetchDefaultZoneTextRecords()
+        // This migration is why a TestFlight user's sync failed on every pass,
+        // and it only fails against a container whose legacy schema is not
+        // queryable -- which no development build reproduces. Report what it
+        // actually did, so the fix can be confirmed from the field rather than
+        // inferred.
+        let legacyDefaultZoneRecords: [CKRecord]
+        do {
+            legacyDefaultZoneRecords = try await fetchDefaultZoneTextRecords()
+            let readCount = legacyDefaultZoneRecords.count
+            await MainActor.run {
+                AppTelemetry.signal(
+                    "icloud_legacy_migration_read",
+                    parameters: [
+                        "outcome": readCount == 0 ? "empty" : "records_found",
+                        "record_count": String(readCount)
+                    ]
+                )
+            }
+        } catch {
+            // Reached only for errors the tolerance deliberately does not
+            // cover, or an interrupted read of a set that does exist. Either
+            // way the migration stays unfinished and retries next sync.
+            await MainActor.run {
+                AppTelemetry.failure(
+                    "icloud_legacy_migration_failed",
+                    domain: .cloudSync,
+                    stage: "legacy_default_zone_read",
+                    error: error
+                )
+            }
+            throw error
+        }
         for record in legacyDefaultZoneRecords {
             guard let syncRecord = Self.syncTextRecord(from: record) else { continue }
             try store.upsertSyncedTextRecord(syncRecord)
@@ -354,6 +385,13 @@ final class ICloudTextSyncEngine {
         }
 
         defaults.set(true, forKey: Schema.migratedDefaultZoneKey)
+        let importedCount = legacyDefaultZoneRecords.count
+        await MainActor.run {
+            AppTelemetry.signal(
+                "icloud_legacy_migration_completed",
+                parameters: ["imported": String(importedCount)]
+            )
+        }
     }
 
     private func fetchChangedTextRecords() async throws -> [CKRecord] {

--- a/Muesli/ICloudTextSyncEngine.swift
+++ b/Muesli/ICloudTextSyncEngine.swift
@@ -371,9 +371,13 @@ final class ICloudTextSyncEngine {
     /// `isMissingLegacyDefaultZoneRecords`); iOS shipped the same migration
     /// without it, so a TestFlight user saw every sync fail with that message.
     private func fetchDefaultZoneTextRecords() async throws -> [CKRecord] {
+        // Accumulated outside the do/catch: a later page failing must not
+        // discard what earlier pages already returned. The migration marks
+        // itself complete afterwards, so anything dropped here is dropped for
+        // good.
+        var records: [CKRecord] = []
         do {
             let query = CKQuery(recordType: Schema.textRecordType, predicate: NSPredicate(value: true))
-            var records: [CKRecord] = []
             let firstPage = try await fetch(query: query)
             records.append(contentsOf: firstPage.records)
             var cursor = firstPage.cursor
@@ -385,7 +389,7 @@ final class ICloudTextSyncEngine {
             return records
         } catch {
             guard Self.isMissingLegacyDefaultZoneRecords(error) else { throw error }
-            return []
+            return records
         }
     }
 
@@ -400,8 +404,13 @@ final class ICloudTextSyncEngine {
             if isIgnorableLegacyDefaultZoneCode(ckError.code) {
                 return true
             }
+            // Every per-item error has to be tolerable. Matching on any one of
+            // them would swallow a real failure whenever it happened to be
+            // batched alongside a missing-schema error.
             if ckError.code == .partialFailure,
-               ckError.partialErrorsByItemID?.values.contains(where: isMissingLegacyDefaultZoneRecords) == true {
+               let partialErrors = ckError.partialErrorsByItemID,
+               !partialErrors.isEmpty,
+               partialErrors.values.allSatisfy(isMissingLegacyDefaultZoneRecords) {
                 return true
             }
         }

--- a/Muesli/ICloudTextSyncEngine.swift
+++ b/Muesli/ICloudTextSyncEngine.swift
@@ -371,26 +371,36 @@ final class ICloudTextSyncEngine {
     /// `isMissingLegacyDefaultZoneRecords`); iOS shipped the same migration
     /// without it, so a TestFlight user saw every sync fail with that message.
     private func fetchDefaultZoneTextRecords() async throws -> [CKRecord] {
-        // Accumulated outside the do/catch: a later page failing must not
-        // discard what earlier pages already returned. The migration marks
-        // itself complete afterwards, so anything dropped here is dropped for
-        // good.
         var records: [CKRecord] = []
+        var cursor: CKQueryOperation.Cursor?
+
+        // Tolerance applies to the opening query only. An unindexed or absent
+        // legacy schema fails here, before any page is read, and means there is
+        // nothing to migrate.
         do {
             let query = CKQuery(recordType: Schema.textRecordType, predicate: NSPredicate(value: true))
             let firstPage = try await fetch(query: query)
             records.append(contentsOf: firstPage.records)
-            var cursor = firstPage.cursor
-            while let nextCursor = cursor {
-                let page = try await fetch(cursor: nextCursor)
-                records.append(contentsOf: page.records)
-                cursor = page.cursor
-            }
-            return records
+            cursor = firstPage.cursor
         } catch {
             guard Self.isMissingLegacyDefaultZoneRecords(error) else { throw error }
-            return records
+            return []
         }
+
+        // Past this point the type is demonstrably queryable, so the same error
+        // codes no longer mean "no legacy records" -- they mean a real failure
+        // partway through a set that does exist. Let it propagate: the caller
+        // leaves the migration flag unset and retries on the next sync, which
+        // is safe because importing is an idempotent upsert. Returning the
+        // pages read so far would instead mark the migration complete and
+        // strand every record after the failure.
+        while let nextCursor = cursor {
+            let page = try await fetch(cursor: nextCursor)
+            records.append(contentsOf: page.records)
+            cursor = page.cursor
+        }
+
+        return records
     }
 
     /// Whether an error means the legacy default-zone records cannot be read,

--- a/Tests/MuesliTests/ICloudLegacyMigrationToleranceTests.swift
+++ b/Tests/MuesliTests/ICloudLegacyMigrationToleranceTests.swift
@@ -1,0 +1,90 @@
+import CloudKit
+import XCTest
+@testable import Muesli
+
+/// The legacy default-zone migration runs before any real syncing, so anything
+/// it treats as fatal takes down sync in both directions. A TestFlight user hit
+/// exactly that: "Sync failed: Type is not marked indexable: MuesliTextRecord",
+/// on every sync, permanently, because the migration flag is only set on
+/// success.
+///
+/// These pin which errors mean "there are no legacy records to read" and,
+/// more importantly, which must still be allowed to fail the sync.
+final class ICloudLegacyMigrationToleranceTests: XCTestCase {
+    private func ckError(_ code: CKError.Code, userInfo: [String: Any] = [:]) -> CKError {
+        CKError(code, userInfo: userInfo)
+    }
+
+    /// A missing queryable index reports `invalidArguments`. This is the one
+    /// that was breaking sync in Production, where the app cannot create schema.
+    func testAMissingQueryableIndexIsTolerated() {
+        XCTAssertTrue(
+            ICloudTextSyncEngine.isMissingLegacyDefaultZoneRecords(ckError(.invalidArguments))
+        )
+    }
+
+    func testTheOtherEmptyLegacySchemaCodesAreTolerated() {
+        for code in [CKError.Code.unknownItem, .serverRejectedRequest, .zoneNotFound] {
+            XCTAssertTrue(
+                ICloudTextSyncEngine.isMissingLegacyDefaultZoneRecords(ckError(code)),
+                "\(code) should read as 'no legacy records'"
+            )
+        }
+    }
+
+    /// The point of the classifier is to be narrow. A network drop or a signed
+    /// out account is a real failure and must still surface, or this becomes a
+    /// blanket catch that hides genuine sync breakage.
+    func testRealFailuresAreStillFatal() {
+        for code in [
+            CKError.Code.networkUnavailable,
+            .networkFailure,
+            .notAuthenticated,
+            .quotaExceeded,
+            .permissionFailure,
+            .serviceUnavailable,
+            .requestRateLimited
+        ] {
+            XCTAssertFalse(
+                ICloudTextSyncEngine.isMissingLegacyDefaultZoneRecords(ckError(code)),
+                "\(code) is a real failure and must not be swallowed"
+            )
+        }
+    }
+
+    /// CloudKit reports batch operations as a partial failure wrapping the real
+    /// per-item errors, so the classifier has to look inside.
+    func testAPartialFailureWrappingATolerableErrorIsTolerated() {
+        let inner = ckError(.invalidArguments)
+        let partial = ckError(
+            .partialFailure,
+            userInfo: [CKPartialErrorsByItemIDKey: [CKRecord.ID(recordName: "legacy"): inner]]
+        )
+        XCTAssertTrue(ICloudTextSyncEngine.isMissingLegacyDefaultZoneRecords(partial))
+    }
+
+    func testAPartialFailureWrappingARealFailureIsNotTolerated() {
+        let inner = ckError(.networkFailure)
+        let partial = ckError(
+            .partialFailure,
+            userInfo: [CKPartialErrorsByItemIDKey: [CKRecord.ID(recordName: "legacy"): inner]]
+        )
+        XCTAssertFalse(ICloudTextSyncEngine.isMissingLegacyDefaultZoneRecords(partial))
+    }
+
+    /// Errors surfacing through URL loading or an operation wrapper arrive
+    /// nested rather than as a top-level CKError.
+    func testANestedUnderlyingErrorIsUnwrapped() {
+        let wrapper = NSError(
+            domain: "com.example.wrapper",
+            code: 1,
+            userInfo: [NSUnderlyingErrorKey: ckError(.invalidArguments)]
+        )
+        XCTAssertTrue(ICloudTextSyncEngine.isMissingLegacyDefaultZoneRecords(wrapper))
+    }
+
+    func testAnUnrelatedErrorIsNotTolerated() {
+        let unrelated = NSError(domain: NSPOSIXErrorDomain, code: 2)
+        XCTAssertFalse(ICloudTextSyncEngine.isMissingLegacyDefaultZoneRecords(unrelated))
+    }
+}

--- a/Tests/MuesliTests/ICloudLegacyMigrationToleranceTests.swift
+++ b/Tests/MuesliTests/ICloudLegacyMigrationToleranceTests.swift
@@ -105,6 +105,24 @@ final class ICloudLegacyMigrationToleranceTests: XCTestCase {
         XCTAssertTrue(ICloudTextSyncEngine.isMissingLegacyDefaultZoneRecords(wrapper))
     }
 
+    /// The wrapper exists so an empty result can be told apart from an
+    /// interrupted one; classification must still see through it.
+    func testAPartialQueryFailureIsClassifiedByItsUnderlyingError() {
+        let tolerable = ICloudPartialQueryFailure(records: [], underlying: ckError(.invalidArguments))
+        XCTAssertTrue(ICloudTextSyncEngine.isMissingLegacyDefaultZoneRecords(tolerable))
+
+        let fatal = ICloudPartialQueryFailure(records: [], underlying: ckError(.networkFailure))
+        XCTAssertFalse(ICloudTextSyncEngine.isMissingLegacyDefaultZoneRecords(fatal))
+    }
+
+    /// Status text and telemetry read localizedDescription, so wrapping must
+    /// not change what the user is told.
+    func testAPartialQueryFailureReportsTheUnderlyingMessage() {
+        let underlying = ckError(.networkFailure)
+        let wrapped = ICloudPartialQueryFailure(records: [], underlying: underlying)
+        XCTAssertEqual(wrapped.localizedDescription, underlying.localizedDescription)
+    }
+
     func testAnUnrelatedErrorIsNotTolerated() {
         let unrelated = NSError(domain: NSPOSIXErrorDomain, code: 2)
         XCTAssertFalse(ICloudTextSyncEngine.isMissingLegacyDefaultZoneRecords(unrelated))

--- a/Tests/MuesliTests/ICloudLegacyMigrationToleranceTests.swift
+++ b/Tests/MuesliTests/ICloudLegacyMigrationToleranceTests.swift
@@ -72,6 +72,28 @@ final class ICloudLegacyMigrationToleranceTests: XCTestCase {
         XCTAssertFalse(ICloudTextSyncEngine.isMissingLegacyDefaultZoneRecords(partial))
     }
 
+    /// A real failure batched alongside a missing-schema error is still a real
+    /// failure. Tolerating the batch because one item happened to be benign
+    /// would hide it.
+    func testAMixedPartialFailureIsNotTolerated() {
+        let partial = ckError(
+            .partialFailure,
+            userInfo: [CKPartialErrorsByItemIDKey: [
+                CKRecord.ID(recordName: "legacy"): ckError(.invalidArguments),
+                CKRecord.ID(recordName: "other"): ckError(.networkFailure)
+            ]]
+        )
+        XCTAssertFalse(ICloudTextSyncEngine.isMissingLegacyDefaultZoneRecords(partial))
+    }
+
+    func testAnEmptyPartialFailureIsNotTolerated() {
+        let partial = ckError(
+            .partialFailure,
+            userInfo: [CKPartialErrorsByItemIDKey: [CKRecord.ID: Error]()]
+        )
+        XCTAssertFalse(ICloudTextSyncEngine.isMissingLegacyDefaultZoneRecords(partial))
+    }
+
     /// Errors surfacing through URL loading or an operation wrapper arrive
     /// nested rather than as a top-level CKError.
     func testANestedUnderlyingErrorIsUnwrapped() {

--- a/Tests/MuesliTests/ICloudLegacyMigrationToleranceTests.swift
+++ b/Tests/MuesliTests/ICloudLegacyMigrationToleranceTests.swift
@@ -105,24 +105,6 @@ final class ICloudLegacyMigrationToleranceTests: XCTestCase {
         XCTAssertTrue(ICloudTextSyncEngine.isMissingLegacyDefaultZoneRecords(wrapper))
     }
 
-    /// The wrapper exists so an empty result can be told apart from an
-    /// interrupted one; classification must still see through it.
-    func testAPartialQueryFailureIsClassifiedByItsUnderlyingError() {
-        let tolerable = ICloudPartialQueryFailure(records: [], underlying: ckError(.invalidArguments))
-        XCTAssertTrue(ICloudTextSyncEngine.isMissingLegacyDefaultZoneRecords(tolerable))
-
-        let fatal = ICloudPartialQueryFailure(records: [], underlying: ckError(.networkFailure))
-        XCTAssertFalse(ICloudTextSyncEngine.isMissingLegacyDefaultZoneRecords(fatal))
-    }
-
-    /// Status text and telemetry read localizedDescription, so wrapping must
-    /// not change what the user is told.
-    func testAPartialQueryFailureReportsTheUnderlyingMessage() {
-        let underlying = ckError(.networkFailure)
-        let wrapped = ICloudPartialQueryFailure(records: [], underlying: underlying)
-        XCTAssertEqual(wrapped.localizedDescription, underlying.localizedDescription)
-    }
-
     func testAnUnrelatedErrorIsNotTolerated() {
         let unrelated = NSError(domain: NSPOSIXErrorDomain, code: 2)
         XCTAssertFalse(ICloudTextSyncEngine.isMissingLegacyDefaultZoneRecords(unrelated))


### PR DESCRIPTION
Fixes the TestFlight report on 0.1.2(8): *"Notes not syncing."* The attached screenshot showed the real cause — **`Sync failed: Type is not marked indexable: MuesliTextRecord`**.

## What was happening

`fetchDefaultZoneTextRecords` reads text records left in the default zone by builds predating `MuesliSyncZone`. It's a `CKQuery`, and CloudKit queries require the record type to carry a **queryable index**. That index isn't guaranteed to exist — notably in **Production**, where the app cannot create schema — so a container that has never been indexed answers with exactly that error.

Three things made it fatal rather than cosmetic:

1. The error propagated out of `migrateDefaultZoneIfNeeded`, which is called at `sync()` **before both download and upload**. All syncing stopped, both directions.
2. The migration flag is only set **after** success, so every later sync retried the same doomed query. Permanent, not transient.
3. The migration is optional by nature — it looks for legacy records a new install doesn't even have. The reporting user had **0 notes**. There was nothing to migrate, and it still took sync down.

A container with no legacy records is indistinguishable from one that cannot answer the question, and neither is a reason to fail. Steady-state sync uses `CKFetchRecordZoneChangesOperation` on the custom zone, which needs **no index** — which is why sync works fine between a Mac and an iPhone whose migration already completed.

## The fix

Ports the tolerance macOS has carried since June (`MuesliICloudSyncEngine.isMissingLegacyDefaultZoneRecords`). macOS hit this same error during bridge development — it's written up in the macOS repo at `Context/handoff-2026-06-19-icloud-sync-bridge.md:91` — and was fixed there. iOS shipped the same migration pattern without the lesson.

```swift
} catch {
    guard Self.isMissingLegacyDefaultZoneRecords(error) else { throw error }
    return []
}
```

The classifier is deliberately narrow: `unknownItem`, `serverRejectedRequest`, `invalidArguments`, `zoneNotFound`. It unwraps `partialFailure` and `NSUnderlyingErrorKey`, matching the macOS implementation so the two platforms tolerate the same conditions.

## Tests

`Tests/MuesliTests/ICloudLegacyMigrationToleranceTests.swift` — 7 tests. The ones that matter most assert what is **not** swallowed: network failure, authentication failure, quota, permission, service unavailable, and rate limiting all still fail the sync. A blanket catch here would hide real breakage behind a permanently green status line, which is worse than the bug being fixed.

Build succeeds, **194/194 tests pass**.

## Not included

- **Deploying a queryable index for `MuesliTextRecord` to Production CloudKit.** Worth doing separately: it only affects users who genuinely have default-zone records, who would otherwise lose those legacy notes. With this fix they at least sync everything else. Note the error message itself proves the *record type* exists in Production — an absent type reports "unknown record type" instead — so only the index is missing.
- **Verification on a device against Production CloudKit.** This was reasoned from the error and from macOS's handling of the identical failure; it has not been reproduced against an unindexed Production container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli-ios/pr/27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787833191&installation_model_id=422865&pr_number=27&repository=Muesli-HQ%2Fmuesli-ios&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli-ios%2Fpull%2F27&signature=90b5b473cb236a59c7d41edfff831c0b400e4c68350bcd4c79b2d89ed0dfdf4d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/muesli-hq/muesli-ios/pull/27" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tolerance during legacy default-zone CloudKit migration so it no longer fails when no legacy records are delivered.
  * Migration now distinguishes between truly “missing/unqueryable legacy records” vs genuine errors, including correct handling of `partialFailure`, to avoid suppressing real failures.
* **Tests**
  * Added coverage for legacy error classification, nested/underlying error unwrapping, and `partialFailure` cases (tolerable, non-tolerable, and mixed).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->