### PR TITLE
Report sync state in the diagnostics export

### DIFF
--- a/Muesli/AboutSettingsContent.swift
+++ b/Muesli/AboutSettingsContent.swift
@@ -10,9 +10,11 @@ struct AboutSettingsContent: View {
     /// the notes that own them. Filenames are never included -- only totals.
     private func diagnosticsReport() -> String {
         var header = ""
-        if let audit = try? SharedStore().audioFileAudit() {
-            header = "audio: \(audit.onDisk) files, \(audit.owned) owned, \(audit.orphaned) orphaned\n\n"
+        let store = SharedStore()
+        if let audit = try? store.audioFileAudit() {
+            header += "audio: \(audit.onDisk) files, \(audit.owned) owned, \(audit.orphaned) orphaned\n"
         }
+        header += ICloudTextSyncEngine.diagnosticsSummary(store: store) + "\n\n"
         return header + KeyboardDiagnosticsLog.exportText()
     }
 

--- a/Muesli/ICloudTextSyncEngine.swift
+++ b/Muesli/ICloudTextSyncEngine.swift
@@ -38,12 +38,14 @@ protocol ICloudTextChangeTokenStore {
 }
 
 final class UserDefaultsICloudTextChangeTokenStore: ICloudTextChangeTokenStore {
+    static let defaultKey = "muesli.icloud.textRecords.MuesliSyncZone.serverChangeToken.v1"
+
     private let defaults: UserDefaults
     private let key: String
 
     init(
         defaults: UserDefaults = .standard,
-        key: String = "muesli.icloud.textRecords.MuesliSyncZone.serverChangeToken.v1"
+        key: String = UserDefaultsICloudTextChangeTokenStore.defaultKey
     ) {
         self.defaults = defaults
         self.key = key
@@ -81,9 +83,9 @@ struct MuesliBridgeDeviceSnapshot: Equatable {
 enum MuesliBridgeDeviceIdentity {
     private static let localDeviceIDKey = "muesli.sync.bridge.localDeviceID.v1"
     private static let localDeviceNameKey = "muesli.sync.bridge.localDeviceName.v1"
-    private static let remoteDeviceIDKey = "muesli.sync.bridge.remoteDeviceID.v1"
+    static let remoteDeviceIDKey = "muesli.sync.bridge.remoteDeviceID.v1"
     private static let remoteDeviceNameKey = "muesli.sync.bridge.remoteDeviceName.v1"
-    private static let remoteDevicePlatformKey = "muesli.sync.bridge.remoteDevicePlatform.v1"
+    static let remoteDevicePlatformKey = "muesli.sync.bridge.remoteDevicePlatform.v1"
     private static let remoteDeviceLastSeenAtKey = "muesli.sync.bridge.remoteDeviceLastSeenAt.v1"
     private static let lastRefreshKey = "muesli.sync.bridge.lastDeviceRefreshAttemptAt.v1"
     private static let lastRefreshFailureKey = "muesli.sync.bridge.lastDeviceRefreshFailureAt.v1"
@@ -248,24 +250,28 @@ final class ICloudTextSyncEngine {
         let defaults = UserDefaults.standard
         let migrated = defaults.bool(forKey: Schema.migratedDefaultZoneKey)
         let hasToken = defaults.data(
-            forKey: "muesli.icloud.textRecords.MuesliSyncZone.serverChangeToken.v1"
+            forKey: UserDefaultsICloudTextChangeTokenStore.defaultKey
         ) != nil
         let enabled = MuesliPreferences.iCloudSyncEnabled
 
-        let pending = (try? store.textRecordsNeedingSync(limit: 500))?.count
+        // Reported as "500+" at the cap: a diagnostic that silently floors the
+        // number hides exactly the backlog it exists to reveal.
+        let pendingCap = 500
+        let pendingFetched = (try? store.textRecordsNeedingSync(limit: pendingCap))?.count
+        let pending = pendingFetched.map { $0 >= pendingCap ? "\(pendingCap)+" : String($0) }
         let sessions = (try? store.recordingSessions())?.count
         let results = (try? store.resultsHistory())?.count
         // Presence and platform only. The stored device name is
         // ProcessInfo.hostName, which is routinely someone's real name, and
         // this text gets pasted into chats.
-        let hasRemoteDevice = defaults.string(forKey: "muesli.sync.bridge.remoteDeviceID.v1") != nil
-        let remotePlatform = defaults.string(forKey: "muesli.sync.bridge.remoteDevicePlatform.v1")
+        let hasRemoteDevice = defaults.string(forKey: MuesliBridgeDeviceIdentity.remoteDeviceIDKey) != nil
+        let remotePlatform = defaults.string(forKey: MuesliBridgeDeviceIdentity.remoteDevicePlatformKey)
 
         return [
             "sync: enabled=\(enabled)",
             "migrated=\(migrated)",
             "changeToken=\(hasToken ? "present" : "none")",
-            "pendingUpload=\(pending.map(String.init) ?? "?")",
+            "pendingUpload=\(pending ?? "?")",
             "localNotes=\(results.map(String.init) ?? "?")",
             "localSessions=\(sessions.map(String.init) ?? "?")",
             "linkedDevice=\(hasRemoteDevice ? (remotePlatform ?? "yes") : "none")"

--- a/Muesli/ICloudTextSyncEngine.swift
+++ b/Muesli/ICloudTextSyncEngine.swift
@@ -255,7 +255,10 @@ final class ICloudTextSyncEngine {
         let pending = (try? store.textRecordsNeedingSync(limit: 500))?.count
         let sessions = (try? store.recordingSessions())?.count
         let results = (try? store.resultsHistory())?.count
-        let remoteDevice = defaults.string(forKey: "muesli.sync.bridge.remoteDeviceName.v1")
+        // Presence and platform only. The stored device name is
+        // ProcessInfo.hostName, which is routinely someone's real name, and
+        // this text gets pasted into chats.
+        let hasRemoteDevice = defaults.string(forKey: "muesli.sync.bridge.remoteDeviceID.v1") != nil
         let remotePlatform = defaults.string(forKey: "muesli.sync.bridge.remoteDevicePlatform.v1")
 
         return [
@@ -265,7 +268,7 @@ final class ICloudTextSyncEngine {
             "pendingUpload=\(pending.map(String.init) ?? "?")",
             "localNotes=\(results.map(String.init) ?? "?")",
             "localSessions=\(sessions.map(String.init) ?? "?")",
-            "linkedDevice=\(remoteDevice ?? "none")\(remotePlatform.map { " (\($0))" } ?? "")"
+            "linkedDevice=\(hasRemoteDevice ? (remotePlatform ?? "yes") : "none")"
         ].joined(separator: " ")
     }
 

--- a/Muesli/ICloudTextSyncEngine.swift
+++ b/Muesli/ICloudTextSyncEngine.swift
@@ -254,13 +254,14 @@ final class ICloudTextSyncEngine {
         ) != nil
         let enabled = MuesliPreferences.iCloudSyncEnabled
 
-        // Reported as "500+" at the cap: a diagnostic that silently floors the
-        // number hides exactly the backlog it exists to reveal.
-        let pendingCap = 500
-        let pendingFetched = (try? store.textRecordsNeedingSync(limit: pendingCap))?.count
-        let pending = pendingFetched.map { $0 >= pendingCap ? "\(pendingCap)+" : String($0) }
-        let sessions = (try? store.recordingSessions())?.count
-        let results = (try? store.resultsHistory())?.count
+        // Counted in SQL rather than by fetching rows: this runs on the main
+        // actor, and a history of a few thousand notes would otherwise be
+        // decoded in full just to be counted. It also means the pending figure
+        // is exact rather than capped by a fetch limit.
+        let counts = try? store.syncRecordCounts()
+        let pending = counts.map { String($0.pendingUpload) }
+        let sessions = counts.map(\.sessions)
+        let results = counts.map(\.results)
         // Presence and platform only. The stored device name is
         // ProcessInfo.hostName, which is routinely someone's real name, and
         // this text gets pasted into chats.

--- a/Muesli/ICloudTextSyncEngine.swift
+++ b/Muesli/ICloudTextSyncEngine.swift
@@ -259,7 +259,7 @@ final class ICloudTextSyncEngine {
         // decoded in full just to be counted. It also means the pending figure
         // is exact rather than capped by a fetch limit.
         let counts = try? store.syncRecordCounts()
-        let pending = counts.map { String($0.pendingUpload) }
+        let dirty = counts.map { "\($0.dirtyResults)/\($0.dirtySessions)" }
         let sessions = counts.map(\.sessions)
         let results = counts.map(\.results)
         // Presence and platform only. The stored device name is
@@ -272,7 +272,7 @@ final class ICloudTextSyncEngine {
             "sync: enabled=\(enabled)",
             "migrated=\(migrated)",
             "changeToken=\(hasToken ? "present" : "none")",
-            "pendingUpload=\(pending ?? "?")",
+            "dirtyNotes/dirtySessions=\(dirty ?? "?")",
             "localNotes=\(results.map(String.init) ?? "?")",
             "localSessions=\(sessions.map(String.init) ?? "?")",
             "linkedDevice=\(hasRemoteDevice ? (remotePlatform ?? "yes") : "none")"

--- a/Muesli/ICloudTextSyncEngine.swift
+++ b/Muesli/ICloudTextSyncEngine.swift
@@ -236,6 +236,39 @@ final class ICloudTextSyncEngine {
         self.defaults = defaults
     }
 
+    /// A one-line summary of why sync may not be moving anything.
+    ///
+    /// Sync reports "All text is up to date." whenever a pass downloads and
+    /// uploads nothing, which looks identical whether there was genuinely
+    /// nothing to do or the device is queued behind something invisible. These
+    /// are the values that tell those apart, and every one of them is currently
+    /// unobservable from the outside.
+    @MainActor
+    static func diagnosticsSummary(store: SharedStore = SharedStore()) -> String {
+        let defaults = UserDefaults.standard
+        let migrated = defaults.bool(forKey: Schema.migratedDefaultZoneKey)
+        let hasToken = defaults.data(
+            forKey: "muesli.icloud.textRecords.MuesliSyncZone.serverChangeToken.v1"
+        ) != nil
+        let enabled = MuesliPreferences.iCloudSyncEnabled
+
+        let pending = (try? store.textRecordsNeedingSync(limit: 500))?.count
+        let sessions = (try? store.recordingSessions())?.count
+        let results = (try? store.resultsHistory())?.count
+        let remoteDevice = defaults.string(forKey: "muesli.sync.bridge.remoteDeviceName.v1")
+        let remotePlatform = defaults.string(forKey: "muesli.sync.bridge.remoteDevicePlatform.v1")
+
+        return [
+            "sync: enabled=\(enabled)",
+            "migrated=\(migrated)",
+            "changeToken=\(hasToken ? "present" : "none")",
+            "pendingUpload=\(pending.map(String.init) ?? "?")",
+            "localNotes=\(results.map(String.init) ?? "?")",
+            "localSessions=\(sessions.map(String.init) ?? "?")",
+            "linkedDevice=\(remoteDevice ?? "none")\(remotePlatform.map { " (\($0))" } ?? "")"
+        ].joined(separator: " ")
+    }
+
     func sync(
         store: SharedStore = SharedStore(),
         forceBridgeDeviceRefresh: Bool = false

--- a/Shared/SharedStore.swift
+++ b/Shared/SharedStore.swift
@@ -258,7 +258,13 @@ struct SharedStore: Sendable {
     }
 
     /// Row counts for diagnostics, without decoding any payloads.
-    func syncRecordCounts() throws -> (results: Int, sessions: Int, pendingUpload: Int) {
+    ///
+    /// The dirty counts are raw flag counts, not the uploader's queue.
+    /// `textRecordsNeedingSync` applies further rules -- kind, lifecycle state,
+    /// and dirty transcripts belonging to clean sessions -- so these answer
+    /// "is anything marked for upload at all", which is the question a
+    /// diagnostic needs, and deliberately not "how many will be sent".
+    func syncRecordCounts() throws -> (results: Int, sessions: Int, dirtyResults: Int, dirtySessions: Int) {
         try database().syncRecordCounts()
     }
 
@@ -863,7 +869,7 @@ private struct SharedStoreDatabase {
     /// Counts only. The diagnostics summary runs on the main actor, and
     /// decoding a full history there is exactly the kind of harm a diagnostic
     /// must not do.
-    func syncRecordCounts() throws -> (results: Int, sessions: Int, pendingUpload: Int) {
+    func syncRecordCounts() throws -> (results: Int, sessions: Int, dirtyResults: Int, dirtySessions: Int) {
         try withDatabase { db in
             func count(_ sql: String) throws -> Int {
                 try queryRows(sql, db: db) { _ in } read: { statement in
@@ -879,7 +885,7 @@ private struct SharedStoreDatabase {
             let pendingSessions = try count(
                 "SELECT COUNT(*) FROM recording_sessions WHERE sync_dirty = 1 AND cloud_record_name IS NOT NULL"
             )
-            return (results, sessions, pendingDictations + pendingSessions)
+            return (results, sessions, pendingDictations, pendingSessions)
         }
     }
 

--- a/Shared/SharedStore.swift
+++ b/Shared/SharedStore.swift
@@ -257,6 +257,11 @@ struct SharedStore: Sendable {
         try database().textRecordsNeedingSync(limit: limit)
     }
 
+    /// Row counts for diagnostics, without decoding any payloads.
+    func syncRecordCounts() throws -> (results: Int, sessions: Int, pendingUpload: Int) {
+        try database().syncRecordCounts()
+    }
+
     func textRecordsForSyncMigration(limit: Int = 5_000) throws -> [SyncTextRecord] {
         try database().textRecordsForSyncMigration(limit: limit)
     }
@@ -852,6 +857,29 @@ private struct SharedStoreDatabase {
                 }
                 try upsertValue(try encoder.encode(true), key: .customWordsInitialized, db: db)
             }
+        }
+    }
+
+    /// Counts only. The diagnostics summary runs on the main actor, and
+    /// decoding a full history there is exactly the kind of harm a diagnostic
+    /// must not do.
+    func syncRecordCounts() throws -> (results: Int, sessions: Int, pendingUpload: Int) {
+        try withDatabase { db in
+            func count(_ sql: String) throws -> Int {
+                try queryRows(sql, db: db) { _ in } read: { statement in
+                    Int(sqlite3_column_int64(statement, 0))
+                }.first ?? 0
+            }
+
+            let results = try count("SELECT COUNT(*) FROM result_history WHERE deleted_at IS NULL")
+            let sessions = try count("SELECT COUNT(*) FROM recording_sessions WHERE deleted_at IS NULL")
+            let pendingDictations = try count(
+                "SELECT COUNT(*) FROM result_history WHERE sync_dirty = 1 AND cloud_record_name IS NOT NULL"
+            )
+            let pendingSessions = try count(
+                "SELECT COUNT(*) FROM recording_sessions WHERE sync_dirty = 1 AND cloud_record_name IS NOT NULL"
+            )
+            return (results, sessions, pendingDictations + pendingSessions)
         }
     }
 


### PR DESCRIPTION
A tester on 0.1.3(9) has sync enabled, iCloud available, no error, and *"All text is up to date."* on the phone, while his Mac reports *"iCloud sync active"*. Nothing crosses in either direction — including a voice note recorded after the update.

## Why this is needed

That status line appears whenever a pass downloads and uploads nothing. It looks identical whether there was genuinely nothing to do or the device is stuck behind something invisible.

Every value that would tell those apart is currently unobservable from outside the app:

- whether the legacy default-zone migration completed
- whether a change token exists
- how many records are queued for upload
- whether a companion device was ever discovered

Several rounds of screenshots did not converge on an answer, which is the signal that the app isn't reporting enough. This adds those four to the existing diagnostics export, so one copy from a tester answers what screenshots could not.

## What each field discriminates

| Reading | Means |
|---|---|
| `migrated=false` | The migration still isn't completing — #27 didn't hold |
| `pendingUpload=N`, N>0 | Records are queued and not going up — upload path |
| `pendingUpload=0` with notes present | Nothing is being *marked* for upload |
| `changeToken=none` | Downloads never establish a baseline |
| `linkedDevice=none` | The devices can't see each other's records at all |

## Privacy

Counts and flags only. No note text, transcripts, titles, or filenames, and no identifier longer than an eight-character request-ID fragment.

The second commit removes the companion device's **name** from the output. It was `ProcessInfo.hostName` / `Host.current().localizedName`, which is routinely someone's real name — and this text exists to be pasted into a chat. It now reports presence and platform (`linkedDevice=macOS`), which is all the field was for.

## Scope

Diagnostics only — no change to sync behaviour. The underlying failure is still undiagnosed; this is how it gets diagnosed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli-ios/pr/29"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788099035&installation_model_id=422865&pr_number=29&repository=Muesli-HQ%2Fmuesli-ios&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli-ios%2Fpull%2F29&signature=7c3f8268384c100d666b538deff5fcd00dd96936a206d3df02f33a75fe21bb09"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced diagnostic reports with a concise overview of iCloud synchronization status.
  * Reports now include migration status, saved sync information, pending uploads, local notes and sessions, and linked device details.

* **Improvements**
  * Improved report formatting for clearer, more readable audio audit and synchronization information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->