### PR TITLE
Migrate iOS text sync to CKSyncEngine

### DIFF
--- a/Context/handoff-2026-08-10-ios-cksyncengine-migration.md
+++ b/Context/handoff-2026-08-10-ios-cksyncengine-migration.md
@@ -14,6 +14,7 @@ This branch migrates Muesli iOS text-record synchronization from the manual Clou
   - `d1d56a6` Report privacy-safe iCloud sync progress
   - `a8b37c6` Fix CKSyncEngine account-change crash
   - `2643d0e` Repair synced dictation timing metadata
+  - `f6d267e` Harden CKSyncEngine account and batching safety
 
 ## Behavior
 
@@ -21,6 +22,7 @@ This branch migrates Muesli iOS text-record synchronization from the manual Clou
 - SQLite dirty state remains the durable source of pending local changes.
 - Engine serialization is environment-namespaced so Development and Production state cannot collide.
 - The first CloudKit account is stored only as a SHA-256 scope. A different account clears pending engine work and pauses sync without requeueing or uploading the local library.
+- Before an already-synced legacy library can claim its first account scope, the current private zone must contain at least one matching stable text-record ID. The proof uses batched record existence requests with no desired fields, so it downloads no authored content. A missing zone or zero overlap pauses sync instead of risking a cross-account upload; local-only libraries can claim normally.
 - Same-account zone recreation clears obsolete record change tags/system fields before migration, then safely requeues the preserved local text.
 - CloudKit chooses size-aware upload batches through its record-provider API while SQLite still loads each local page once.
 - Sync diagnostics expose only phase, timestamps, and counts; note text and record identifiers are never emitted.
@@ -29,7 +31,7 @@ This branch migrates Muesli iOS text-record synchronization from the manual Clou
 
 ## Validation
 
-- Full `MuesliTests` suite passed after the review fixes: 222 tests, 0 failures.
+- Full `MuesliTests` suite passed after the review fixes: 225 tests, 0 failures.
 - A disposable MuesliDev device harness was signed with:
   - bundle: `com.phequals7.muesli.ios.dev`
   - app group: `group.com.phequals7.muesli.dev`

--- a/Context/handoff-2026-08-10-ios-cksyncengine-migration.md
+++ b/Context/handoff-2026-08-10-ios-cksyncengine-migration.md
@@ -76,6 +76,26 @@ reset, size-aware batching, exact-version acknowledgements, conflict/retry handl
 privacy-safe diagnostics, recoverable WPM timing/one-time repair, local audio semantics,
 and cancellation/account-change crash protection.
 
+The recovery follow-up also closes lifecycle edge cases found during cross-platform
+review:
+
+- zone loss now includes direct or recursively nested `unknownItem`, `zoneNotFound`,
+  and `userDeletedZone` errors;
+- nested partial failures containing `notAuthenticated` or `permissionFailure` retire
+  cached preparation so the account boundary must be proven again;
+- a second zone/account-context failure after the bounded zone retry also invalidates
+  the newly prepared state before it is rethrown;
+- a failed merged runtime drain discards its pending intent with the failed waiters,
+  and cancellation generations prevent a retired drain from consuming new work;
+- cancellation releases APNs/UI waiters before waiting for CKSyncEngine cleanup, so
+  the application delegate's background completion cannot hang behind that cleanup.
+
+Validation used the existing DerivedData cache at
+`/Users/pranavhari/Library/Developer/Xcode/DerivedData/MuesliiOS-hfpsukoywdcgmbddckyxgiejqtau`:
+
+- focused `MuesliCKSyncEngineTests`: 29 tests, 0 failures;
+- full iOS unit suite (UI tests skipped): 238 tests, 0 failures.
+
 ## Remaining physical checks
 
 1. Launch MuesliDev on the unlocked picophone and allow the one-time repair to sync.

--- a/Context/handoff-2026-08-10-ios-cksyncengine-migration.md
+++ b/Context/handoff-2026-08-10-ios-cksyncengine-migration.md
@@ -103,11 +103,23 @@ review:
 - missing-provenance error traversal is depth-bounded like other recursive CloudKit
   classifiers.
 
+The final lifecycle audit added two further barriers:
+
+- overlapping cancellations are reference-counted, so a new-generation request cannot
+  execute until every older CKSyncEngine cleanup has returned, regardless of completion
+  order;
+- bridge refresh cancellation now waits for the retired bridge task, cancels its concrete
+  `CKModifyRecordsOperation`, and owns its continuation exactly once. This prevents a late
+  private-CloudKit callback from publishing stale companion presence after sync disable or
+  an account transition, without introducing any analytics identifier.
+
 Validation used the existing DerivedData cache at
 `/Users/pranavhari/Library/Developer/Xcode/DerivedData/MuesliiOS-hfpsukoywdcgmbddckyxgiejqtau`:
 
-- focused `MuesliCKSyncEngineTests`: 37 tests, 0 failures;
-- full iOS unit suite (UI tests skipped): 246 tests, 0 failures.
+- focused `MuesliCKSyncEngineTests`: 39 tests, 0 failures (43 tests including
+  `MuesliBridgeDeviceIdentityTests`);
+- full iOS unit suite (UI tests skipped): 248 tests, 0 failures;
+- `build-for-testing`: succeeded with signing disabled.
 
 ## Remaining physical checks
 

--- a/Context/handoff-2026-08-10-ios-cksyncengine-migration.md
+++ b/Context/handoff-2026-08-10-ios-cksyncengine-migration.md
@@ -137,9 +137,40 @@ Validation after provenance hardening, using the same DerivedData cache:
 - `build-for-testing`: succeeded with signing disabled;
 - `git diff --check`: clean.
 
+Physical-device validation then exposed an independent model lifecycle bug while checking
+the sync changes: a selected Parakeet v3 model was absent, but launch/foreground prewarm
+called FluidAudio's download-capable loader directly. A recorded note could therefore wait
+inside model acquisition until the voice-note watchdog fired, even though CloudKit sync had
+already completed. The fix keeps model transfer and inference ownership separate:
+
+- missing launch/foreground models enter `ModelBackgroundDownloadService`; only a complete
+  downloaded model is warmed into memory;
+- all selectable Parakeet, realtime Parakeet, and WhisperKit models now have background
+  download plans, and each app bundle owns a distinct background-session identifier so the
+  side-by-side MuesliDev and TestFlight apps cannot share transfer state;
+- recording is refused with a recoverable status while the selected model is incomplete,
+  instead of accepting audio that is guaranteed to stall during transcription;
+- the transcription engine opens the selected model's local directory and never uses
+  FluidAudio's `downloadAndLoad` or the streaming manager's download-capable load path;
+- FluidAudio readiness requires every compiled CoreML artifact plus its vocabulary, while
+  WhisperKit commits its existing completion marker only after all required components land;
+- no model path, authored audio, transcript, account identifier, or CloudKit record identity
+  was added to telemetry or diagnostics.
+
+Validation used the same existing DerivedData cache:
+
+- focused `SettingsModelCatalogTests`: 16 tests, 0 failures;
+- full iOS unit suite (UI tests skipped): 256 tests, 0 failures;
+- `build-for-testing`: succeeded with signing disabled;
+- `git diff --check`: clean.
+
 ## Remaining physical checks
 
-1. Launch MuesliDev on the unlocked picophone and allow the one-time repair to sync.
-2. Confirm MuesliDev on macOS reports a plausible WPM rather than a six-digit value.
-3. Record a timestamped iPhone note with measurable duration; confirm it appears on the Mac and WPM remains plausible.
-4. If inspecting SQLite, query aggregate counts and duration sums only. Do not inspect transcript text or record identifiers.
+1. Deploy this PR over the existing MuesliDev installation without resetting app data or permissions.
+2. Select an absent model, leave the Models/onboarding step, and confirm its download keeps
+   progressing and ends in the ready state.
+3. Confirm the record button cannot begin a doomed voice note while that model is incomplete.
+4. After readiness, record a >20-second note and confirm local transcription completes without
+   any FluidAudio model-network request.
+5. Confirm the timestamped iPhone note appears on the Mac and WPM remains plausible.
+6. If inspecting SQLite, query aggregate counts and duration sums only. Do not inspect transcript text or record identifiers.

--- a/Context/handoff-2026-08-10-ios-cksyncengine-migration.md
+++ b/Context/handoff-2026-08-10-ios-cksyncengine-migration.md
@@ -1,0 +1,48 @@
+# iOS CKSyncEngine migration handoff (2026-08-10)
+
+## Scope
+
+This branch migrates Muesli iOS text-record synchronization from the manual CloudKit cursor loop to `CKSyncEngine`. Audio remains local. It also adds privacy-safe progress state and repairs recoverable dictation timing metadata so synced records do not corrupt cross-device WPM metrics.
+
+## Branch
+
+- Repository: `muesli-ios`
+- Branch: `codex/ios-cksyncengine-migration`
+- Base: `origin/main` at `90f2942`
+- Commits before this handoff:
+  - `a14f7a9` Migrate iOS text sync to CKSyncEngine
+  - `d1d56a6` Report privacy-safe iCloud sync progress
+  - `a8b37c6` Fix CKSyncEngine account-change crash
+  - `2643d0e` Repair synced dictation timing metadata
+
+## Behavior
+
+- `CKSyncEngine` owns CloudKit change fetching and upload scheduling.
+- SQLite dirty state remains the durable source of pending local changes.
+- Engine serialization is environment-namespaced so Development and Production state cannot collide.
+- Account changes clear stale serialized engine state without cancelling the engine from inside its own delegate callback.
+- Sync diagnostics expose only phase, timestamps, and counts; note text and record identifiers are never emitted.
+- Dictation records now carry linked recording-session start/end times and a positive duration when recoverable.
+- A versioned, environment-scoped repair marks only existing cloud-backed dictations with valid linked timing dirty once. It does not fabricate timing for legacy rows that lack it.
+
+## Validation
+
+- Full `MuesliTests` suite passed after the timing repair.
+- A disposable MuesliDev device harness was signed with:
+  - bundle: `com.phequals7.muesli.ios.dev`
+  - app group: `group.com.phequals7.muesli.dev`
+  - CloudKit container: `iCloud.com.mueslihq.muesli`
+  - CloudKit environment: Production
+- The updated app installed successfully over the existing picophone MuesliDev installation, preserving the same identity and application data.
+- Final launch and two-way timing validation still require the phone to remain unlocked.
+
+## Companion macOS defense
+
+The macOS branch `codex/wpm-invalid-duration-defense` excludes untimed records from the WPM numerator and denominator while continuing to include their words in total-word metrics. That defense is intentionally separate from this iOS transport migration.
+
+## Remaining physical checks
+
+1. Launch MuesliDev on the unlocked picophone and allow the one-time repair to sync.
+2. Confirm MuesliDev on macOS reports a plausible WPM rather than a six-digit value.
+3. Record a timestamped iPhone note with measurable duration; confirm it appears on the Mac and WPM remains plausible.
+4. If inspecting SQLite, query aggregate counts and duration sums only. Do not inspect transcript text or record identifiers.

--- a/Context/handoff-2026-08-10-ios-cksyncengine-migration.md
+++ b/Context/handoff-2026-08-10-ios-cksyncengine-migration.md
@@ -22,7 +22,7 @@ This branch migrates Muesli iOS text-record synchronization from the manual Clou
 - SQLite dirty state remains the durable source of pending local changes.
 - Engine serialization is environment-namespaced so Development and Production state cannot collide.
 - The first CloudKit account is stored only as a SHA-256 scope. A different account clears pending engine work and pauses sync without requeuing or uploading the local library.
-- Before an already-synced legacy library can claim its first account scope, the current private zone must contain at least one matching stable text-record ID. The proof uses batched record existence requests with no desired fields, so it downloads no authored content. A missing zone or zero overlap pauses sync instead of risking a cross-account upload; local-only libraries can claim normally.
+- Before an already-synced legacy library can claim its first account scope, the current private zone must contain every stable text-record ID that carries evidence of prior CloudKit sync. The proof uses batched record existence requests with `desiredKeys: []`, so it downloads no authored content. Missing, partial, extra, incomplete-response, or wrong-record-type proof pauses sync instead of risking a cross-account upload; local-only libraries can claim normally.
 - Same-account zone recreation clears obsolete record change tags/system fields before migration, then safely requeues the preserved local text.
 - CloudKit chooses size-aware upload batches through its record-provider API while SQLite still loads each local page once.
 - Sync diagnostics expose only phase, timestamps, and counts; note text and record identifiers are never emitted.
@@ -120,6 +120,22 @@ Validation used the existing DerivedData cache at
   `MuesliBridgeDeviceIdentityTests`);
 - full iOS unit suite (UI tests skipped): 248 tests, 0 failures;
 - `build-for-testing`: succeeded with signing disabled.
+
+The final account-provenance review tightened the legacy claim gate from “any overlap”
+to exact set equality. CloudKit returns only the matching expected `TextRecord` identities;
+the account is claimed only when that set equals the complete local set requiring proof.
+Missing IDs, partial overlap, unrequested IDs, incomplete responses, and wrong record
+types fail closed; service errors still propagate. The request continues to use
+`desiredKeys: []`, and neither authored content nor raw record identities are logged or
+persisted as diagnostics. Fresh local-only libraries bypass this legacy proof and retain
+normal first-account behavior.
+
+Validation after provenance hardening, using the same DerivedData cache:
+
+- focused `MuesliCKSyncEngineTests`: 43 tests, 0 failures;
+- full iOS unit suite (UI tests skipped): 252 tests, 0 failures;
+- `build-for-testing`: succeeded with signing disabled;
+- `git diff --check`: clean.
 
 ## Remaining physical checks
 

--- a/Context/handoff-2026-08-10-ios-cksyncengine-migration.md
+++ b/Context/handoff-2026-08-10-ios-cksyncengine-migration.md
@@ -21,7 +21,7 @@ This branch migrates Muesli iOS text-record synchronization from the manual Clou
 - `CKSyncEngine` owns CloudKit change fetching and upload scheduling.
 - SQLite dirty state remains the durable source of pending local changes.
 - Engine serialization is environment-namespaced so Development and Production state cannot collide.
-- The first CloudKit account is stored only as a SHA-256 scope. A different account clears pending engine work and pauses sync without requeueing or uploading the local library.
+- The first CloudKit account is stored only as a SHA-256 scope. A different account clears pending engine work and pauses sync without requeuing or uploading the local library.
 - Before an already-synced legacy library can claim its first account scope, the current private zone must contain at least one matching stable text-record ID. The proof uses batched record existence requests with no desired fields, so it downloads no authored content. A missing zone or zero overlap pauses sync instead of risking a cross-account upload; local-only libraries can claim normally.
 - Same-account zone recreation clears obsolete record change tags/system fields before migration, then safely requeues the preserved local text.
 - CloudKit chooses size-aware upload batches through its record-provider API while SQLite still loads each local page once.

--- a/Context/handoff-2026-08-10-ios-cksyncengine-migration.md
+++ b/Context/handoff-2026-08-10-ios-cksyncengine-migration.md
@@ -164,6 +164,32 @@ Validation used the same existing DerivedData cache:
 - `build-for-testing`: succeeded with signing disabled;
 - `git diff --check`: clean.
 
+Physical-device sync testing also exposed a presentation-only failure when one incoming
+Mac note was inserted into an iPhone history containing roughly 2,600 entries. The data
+had committed correctly, but each fetched CloudKit page independently refreshed three
+related SQLite inventories while the home view recomputed and animated a large,
+variable-height `LazyVStack`. That allowed transient combinations of old/new history and
+session data to be rendered, producing overlapping or disappearing cards.
+
+The presentation boundary is now deterministic:
+
+- CKSyncEngine continues committing every fetched page to SQLite, but publishes one remote
+  history invalidation only after the complete fetch finishes;
+- results, recording sessions, and transcripts are read from one SQLite read transaction;
+- the coordinator publishes one immutable, equality-gated history presentation revision;
+- the three source-filtered timelines are derived once per actual history revision, not for
+  unrelated sync progress or spinner frames;
+- the animated sync button observes progress in its own small SwiftUI subtree, and external
+  history revisions do not animate the large timeline diff.
+
+Regression coverage includes a 2,600-row existing history followed by one incoming Mac
+record. It asserts one presentation revision, 2,601 unique stable row identities, and
+unchanged order for every pre-existing row. Validation used the same DerivedData cache:
+
+- focused CKSyncEngine, store, and presentation suites: 113 tests, 0 failures;
+- full iOS unit suite (UI tests skipped): 259 tests, 0 failures;
+- `git diff --check`: clean.
+
 ## Remaining physical checks
 
 1. Deploy this PR over the existing MuesliDev installation without resetting app data or permissions.
@@ -173,4 +199,6 @@ Validation used the same existing DerivedData cache:
 4. After readiness, record a >20-second note and confirm local transcription completes without
    any FluidAudio model-network request.
 5. Confirm the timestamped iPhone note appears on the Mac and WPM remains plausible.
-6. If inspecting SQLite, query aggregate counts and duration sums only. Do not inspect transcript text or record identifiers.
+6. While the iPhone home timeline is visible, sync one new Mac note and confirm the saved
+   count advances once without overlapping, disappearing, or animated row churn.
+7. If inspecting SQLite, query aggregate counts and duration sums only. Do not inspect transcript text or record identifiers.

--- a/Context/handoff-2026-08-10-ios-cksyncengine-migration.md
+++ b/Context/handoff-2026-08-10-ios-cksyncengine-migration.md
@@ -85,16 +85,29 @@ review:
   cached preparation so the account boundary must be proven again;
 - a second zone/account-context failure after the bounded zone retry also invalidates
   the newly prepared state before it is rethrown;
-- a failed merged runtime drain discards its pending intent with the failed waiters,
-  and cancellation generations prevent a retired drain from consuming new work;
+- runtime batches own only the waiters present when that batch starts, so a failed
+  send cannot discard a later APNs fetch; the later request drains exactly once;
 - cancellation releases APNs/UI waiters before waiting for CKSyncEngine cleanup, so
-  the application delegate's background completion cannot hang behind that cleanup.
+  the application delegate's background completion cannot hang behind that cleanup;
+- cancellation is also an execution barrier: requests accepted into the new generation
+  remain queued until engine cleanup finishes, then start exactly once;
+- APNs fetch waiters expire after a 20-second background budget and are removed exactly
+  once without cancelling durable CKSyncEngine convergence;
+- enabled startup now performs nonblocking send-then-fetch convergence, rebuilding
+  ordinary persisted SQLite dirty rows even when restored engine pending state is empty;
+- automatic zone-deletion/missing-zone delegate events only invalidate preparation and
+  serialized state. The next external recovery fetch escalates to paginated send-then-fetch
+  so metadata-reset rows rebuild the zone without delegate reentrancy;
+- ancillary bridge refreshes coalesce, union forced refresh intent, cancel with the sync
+  lifecycle, and require current-generation authority before publishing device identity;
+- missing-provenance error traversal is depth-bounded like other recursive CloudKit
+  classifiers.
 
 Validation used the existing DerivedData cache at
 `/Users/pranavhari/Library/Developer/Xcode/DerivedData/MuesliiOS-hfpsukoywdcgmbddckyxgiejqtau`:
 
-- focused `MuesliCKSyncEngineTests`: 29 tests, 0 failures;
-- full iOS unit suite (UI tests skipped): 238 tests, 0 failures.
+- focused `MuesliCKSyncEngineTests`: 37 tests, 0 failures;
+- full iOS unit suite (UI tests skipped): 246 tests, 0 failures.
 
 ## Remaining physical checks
 

--- a/Context/handoff-2026-08-10-ios-cksyncengine-migration.md
+++ b/Context/handoff-2026-08-10-ios-cksyncengine-migration.md
@@ -20,21 +20,23 @@ This branch migrates Muesli iOS text-record synchronization from the manual Clou
 - `CKSyncEngine` owns CloudKit change fetching and upload scheduling.
 - SQLite dirty state remains the durable source of pending local changes.
 - Engine serialization is environment-namespaced so Development and Production state cannot collide.
-- Account changes clear stale serialized engine state without cancelling the engine from inside its own delegate callback.
+- The first CloudKit account is stored only as a SHA-256 scope. A different account clears pending engine work and pauses sync without requeueing or uploading the local library.
+- Same-account zone recreation clears obsolete record change tags/system fields before migration, then safely requeues the preserved local text.
+- CloudKit chooses size-aware upload batches through its record-provider API while SQLite still loads each local page once.
 - Sync diagnostics expose only phase, timestamps, and counts; note text and record identifiers are never emitted.
 - Dictation records now carry linked recording-session start/end times and a positive duration when recoverable.
 - A versioned, environment-scoped repair marks only existing cloud-backed dictations with valid linked timing dirty once. It does not fabricate timing for legacy rows that lack it.
 
 ## Validation
 
-- Full `MuesliTests` suite passed after the timing repair.
+- Full `MuesliTests` suite passed after the review fixes: 222 tests, 0 failures.
 - A disposable MuesliDev device harness was signed with:
   - bundle: `com.phequals7.muesli.ios.dev`
   - app group: `group.com.phequals7.muesli.dev`
   - CloudKit container: `iCloud.com.mueslihq.muesli`
   - CloudKit environment: Production
 - The updated app installed successfully over the existing picophone MuesliDev installation, preserving the same identity and application data.
-- Final launch and two-way timing validation still require the phone to remain unlocked.
+- Final automated device validation was blocked by a disconnected Xcode Wi-Fi tunnel; rerunning it requires the picophone to be unlocked and reachable from this Mac.
 
 ## Companion macOS defense
 

--- a/Context/handoff-2026-08-10-ios-cksyncengine-migration.md
+++ b/Context/handoff-2026-08-10-ios-cksyncengine-migration.md
@@ -44,6 +44,38 @@ This branch migrates Muesli iOS text-record synchronization from the manual Clou
 
 The macOS branch `codex/wpm-invalid-duration-defense` excludes untimed records from the WPM numerator and denominator while continuing to include their words in total-word metrics. That defense is intentionally separate from this iOS transport migration.
 
+## 2026-08-12 low-latency orchestration follow-up
+
+Physical Production-entitled testing showed correct convergence but exposed avoidable
+latency: every small local mutation waited one second and then paid account lookup,
+zone lookup, legacy migration, fetch, and send in series. Fetch-first was an intentional
+bootstrap safety decision while CKSyncEngine first hydrated server system fields; it is
+not required for every steady-state mutation once the persistent engine is prepared.
+
+The branch now shares the same operation contract as the macOS follow-up:
+
+- `prepare()` creates/restores the persistent automatic CKSyncEngine and performs the
+  account-boundary, zone, and legacy migration work once per valid engine lifecycle;
+- `sendLocalChanges()` immediately registers SQLite `sync_dirty` pages and calls
+  `sendChanges()` without a fetch-first round trip;
+- `fetchRemoteChanges()` only fetches incoming changes for foreground/APNs delivery;
+- `syncManually()` deliberately sends outgoing changes before fetching incoming ones;
+- concurrent foreground, local, APNs, and manual triggers union their intent rather
+  than overwriting one another;
+- account/zone invalidation re-enters preparation, with one bounded same-account
+  zone-recreation retry and no cross-account upload;
+- bridge-device discovery remains throttled onboarding/UI metadata and runs outside
+  the visible text-sync critical path;
+- the app delegate creates the process-wide runtime at launch whenever sync is enabled,
+  and routes CloudKit remote notifications to fetch-only work with a correct background
+  completion result. CKSyncEngine delegate callbacks never start sync recursively.
+
+All earlier safety work remains in place: the durable outbox, environment-scoped state,
+hashed account boundary, no-content legacy provenance proof, same-account metadata
+reset, size-aware batching, exact-version acknowledgements, conflict/retry handling,
+privacy-safe diagnostics, recoverable WPM timing/one-time repair, local audio semantics,
+and cancellation/account-change crash protection.
+
 ## Remaining physical checks
 
 1. Launch MuesliDev on the unlocked picophone and allow the one-time repair to sync.

--- a/Muesli/DictationCoordinator.swift
+++ b/Muesli/DictationCoordinator.swift
@@ -177,6 +177,9 @@ final class DictationCoordinator {
         store: store,
         onRemoteChanges: { @MainActor [weak self] in
             self?.scheduleHistoryRefreshAfterRemoteChanges()
+        },
+        onProgress: { @MainActor [weak self] progress in
+            self?.updateICloudSyncProgress(progress)
         }
     )
     private var onboardingModelReadyCueModel: LocalTranscriptionModel?
@@ -2779,6 +2782,22 @@ final class DictationCoordinator {
             guard !Task.isCancelled else { return }
             self?.iCloudRemoteRefreshTask = nil
             self?.refreshHistory()
+        }
+    }
+
+    private func updateICloudSyncProgress(_ progress: MuesliCKSyncProgress) {
+        guard MuesliPreferences.iCloudSyncEnabled else { return }
+        switch progress {
+        case .preparing:
+            iCloudSyncStatusText = "Preparing private iCloud..."
+        case .fetching:
+            iCloudSyncStatusText = "Checking iCloud for changes..."
+        case .downloading(let count):
+            iCloudSyncStatusText = "Applied \(count) iCloud changes..."
+        case .uploading(let count):
+            iCloudSyncStatusText = count > 0
+                ? "Uploaded \(count) local changes..."
+                : "Uploading local changes..."
         }
     }
 

--- a/Muesli/DictationCoordinator.swift
+++ b/Muesli/DictationCoordinator.swift
@@ -3213,6 +3213,10 @@ final class DictationCoordinator {
         guard !isRecording, !hasMeetingRecordingInProgress else { return }
 
         let model = selectedTranscriptionModel
+        guard ModelPreparationPolicy.action(isDownloaded: model.isDownloaded) == .warmDownloadedModel else {
+            prepareSelectedModel(reason: "prewarm_\(reason)")
+            return
+        }
         modelPreparation = ModelPreparationState(
             phase: .preparing,
             progress: nil,
@@ -3598,6 +3602,25 @@ final class DictationCoordinator {
     }
 
     private func startRecording(for request: DictationRequest, source: String) {
+        guard selectedTranscriptionModel.isDownloaded else {
+            let message = "\(selectedTranscriptionModel.shortName) is still downloading"
+            statusText = message
+            if !isSelectedModelDownloadSuppressed {
+                prepareSelectedModel(reason: "\(source)_recording")
+            }
+            if source == "keyboard" {
+                try? store.saveStatus(.init(requestID: request.id, phase: .failed, message: message))
+                saveKeyboardHandoff(requestID: request.id, phase: .failed, message: message)
+                saveKeyboardRuntimeStatus(
+                    isActive: canStartKeyboardRequestsInBackground,
+                    activeRequestID: nil,
+                    phase: .failed,
+                    message: message,
+                    supportsBackgroundStart: canStartKeyboardRequestsInBackground
+                )
+            }
+            return
+        }
         guard !isRecording,
               !hasMeetingRecordingInProgress,
               !voiceNoteLifecycleState.isWorkActive,

--- a/Muesli/DictationCoordinator.swift
+++ b/Muesli/DictationCoordinator.swift
@@ -170,7 +170,15 @@ final class DictationCoordinator {
     private var persistentKeyboardSessionRequestIDs = Set<UUID>()
     private var iCloudSyncTask: Task<Void, Never>?
     private var iCloudSyncDebounceTask: Task<Void, Never>?
+    private var iCloudRemoteRefreshTask: Task<Void, Never>?
     private var pendingICloudSyncReason: String?
+    private var iCloudSyncGeneration = 0
+    @ObservationIgnored private lazy var iCloudSyncEngine = MuesliCKSyncEngine(
+        store: store,
+        onRemoteChanges: { @MainActor [weak self] in
+            self?.scheduleHistoryRefreshAfterRemoteChanges()
+        }
+    )
     private var onboardingModelReadyCueModel: LocalTranscriptionModel?
     private var meetingChunkTasks: [Task<MeetingChunkTranscription?, Never>] = []
     private var meetingChunkTranscriptions: [MeetingChunkTranscription] = []
@@ -2686,13 +2694,14 @@ final class DictationCoordinator {
         }
         isICloudSyncInProgress = true
         iCloudSyncStatusText = "Syncing through private iCloud..."
+        let syncGeneration = iCloudSyncGeneration
         iCloudSyncTask = Task { @MainActor [weak self] in
             guard let self else { return }
             do {
-                let result = try await ICloudTextSyncEngine().sync(
-                    store: self.store,
+                let result = try await self.iCloudSyncEngine.sync(
                     forceBridgeDeviceRefresh: self.shouldForceBridgeDeviceRefresh(for: reason)
                 )
+                guard syncGeneration == self.iCloudSyncGeneration else { return }
                 self.iCloudSyncTask = nil
                 self.isICloudSyncInProgress = false
                 let remoteDeviceName = MuesliBridgeDeviceIdentity.remoteDeviceDisplayName
@@ -2722,6 +2731,7 @@ final class DictationCoordinator {
                 }
                 self.runPendingICloudSyncIfNeeded()
             } catch {
+                guard syncGeneration == self.iCloudSyncGeneration else { return }
                 self.iCloudSyncTask = nil
                 self.isICloudSyncInProgress = false
                 self.iCloudSyncStatusText = "Sync failed: \(error.localizedDescription)"
@@ -2744,6 +2754,31 @@ final class DictationCoordinator {
                 }
                 self.runPendingICloudSyncIfNeeded()
             }
+        }
+    }
+
+    func disableICloudTextSync() {
+        iCloudSyncGeneration += 1
+        iCloudSyncDebounceTask?.cancel()
+        iCloudSyncDebounceTask = nil
+        iCloudRemoteRefreshTask?.cancel()
+        iCloudRemoteRefreshTask = nil
+        iCloudSyncTask?.cancel()
+        iCloudSyncTask = nil
+        pendingICloudSyncReason = nil
+        isICloudSyncInProgress = false
+        iCloudSyncStatusText = "iCloud sync is off."
+        Task { await iCloudSyncEngine.cancel() }
+    }
+
+    private func scheduleHistoryRefreshAfterRemoteChanges() {
+        guard UIApplication.shared.applicationState == .active else { return }
+        iCloudRemoteRefreshTask?.cancel()
+        iCloudRemoteRefreshTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .milliseconds(150))
+            guard !Task.isCancelled else { return }
+            self?.iCloudRemoteRefreshTask = nil
+            self?.refreshHistory()
         }
     }
 

--- a/Muesli/DictationCoordinator.swift
+++ b/Muesli/DictationCoordinator.swift
@@ -173,6 +173,7 @@ final class DictationCoordinator {
     private var pendingICloudSyncIntent: MuesliCKSyncIntent = []
     private var pendingICloudSyncReason: String?
     private var iCloudSyncGeneration = 0
+    @ObservationIgnored private var historyPresentationPublicationIsSuspended = false
     @ObservationIgnored private let iCloudSyncRuntime = MuesliCKSyncRuntime.shared
     @ObservationIgnored nonisolated(unsafe) private var iCloudRemoteChangesObserver: NSObjectProtocol?
     @ObservationIgnored nonisolated(unsafe) private var iCloudSyncProgressObserver: NSObjectProtocol?
@@ -304,8 +305,13 @@ final class DictationCoordinator {
         get { voiceNoteLiveState.transcript }
         set { voiceNoteLiveState.setTranscript(newValue) }
     }
-    var dictationHistory: [DictationResult] = []
-    var recordingSessions: [RecordingSession] = []
+    var voiceNoteHistoryPresentation = VoiceNoteHistoryPresentation.empty
+    var dictationHistory: [DictationResult] = [] {
+        didSet { publishVoiceNoteHistoryPresentationIfNeeded() }
+    }
+    var recordingSessions: [RecordingSession] = [] {
+        didSet { publishVoiceNoteHistoryPresentationIfNeeded() }
+    }
     private var transcriptCache: [UUID: Transcript] = [:]
     var isMeetingRecording: Bool {
         meetingPresentationState.isCapturing
@@ -1830,8 +1836,8 @@ final class DictationCoordinator {
         guard !Self.shouldConfigureForUITestingFromLaunchArguments() else { return }
         #endif
         do {
-            dictationHistory = try store.resultsHistory()
-            let persistedSessions = try store.recordingSessions()
+            let snapshot = try store.historySnapshot()
+            let persistedSessions = snapshot.sessions
             let inventoryActiveSession = activeSession?.kind == .meeting ? nil : activeSession
             let repairedSessions = RecordingSessionInventory.preservingActiveSession(
                 inventoryActiveSession,
@@ -1850,13 +1856,33 @@ final class DictationCoordinator {
                     ]
                 )
             }
-            recordingSessions = repairedSessions
+            historyPresentationPublicationIsSuspended = true
+            defer {
+                historyPresentationPublicationIsSuspended = false
+                publishVoiceNoteHistoryPresentationIfNeeded()
+            }
             reconcileMeetingRuntime(with: persistedSessions, reason: "history_refresh")
-            transcriptCache = transcriptsBySessionID(try store.transcripts())
-            lastTranscript = dictationHistory.first?.text ?? lastTranscript
+            dictationHistory = snapshot.history
+            recordingSessions = repairedSessions
+            transcriptCache = transcriptsBySessionID(snapshot.transcripts)
+            lastTranscript = snapshot.history.first?.text ?? lastTranscript
         } catch {
             statusText = error.localizedDescription
         }
+    }
+
+    private func publishVoiceNoteHistoryPresentationIfNeeded() {
+        guard !historyPresentationPublicationIsSuspended,
+              !voiceNoteHistoryPresentation.matches(
+                history: dictationHistory,
+                sessions: recordingSessions
+              )
+        else { return }
+
+        voiceNoteHistoryPresentation = voiceNoteHistoryPresentation.updated(
+            history: dictationHistory,
+            sessions: recordingSessions
+        )
     }
 
     func reconcileMeetingRuntime(reason: String) {
@@ -2755,7 +2781,6 @@ final class DictationCoordinator {
                     self.iCloudSyncStatusText = remoteDeviceName.map { "All text is up to date with \($0)." }
                         ?? "All text is up to date."
                 }
-                self.refreshHistory()
                 AppTelemetry.signal(
                     "icloud_text_sync_completed",
                     parameters: ["reason": reason]

--- a/Muesli/DictationCoordinator.swift
+++ b/Muesli/DictationCoordinator.swift
@@ -169,19 +169,13 @@ final class DictationCoordinator {
     )
     private var persistentKeyboardSessionRequestIDs = Set<UUID>()
     private var iCloudSyncTask: Task<Void, Never>?
-    private var iCloudSyncDebounceTask: Task<Void, Never>?
     private var iCloudRemoteRefreshTask: Task<Void, Never>?
+    private var pendingICloudSyncIntent: MuesliCKSyncIntent = []
     private var pendingICloudSyncReason: String?
     private var iCloudSyncGeneration = 0
-    @ObservationIgnored private lazy var iCloudSyncEngine = MuesliCKSyncEngine(
-        store: store,
-        onRemoteChanges: { @MainActor [weak self] in
-            self?.scheduleHistoryRefreshAfterRemoteChanges()
-        },
-        onProgress: { @MainActor [weak self] progress in
-            self?.updateICloudSyncProgress(progress)
-        }
-    )
+    @ObservationIgnored private let iCloudSyncRuntime = MuesliCKSyncRuntime.shared
+    @ObservationIgnored nonisolated(unsafe) private var iCloudRemoteChangesObserver: NSObjectProtocol?
+    @ObservationIgnored nonisolated(unsafe) private var iCloudSyncProgressObserver: NSObjectProtocol?
     private var onboardingModelReadyCueModel: LocalTranscriptionModel?
     private var meetingChunkTasks: [Task<MeetingChunkTranscription?, Never>] = []
     private var meetingChunkTranscriptions: [MeetingChunkTranscription] = []
@@ -471,6 +465,26 @@ final class DictationCoordinator {
                 self?.handleAudioServicesReset()
             }
         }
+        iCloudRemoteChangesObserver = NotificationCenter.default.addObserver(
+            forName: .muesliCKSyncRemoteChanges,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor in
+                self?.scheduleHistoryRefreshAfterRemoteChanges()
+            }
+        }
+        iCloudSyncProgressObserver = NotificationCenter.default.addObserver(
+            forName: .muesliCKSyncProgress,
+            object: nil,
+            queue: .main
+        ) { [weak self] notification in
+            guard let progress = notification.userInfo?[MuesliCKSyncNotificationKey.progress]
+                    as? MuesliCKSyncProgress else { return }
+            Task { @MainActor in
+                self?.updateICloudSyncProgress(progress)
+            }
+        }
         keyboardSessionKeeper.onRecordingFailure = { [weak self] failure in
             Task { @MainActor in
                 self?.handleVoiceNoteWriterFailure(failure)
@@ -510,6 +524,12 @@ final class DictationCoordinator {
         }
         if let mediaServicesResetObserver {
             NotificationCenter.default.removeObserver(mediaServicesResetObserver)
+        }
+        if let iCloudRemoteChangesObserver {
+            NotificationCenter.default.removeObserver(iCloudRemoteChangesObserver)
+        }
+        if let iCloudSyncProgressObserver {
+            NotificationCenter.default.removeObserver(iCloudSyncProgressObserver)
         }
     }
 
@@ -2685,6 +2705,14 @@ final class DictationCoordinator {
     }
 
     func syncICloudTextIfEnabled(reason: String = "manual") {
+        let intent: MuesliCKSyncIntent = reason == "foreground" ? .fetch : .manual
+        requestICloudTextSync(intent: intent, reason: reason)
+    }
+
+    private func requestICloudTextSync(
+        intent: MuesliCKSyncIntent,
+        reason: String
+    ) {
         guard MuesliPreferences.iCloudSyncEnabled else {
             iCloudSyncStatusText = "iCloud sync is off."
             isICloudSyncInProgress = false
@@ -2692,6 +2720,7 @@ final class DictationCoordinator {
         }
         guard iCloudSyncTask == nil else {
             isICloudSyncInProgress = true
+            pendingICloudSyncIntent.formUnion(intent)
             pendingICloudSyncReason = reason
             return
         }
@@ -2701,9 +2730,14 @@ final class DictationCoordinator {
         iCloudSyncTask = Task { @MainActor [weak self] in
             guard let self else { return }
             do {
-                let result = try await self.iCloudSyncEngine.sync(
-                    forceBridgeDeviceRefresh: self.shouldForceBridgeDeviceRefresh(for: reason)
-                )
+                let result: ICloudTextSyncResult
+                if intent == .manual {
+                    result = try await self.iCloudSyncRuntime.syncManually()
+                } else if intent == .send {
+                    result = try await self.iCloudSyncRuntime.sendLocalChanges()
+                } else {
+                    result = try await self.iCloudSyncRuntime.fetchRemoteChanges()
+                }
                 guard syncGeneration == self.iCloudSyncGeneration else { return }
                 self.iCloudSyncTask = nil
                 self.isICloudSyncInProgress = false
@@ -2731,6 +2765,11 @@ final class DictationCoordinator {
                         "bridge_enable_completed",
                         parameters: ["platform": "ios", "source": reason]
                     )
+                }
+                if self.shouldForceBridgeDeviceRefresh(for: reason) {
+                    Task {
+                        await self.iCloudSyncRuntime.refreshBridgeDevice(forceRefresh: true)
+                    }
                 }
                 self.runPendingICloudSyncIfNeeded()
             } catch {
@@ -2762,16 +2801,15 @@ final class DictationCoordinator {
 
     func disableICloudTextSync() {
         iCloudSyncGeneration += 1
-        iCloudSyncDebounceTask?.cancel()
-        iCloudSyncDebounceTask = nil
         iCloudRemoteRefreshTask?.cancel()
         iCloudRemoteRefreshTask = nil
         iCloudSyncTask?.cancel()
         iCloudSyncTask = nil
+        pendingICloudSyncIntent = []
         pendingICloudSyncReason = nil
         isICloudSyncInProgress = false
         iCloudSyncStatusText = "iCloud sync is off."
-        Task { await iCloudSyncEngine.cancel() }
+        Task { await iCloudSyncRuntime.cancel() }
     }
 
     private func scheduleHistoryRefreshAfterRemoteChanges() {
@@ -2803,19 +2841,16 @@ final class DictationCoordinator {
 
     private func scheduleICloudSyncAfterLocalChange(reason: String) {
         guard MuesliPreferences.iCloudSyncEnabled else { return }
-        iCloudSyncDebounceTask?.cancel()
-        iCloudSyncDebounceTask = Task { @MainActor [weak self] in
-            try? await Task.sleep(for: .seconds(1.0))
-            guard !Task.isCancelled else { return }
-            self?.iCloudSyncDebounceTask = nil
-            self?.syncICloudTextIfEnabled(reason: reason)
-        }
+        requestICloudTextSync(intent: .send, reason: reason)
     }
 
     private func runPendingICloudSyncIfNeeded() {
-        guard let reason = pendingICloudSyncReason else { return }
+        guard let reason = pendingICloudSyncReason,
+              !pendingICloudSyncIntent.isEmpty else { return }
+        let intent = pendingICloudSyncIntent
+        pendingICloudSyncIntent = []
         pendingICloudSyncReason = nil
-        scheduleICloudSyncAfterLocalChange(reason: reason)
+        requestICloudTextSync(intent: intent, reason: reason)
     }
 
     private func shouldForceBridgeDeviceRefresh(for reason: String) -> Bool {

--- a/Muesli/DictationView.swift
+++ b/Muesli/DictationView.swift
@@ -19,7 +19,6 @@ struct DictationView: View {
     @State private var isSyncSetupPromptPresented = false
     @State private var shouldShowKeyboardSetupRow = false
     @State private var dashboardStats = DictationDashboardStats.empty
-    @State private var voiceNoteTimelineCache = VoiceNoteTimelineCache()
     @State private var navigationPath = NavigationPath()
 
     var body: some View {
@@ -62,11 +61,7 @@ struct DictationView: View {
                 guard active else { return }
                 refreshVisibleStateIfNeeded()
             }
-            .onChange(of: coordinator.dictationHistory.count) { _, _ in
-                guard isActive else { return }
-                updateDashboardStats()
-            }
-            .onChange(of: coordinator.recordingSessions.count) { _, _ in
+            .onChange(of: coordinator.voiceNoteHistoryPresentation.revision) { _, _ in
                 guard isActive else { return }
                 updateDashboardStats()
             }
@@ -87,7 +82,9 @@ struct DictationView: View {
                 coordinator.setKeyboardSessionModeEnabled(enabled)
             }
             .navigationDestination(for: UUID.self) { resultID in
-                if let result = coordinator.dictationHistory.first(where: { $0.id == resultID }),
+                if let result = coordinator.voiceNoteHistoryPresentation.history.first(
+                    where: { $0.id == resultID }
+                ),
                    let session = coordinator.recordingSession(for: result),
                    let audioURL = coordinator.audioFileURL(for: result) {
                     DictationAudioDetailView(result: result, session: session, audioURL: audioURL) {
@@ -521,13 +518,7 @@ struct DictationView: View {
 
     @ViewBuilder
     private var voiceNoteHistorySection: some View {
-        let timeline = voiceNoteTimelineCache.items(
-            for: VoiceNoteTimelineInput(
-                history: displayHistory,
-                sessions: timelineSessions,
-                sourceFilter: sourceFilter
-            )
-        )
+        let timeline = visibleVoiceNoteTimeline
         historyHeader(timeline: timeline)
         historyRows(timeline: timeline)
     }
@@ -546,10 +537,9 @@ struct DictationView: View {
 
                 Spacer()
 
-                ICloudSyncStatusButton(
+                CoordinatorICloudSyncStatusButton(
+                    coordinator: coordinator,
                     isEnabled: iCloudSyncEnabled,
-                    isSyncing: coordinator.isICloudSyncInProgress,
-                    hasError: syncStatusIsError,
                     action: triggerHomeSync
                 )
 
@@ -607,18 +597,26 @@ struct DictationView: View {
                         }
                     }
                 }
+                .animation(
+                    nil,
+                    value: coordinator.voiceNoteHistoryPresentation.revision
+                )
             }
         }
     }
 
-    private var timelineSessions: [RecordingSession] {
-        var sessions = coordinator.recordingSessions
+    private var visibleVoiceNoteTimeline: [VoiceNoteTimelineItem] {
         #if DEBUG
         if shouldUseMockDictations {
-            sessions = Self.mockRecordingSessions
+            return VoiceNoteTimelineBuilder.build(from: .init(
+                history: Self.mockDictationHistory,
+                sessions: Self.mockRecordingSessions,
+                sourceFilter: sourceFilter
+            ))
         }
         #endif
-        return sessions
+
+        return coordinator.voiceNoteHistoryPresentation.timeline(for: sourceFilter)
     }
 
     private func openCompletedVoiceNote(
@@ -638,7 +636,9 @@ struct DictationView: View {
     }
 
     private var statsSessions: [RecordingSession] {
-        coordinator.recordingSessions.filter { sourceFilter.includes($0.syncOrigin) }
+        coordinator.voiceNoteHistoryPresentation.sessions.filter {
+            sourceFilter.includes($0.syncOrigin)
+        }
     }
 
     private var displayHistory: [DictationResult] {
@@ -648,7 +648,7 @@ struct DictationView: View {
         }
         #endif
 
-        return coordinator.dictationHistory
+        return coordinator.voiceNoteHistoryPresentation.history
     }
 
     private var shouldUseMockDictations: Bool {
@@ -725,10 +725,6 @@ struct DictationView: View {
 
     private var isDictationButtonDisabled: Bool {
         isTranscribing
-    }
-
-    private var syncStatusIsError: Bool {
-        coordinator.iCloudSyncStatusText?.localizedCaseInsensitiveContains("sync failed") == true
     }
 
     private var dictationButtonTitle: String {
@@ -1164,6 +1160,22 @@ private struct VoiceNoteRecordButtonLabel: View {
         } else {
             MuesliTheme.textPrimary
         }
+    }
+}
+
+private struct CoordinatorICloudSyncStatusButton: View {
+    @Bindable var coordinator: DictationCoordinator
+    let isEnabled: Bool
+    let action: () -> Void
+
+    var body: some View {
+        ICloudSyncStatusButton(
+            isEnabled: isEnabled,
+            isSyncing: coordinator.isICloudSyncInProgress,
+            hasError: coordinator.iCloudSyncStatusText?
+                .localizedCaseInsensitiveContains("sync failed") == true,
+            action: action
+        )
     }
 }
 

--- a/Muesli/FluidAudioTranscriptionEngine.swift
+++ b/Muesli/FluidAudioTranscriptionEngine.swift
@@ -1,4 +1,5 @@
 import AVFoundation
+import CoreML
 import Foundation
 @preconcurrency import FluidAudio
 
@@ -198,10 +199,9 @@ actor FluidAudioTranscriptionEngine: TranscriptionEngine {
         guard let asrVersion = model.asrVersion else {
             throw TranscriptionEngineError.unsupportedOfflineModel(model.shortName)
         }
-        let models = try await AsrModels.downloadAndLoad(version: asrVersion) { downloadProgress in
-            let fraction = min(max(downloadProgress.fractionCompleted, 0), 1)
-            progress?(fraction, Self.statusText(for: downloadProgress.phase, fraction: fraction))
-        }
+        let modelDirectory = try localModelDirectory(for: model)
+        progress?(0.88, "Loading downloaded model...")
+        let models = try await Self.loadLocalAsrModels(from: modelDirectory, version: asrVersion)
         progress?(1.0, "Preparing model for this iPhone...")
         let manager = AsrManager(config: .default)
         let loadHeartbeat = Self.modelLoadHeartbeatTask(
@@ -240,12 +240,11 @@ actor FluidAudioTranscriptionEngine: TranscriptionEngine {
         guard let variant = model.streamingVariant, let chunkSize = variant.eouChunkSize else {
             throw TranscriptionEngineError.unsupportedStreamingModel(model.shortName)
         }
+        let modelDirectory = try localModelDirectory(for: model)
 
         let manager = StreamingEouAsrManager(chunkSize: chunkSize)
-        try await manager.loadModels(to: nil, configuration: nil) { downloadProgress in
-            let fraction = min(max(downloadProgress.fractionCompleted, 0), 1)
-            progress?(fraction, Self.statusText(for: downloadProgress.phase, fraction: fraction))
-        }
+        progress?(0.9, "Loading downloaded model...")
+        try await manager.loadModels(from: modelDirectory)
         self.streamingManager = manager
         progress?(1.0, "\(model.shortName) ready")
         return manager
@@ -269,6 +268,7 @@ actor FluidAudioTranscriptionEngine: TranscriptionEngine {
         guard let variant = model.whisperVariant else {
             throw TranscriptionEngineError.unsupportedOfflineModel(model.shortName)
         }
+        _ = try localModelDirectory(for: model)
 
         isLoadingWhisperRuntime = true
         defer {
@@ -287,6 +287,93 @@ actor FluidAudioTranscriptionEngine: TranscriptionEngine {
             await runtime.unload()
             throw error
         }
+    }
+
+    private func localModelDirectory(for model: LocalTranscriptionModel) throws -> URL {
+        guard ModelBackgroundDownloadService.isModelDownloaded(model),
+              let directory = ModelBackgroundDownloadService.storageDirectory(for: model)
+        else {
+            throw TranscriptionEngineError.modelNotDownloaded(model.shortName)
+        }
+        return directory
+    }
+
+    private static func loadLocalAsrModels(
+        from directory: URL,
+        version: AsrModelVersion
+    ) async throws -> AsrModels {
+        let preprocessorFile: String
+        let encoderFile: String?
+        let decoderFile: String
+        let jointFile: String
+        switch version {
+        case .tdtCtc110m:
+            preprocessorFile = ModelNames.ASR.preprocessorFile
+            encoderFile = nil
+            decoderFile = ModelNames.ASR.decoderFile
+            jointFile = ModelNames.ASR.jointFile
+        case .v3:
+            preprocessorFile = ModelNames.ASR.preprocessorFile
+            encoderFile = ModelNames.ASR.encoderFile
+            decoderFile = ModelNames.ASR.decoderFile
+            jointFile = ModelNames.ASR.jointV3File
+        default:
+            throw TranscriptionEngineError.unsupportedOfflineModel("Parakeet")
+        }
+
+        let defaultConfiguration = AsrModels.defaultConfiguration()
+        let preprocessorConfiguration = MLModelConfiguration()
+        preprocessorConfiguration.computeUnits = .cpuOnly
+
+        let preprocessor = try await MLModel.load(
+            contentsOf: directory.appendingPathComponent(preprocessorFile),
+            configuration: preprocessorConfiguration
+        )
+        let encoder: MLModel?
+        if let encoderFile {
+            encoder = try await MLModel.load(
+                contentsOf: directory.appendingPathComponent(encoderFile),
+                configuration: defaultConfiguration
+            )
+        } else {
+            encoder = nil
+        }
+        let decoder = try await MLModel.load(
+            contentsOf: directory.appendingPathComponent(decoderFile),
+            configuration: defaultConfiguration
+        )
+        let joint = try await MLModel.load(
+            contentsOf: directory.appendingPathComponent(jointFile),
+            configuration: defaultConfiguration
+        )
+        let vocabularyData = try Data(
+            contentsOf: directory.appendingPathComponent(ModelNames.ASR.vocabularyFile)
+        )
+
+        return AsrModels(
+            encoder: encoder,
+            preprocessor: preprocessor,
+            decoder: decoder,
+            joint: joint,
+            configuration: defaultConfiguration,
+            vocabulary: try decodeParakeetVocabulary(vocabularyData),
+            version: version
+        )
+    }
+
+    static func decodeParakeetVocabulary(_ data: Data) throws -> [Int: String] {
+        let object = try JSONSerialization.jsonObject(with: data)
+        if let array = object as? [String] {
+            return Dictionary(uniqueKeysWithValues: array.enumerated().map { ($0.offset, $0.element) })
+        }
+        if let dictionary = object as? [String: String] {
+            return dictionary.reduce(into: [:]) { vocabulary, entry in
+                if let tokenID = Int(entry.key) {
+                    vocabulary[tokenID] = entry.value
+                }
+            }
+        }
+        throw TranscriptionEngineError.invalidLocalVocabulary
     }
 
     private func transcribeWithWhisperKit(
@@ -405,11 +492,17 @@ actor FluidAudioTranscriptionEngine: TranscriptionEngine {
 }
 
 private enum TranscriptionEngineError: LocalizedError {
+    case invalidLocalVocabulary
+    case modelNotDownloaded(String)
     case unsupportedOfflineModel(String)
     case unsupportedStreamingModel(String)
 
     var errorDescription: String? {
         switch self {
+        case .invalidLocalVocabulary:
+            "The downloaded transcription vocabulary is invalid. Download the model again."
+        case .modelNotDownloaded(let modelName):
+            "\(modelName) is still downloading. Open Models to check its progress."
         case .unsupportedOfflineModel(let modelName):
             "\(modelName) does not support offline transcription."
         case .unsupportedStreamingModel(let modelName):

--- a/Muesli/ICloudTextSyncEngine.swift
+++ b/Muesli/ICloudTextSyncEngine.swift
@@ -1,5 +1,6 @@
 import CloudKit
 import Foundation
+import OSLog
 
 struct ICloudTextSyncResult: Equatable {
     let uploaded: Int
@@ -209,6 +210,10 @@ enum MuesliBridgeDeviceIdentity {
 
 final class ICloudTextSyncEngine: @unchecked Sendable {
     static let containerIdentifier = "iCloud.com.mueslihq.muesli"
+    private static let logger = Logger(
+        subsystem: "com.mueslihq.muesli",
+        category: "icloud-preflight"
+    )
 
     enum Schema {
         static let containerIdentifier = ICloudTextSyncEngine.containerIdentifier
@@ -328,6 +333,12 @@ final class ICloudTextSyncEngine: @unchecked Sendable {
         forceBridgeDeviceRefresh: Bool = false
     ) async throws -> Bool {
         let syncZoneWasRecreated = try await ensureSyncZone()
+        if syncZoneWasRecreated {
+            // The new zone belongs to the same account, but persisted system
+            // fields still carry record change tags from the deleted zone.
+            // Clear them before migration builds any CKRecord instances.
+            try store.resetTextRecordCloudMetadataForZoneRecreation()
+        }
         await refreshBridgeDeviceLink(forceRefresh: forceBridgeDeviceRefresh)
         try await migrateDefaultZoneIfNeeded(store: store)
         return syncZoneWasRecreated
@@ -359,7 +370,9 @@ final class ICloudTextSyncEngine: @unchecked Sendable {
             MuesliBridgeDeviceIdentity.updateRemoteDevices(from: records, defaults: defaults)
             MuesliBridgeDeviceIdentity.markRefreshed(defaults: defaults)
         } catch {
-            print("Failed to refresh iCloud bridge device identity: \(error)")
+            Self.logger.error(
+                "bridge_refresh_failed error_type=\(String(describing: type(of: error)), privacy: .public)"
+            )
             MuesliBridgeDeviceIdentity.markRefreshFailed(defaults: defaults)
         }
     }

--- a/Muesli/ICloudTextSyncEngine.swift
+++ b/Muesli/ICloudTextSyncEngine.swift
@@ -421,17 +421,21 @@ final class ICloudTextSyncEngine: @unchecked Sendable {
         )
     }
 
-    /// Proves that an unscoped legacy library belongs to the current account.
+    /// Returns the stable IDs that prove an unscoped legacy library belongs to
+    /// the current account.
     ///
     /// Only stable record IDs are requested and `desiredKeys` is empty, so this
     /// check never downloads authored text or other user-authored fields. A
     /// missing record/zone is a safe non-match; connectivity and service errors
     /// still propagate so a transient failure cannot claim the wrong account.
-    func syncZoneContainsAnyTextRecord(named recordNames: Set<String>) async throws -> Bool {
+    /// The caller requires exact equality with its complete legacy ID set: one
+    /// overlapping record is not sufficient provenance for the rest of a library.
+    func matchingSyncZoneTextRecordNames(named recordNames: Set<String>) async throws -> Set<String> {
         let names = recordNames.filter { !$0.isEmpty }.sorted()
-        guard !names.isEmpty else { return false }
+        guard !names.isEmpty else { return [] }
 
         let batchSize = 200
+        var matchedNames = Set<String>()
         var start = names.startIndex
         while start < names.endIndex {
             let end = names.index(start, offsetBy: batchSize, limitedBy: names.endIndex)
@@ -442,23 +446,39 @@ final class ICloudTextSyncEngine: @unchecked Sendable {
 
             do {
                 let results = try await database.records(for: recordIDs, desiredKeys: [])
-                for result in results.values {
-                    switch result {
-                    case .success(let record):
-                        if record.recordType == Schema.textRecordType {
-                            return true
-                        }
-                    case .failure(let error):
-                        guard Self.isMissingProvenanceRecord(error) else { throw error }
-                    }
-                }
+                matchedNames.formUnion(try Self.matchingProvenanceRecordNames(
+                    expectedRecordIDs: recordIDs,
+                    results: results
+                ))
             } catch {
                 guard Self.isMissingProvenanceRecord(error) else { throw error }
             }
 
             start = end
         }
-        return false
+        return matchedNames
+    }
+
+    /// Classifies only requested, correctly typed records as provenance. Missing
+    /// response entries and wrong record types are safe mismatches; non-missing
+    /// CloudKit failures propagate to keep transient errors from claiming scope.
+    static func matchingProvenanceRecordNames(
+        expectedRecordIDs: [CKRecord.ID],
+        results: [CKRecord.ID: Result<CKRecord, Error>]
+    ) throws -> Set<String> {
+        var matchedNames = Set<String>()
+        for recordID in expectedRecordIDs {
+            guard let result = results[recordID] else { continue }
+            switch result {
+            case .success(let record):
+                guard record.recordID == recordID,
+                      record.recordType == Schema.textRecordType else { continue }
+                matchedNames.insert(recordID.recordName)
+            case .failure(let error):
+                guard Self.isMissingProvenanceRecord(error) else { throw error }
+            }
+        }
+        return matchedNames
     }
 
     @discardableResult

--- a/Muesli/ICloudTextSyncEngine.swift
+++ b/Muesli/ICloudTextSyncEngine.swift
@@ -207,10 +207,10 @@ enum MuesliBridgeDeviceIdentity {
 }
 
 
-final class ICloudTextSyncEngine {
+final class ICloudTextSyncEngine: @unchecked Sendable {
     static let containerIdentifier = "iCloud.com.mueslihq.muesli"
 
-    private enum Schema {
+    enum Schema {
         static let containerIdentifier = ICloudTextSyncEngine.containerIdentifier
         static let syncZoneName = "MuesliSyncZone"
         static let textRecordType = "MuesliTextRecord"
@@ -226,6 +226,13 @@ final class ICloudTextSyncEngine {
     private let database: CKDatabase
     private let changeTokenStore: ICloudTextChangeTokenStore
     private let defaults: UserDefaults
+
+    static var cloudSyncStateKeyComponent: String {
+        Bundle.main.bundleIdentifier?
+            .trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)
+            .lowercased()
+            ?? "unspecified"
+    }
 
     init(
         container: CKContainer = CKContainer(identifier: Schema.containerIdentifier),
@@ -249,9 +256,7 @@ final class ICloudTextSyncEngine {
     static func diagnosticsSummary(store: SharedStore = SharedStore()) -> String {
         let defaults = UserDefaults.standard
         let migrated = defaults.bool(forKey: Schema.migratedDefaultZoneKey)
-        let hasToken = defaults.data(
-            forKey: UserDefaultsICloudTextChangeTokenStore.defaultKey
-        ) != nil
+        let hasEngineState = (try? store.cloudSyncStateData(forKey: MuesliCKSyncEngine.stateKey)) != nil
         let enabled = MuesliPreferences.iCloudSyncEnabled
 
         // Counted in SQL rather than by fetching rows: this runs on the main
@@ -271,7 +276,7 @@ final class ICloudTextSyncEngine {
         return [
             "sync: enabled=\(enabled)",
             "migrated=\(migrated)",
-            "changeToken=\(hasToken ? "present" : "none")",
+            "engineState=\(hasEngineState ? "present" : "none")",
             "dirtyNotes/dirtySessions=\(dirty ?? "?")",
             "localNotes=\(results.map(String.init) ?? "?")",
             "localSessions=\(sessions.map(String.init) ?? "?")",
@@ -283,7 +288,7 @@ final class ICloudTextSyncEngine {
         store: SharedStore = SharedStore(),
         forceBridgeDeviceRefresh: Bool = false
     ) async throws -> ICloudTextSyncResult {
-        try await ensureSyncZone()
+        _ = try await ensureSyncZone()
         await refreshBridgeDeviceLink(forceRefresh: forceBridgeDeviceRefresh)
         try await migrateDefaultZoneIfNeeded(store: store)
 
@@ -296,27 +301,49 @@ final class ICloudTextSyncEngine {
         }
 
         let dirtyRecords = try store.textRecordsNeedingSync()
-        let savedRecords = try await save(records: dirtyRecords.map(Self.syncZoneCloudRecord(from:)))
+        let dirtyByRecordName = Dictionary(uniqueKeysWithValues: dirtyRecords.map { ($0.id, $0) })
+        let savedRecords = try await save(records: dirtyRecords.map {
+            Self.syncZoneCloudRecord(from: $0)
+        })
         for savedRecord in savedRecords {
-            guard let kind = Self.kind(from: savedRecord) else { continue }
+            guard let kind = Self.kind(from: savedRecord),
+                  let uploadedRecord = dirtyByRecordName[savedRecord.recordID.recordName]
+            else { continue }
             try store.markTextRecordSynced(
                 kind: kind,
                 recordName: savedRecord.recordID.recordName,
-                changeTag: savedRecord.recordChangeTag
+                changeTag: savedRecord.recordChangeTag,
+                recordUpdatedAt: uploadedRecord.updatedAt
             )
         }
 
         return ICloudTextSyncResult(uploaded: savedRecords.count, downloaded: downloaded)
     }
 
-    private func ensureSyncZone() async throws {
+    /// Transitional preflight retained during the CKSyncEngine migration.
+    /// Bridge discovery and the one-time default-zone import still use their
+    /// existing operations; custom-zone fetches and uploads belong to CKSyncEngine.
+    func prepareForCKSyncEngine(
+        store: SharedStore,
+        forceBridgeDeviceRefresh: Bool = false
+    ) async throws -> Bool {
+        let syncZoneWasRecreated = try await ensureSyncZone()
+        await refreshBridgeDeviceLink(forceRefresh: forceBridgeDeviceRefresh)
+        try await migrateDefaultZoneIfNeeded(store: store)
+        return syncZoneWasRecreated
+    }
+
+    @discardableResult
+    func ensureSyncZone() async throws -> Bool {
         do {
             _ = try await fetchZone(id: Schema.syncZoneID)
+            return false
         } catch {
             guard Self.isSyncZoneMissing(error) else { throw error }
             _ = try await save(zone: CKRecordZone(zoneName: Schema.syncZoneName))
             changeTokenStore.clearToken()
             defaults.set(false, forKey: Schema.migratedDefaultZoneKey)
+            return true
         }
     }
 
@@ -418,7 +445,9 @@ final class ICloudTextSyncEngine {
         }
 
         let migrationRecords = try store.textRecordsForSyncMigration()
-        _ = try await saveInBatches(records: migrationRecords.map(Self.syncZoneCloudRecord(from:)))
+        _ = try await saveInBatches(records: migrationRecords.map {
+            Self.syncZoneCloudRecord(from: $0)
+        })
 
         changeTokenStore.clearToken()
         let primedSyncZoneRecords = try await fetchChangedTextRecords()
@@ -756,18 +785,13 @@ final class ICloudTextSyncEngine {
         }
     }
 
-    private static func syncZoneCloudRecord(from record: SyncTextRecord) -> CKRecord {
-        let cloud = CKRecord(
-            recordType: Schema.textRecordType,
-            recordID: CKRecord.ID(recordName: record.id, zoneID: Schema.syncZoneID)
-        )
+    static func syncZoneCloudRecord(from record: SyncTextRecord, baseRecord: CKRecord? = nil) -> CKRecord {
+        let recordID = CKRecord.ID(recordName: record.id, zoneID: Schema.syncZoneID)
+        let persistedRecord = record.cloudSystemFields.flatMap(Self.record(fromSystemFields:))
+        let cloud = baseRecord
+            ?? persistedRecord
+            ?? CKRecord(recordType: Schema.textRecordType, recordID: recordID)
         cloud["kind"] = record.kind.rawValue as NSString
-        cloud["title"] = record.title as NSString?
-        cloud["text"] = record.text as NSString
-        cloud["speakerTranscript"] = record.speakerTranscript as NSString?
-        cloud["summaryText"] = record.summaryText as NSString?
-        cloud["manualNotes"] = record.manualNotes as NSString?
-        cloud["manualNotesUpdatedAt"] = record.manualNotesUpdatedAt as NSDate?
         cloud["source"] = record.source as NSString?
         cloud["localSource"] = record.localSource as NSString?
         cloud["engineIdentifier"] = record.engineIdentifier as NSString?
@@ -779,21 +803,37 @@ final class ICloudTextSyncEngine {
         cloud["wordCount"] = record.wordCount as NSNumber
         cloud["isDeleted"] = record.isDeleted as NSNumber
         cloud["schemaVersion"] = 1 as NSNumber
+        guard !record.isDeleted else {
+            cloud["title"] = nil as NSString?
+            cloud["text"] = nil as NSString?
+            cloud["speakerTranscript"] = nil as NSString?
+            cloud["summaryText"] = nil as NSString?
+            cloud["manualNotes"] = nil as NSString?
+            cloud["manualNotesUpdatedAt"] = nil as NSDate?
+            return cloud
+        }
+        cloud["title"] = record.title as NSString?
+        cloud["text"] = record.text as NSString
+        cloud["speakerTranscript"] = record.speakerTranscript as NSString?
+        cloud["summaryText"] = record.summaryText as NSString?
+        cloud["manualNotes"] = record.manualNotes as NSString?
+        cloud["manualNotesUpdatedAt"] = record.manualNotesUpdatedAt as NSDate?
         return cloud
     }
 
-    private static func syncTextRecord(from record: CKRecord) -> SyncTextRecord? {
+    static func syncTextRecord(from record: CKRecord) -> SyncTextRecord? {
         guard let kind = kind(from: record),
-              let text = record["text"] as? String,
               let createdAt = record["createdAt"] as? Date,
               let updatedAt = record["updatedAt"] as? Date else {
             return nil
         }
+        let isDeleted = (record["isDeleted"] as? NSNumber)?.boolValue ?? false
+        guard isDeleted || record["text"] is String else { return nil }
         return SyncTextRecord(
             id: record.recordID.recordName,
             kind: kind,
             title: record["title"] as? String,
-            text: text,
+            text: (record["text"] as? String) ?? "",
             speakerTranscript: record["speakerTranscript"] as? String,
             summaryText: record["summaryText"] as? String,
             manualNotes: record["manualNotes"] as? String,
@@ -807,12 +847,31 @@ final class ICloudTextSyncEngine {
             endedAt: record["endedAt"] as? Date,
             durationSeconds: (record["durationSeconds"] as? NSNumber)?.doubleValue ?? 0,
             wordCount: (record["wordCount"] as? NSNumber)?.intValue ?? 0,
-            isDeleted: (record["isDeleted"] as? NSNumber)?.boolValue ?? false,
-            cloudChangeTag: record.recordChangeTag
+            isDeleted: isDeleted,
+            cloudChangeTag: record.recordChangeTag,
+            cloudSystemFields: encodedSystemFields(for: record)
         )
     }
 
-    private static func kind(from record: CKRecord) -> SyncTextRecordKind? {
+    static func encodedSystemFields(for record: CKRecord) -> Data? {
+        let archiver = NSKeyedArchiver(requiringSecureCoding: true)
+        record.encodeSystemFields(with: archiver)
+        archiver.finishEncoding()
+        return archiver.encodedData
+    }
+
+    static func record(fromSystemFields data: Data) -> CKRecord? {
+        do {
+            let unarchiver = try NSKeyedUnarchiver(forReadingFrom: data)
+            unarchiver.requiresSecureCoding = true
+            defer { unarchiver.finishDecoding() }
+            return CKRecord(coder: unarchiver)
+        } catch {
+            return nil
+        }
+    }
+
+    static func kind(from record: CKRecord) -> SyncTextRecordKind? {
         guard let raw = record["kind"] as? String else { return nil }
         return SyncTextRecordKind(rawValue: raw)
     }

--- a/Muesli/ICloudTextSyncEngine.swift
+++ b/Muesli/ICloudTextSyncEngine.swift
@@ -344,6 +344,46 @@ final class ICloudTextSyncEngine: @unchecked Sendable {
         return syncZoneWasRecreated
     }
 
+    /// Proves that an unscoped legacy library belongs to the current account.
+    ///
+    /// Only stable record IDs are requested and `desiredKeys` is empty, so this
+    /// check never downloads authored text or other user-authored fields. A
+    /// missing record/zone is a safe non-match; connectivity and service errors
+    /// still propagate so a transient failure cannot claim the wrong account.
+    func syncZoneContainsAnyTextRecord(named recordNames: Set<String>) async throws -> Bool {
+        let names = recordNames.filter { !$0.isEmpty }.sorted()
+        guard !names.isEmpty else { return false }
+
+        let batchSize = 200
+        var start = names.startIndex
+        while start < names.endIndex {
+            let end = names.index(start, offsetBy: batchSize, limitedBy: names.endIndex)
+                ?? names.endIndex
+            let recordIDs = names[start..<end].map {
+                CKRecord.ID(recordName: $0, zoneID: Schema.syncZoneID)
+            }
+
+            do {
+                let results = try await database.records(for: recordIDs, desiredKeys: [])
+                for result in results.values {
+                    switch result {
+                    case .success(let record):
+                        if record.recordType == Schema.textRecordType {
+                            return true
+                        }
+                    case .failure(let error):
+                        guard Self.isMissingProvenanceRecord(error) else { throw error }
+                    }
+                }
+            } catch {
+                guard Self.isMissingProvenanceRecord(error) else { throw error }
+            }
+
+            start = end
+        }
+        return false
+    }
+
     @discardableResult
     func ensureSyncZone() async throws -> Bool {
         do {
@@ -913,6 +953,35 @@ final class ICloudTextSyncEngine: @unchecked Sendable {
             .joined(separator: " ")
         return message.contains(Schema.syncZoneName.lowercased())
             && (message.contains("zone not found") || message.contains("zone does not exist"))
+    }
+
+    private static func isMissingProvenanceRecord(_ error: Error) -> Bool {
+        if let ckError = error as? CKError {
+            switch ckError.code {
+            case .unknownItem, .zoneNotFound:
+                return true
+            case .partialFailure:
+                guard let errors = ckError.partialErrorsByItemID?.values,
+                      !errors.isEmpty else { return false }
+                return errors.allSatisfy(isMissingProvenanceRecord)
+            default:
+                return false
+            }
+        }
+
+        let nsError = error as NSError
+        if nsError.domain == CKError.errorDomain {
+            switch CKError.Code(rawValue: nsError.code) {
+            case .unknownItem, .zoneNotFound:
+                return true
+            default:
+                break
+            }
+        }
+        if let underlying = nsError.userInfo[NSUnderlyingErrorKey] as? Error {
+            return isMissingProvenanceRecord(underlying)
+        }
+        return false
     }
 
     private static var desiredTextRecordKeys: [CKRecord.FieldKey] {

--- a/Muesli/ICloudTextSyncEngine.swift
+++ b/Muesli/ICloudTextSyncEngine.swift
@@ -937,16 +937,11 @@ final class ICloudTextSyncEngine: @unchecked Sendable {
     }
 
     static func isSyncZoneMissing(_ error: Error) -> Bool {
-        if let ckError = error as? CKError {
-            if ckError.code == .unknownItem || ckError.code == .zoneNotFound {
-                return true
-            }
-            if ckError.code == .partialFailure,
-               ckError.partialErrorsByItemID?.values.contains(where: { partialError in
-                   (partialError as? CKError)?.code == .unknownItem
-               }) == true {
-                return true
-            }
+        if containsCloudKitError(
+            error,
+            codes: [.unknownItem, .zoneNotFound, .userDeletedZone]
+        ) {
+            return true
         }
 
         let nsError = error as NSError
@@ -962,10 +957,42 @@ final class ICloudTextSyncEngine: @unchecked Sendable {
             && (message.contains("zone not found") || message.contains("zone does not exist"))
     }
 
+    /// Recursively inspects CKError partial failures and underlying errors.
+    /// Depth is bounded defensively because NSError graphs are not guaranteed
+    /// to be acyclic.
+    static func containsCloudKitError(
+        _ error: Error,
+        codes: [CKError.Code],
+        depth: Int = 0
+    ) -> Bool {
+        guard depth < 8 else { return false }
+
+        if let ckError = error as? CKError {
+            if codes.contains(ckError.code) { return true }
+            if ckError.code == .partialFailure,
+               ckError.partialErrorsByItemID?.values.contains(where: {
+                   containsCloudKitError($0, codes: codes, depth: depth + 1)
+               }) == true {
+                return true
+            }
+        }
+
+        let nsError = error as NSError
+        if nsError.domain == CKError.errorDomain,
+           let code = CKError.Code(rawValue: nsError.code),
+           codes.contains(code) {
+            return true
+        }
+        if let underlying = nsError.userInfo[NSUnderlyingErrorKey] as? Error {
+            return containsCloudKitError(underlying, codes: codes, depth: depth + 1)
+        }
+        return false
+    }
+
     private static func isMissingProvenanceRecord(_ error: Error) -> Bool {
         if let ckError = error as? CKError {
             switch ckError.code {
-            case .unknownItem, .zoneNotFound:
+            case .unknownItem, .zoneNotFound, .userDeletedZone:
                 return true
             case .partialFailure:
                 guard let errors = ckError.partialErrorsByItemID?.values,
@@ -979,7 +1006,7 @@ final class ICloudTextSyncEngine: @unchecked Sendable {
         let nsError = error as NSError
         if nsError.domain == CKError.errorDomain {
             switch CKError.Code(rawValue: nsError.code) {
-            case .unknownItem, .zoneNotFound:
+            case .unknownItem, .zoneNotFound, .userDeletedZone:
                 return true
             default:
                 break

--- a/Muesli/ICloudTextSyncEngine.swift
+++ b/Muesli/ICloudTextSyncEngine.swift
@@ -294,7 +294,10 @@ final class ICloudTextSyncEngine: @unchecked Sendable {
         forceBridgeDeviceRefresh: Bool = false
     ) async throws -> ICloudTextSyncResult {
         _ = try await ensureSyncZone()
-        await refreshBridgeDeviceLink(forceRefresh: forceBridgeDeviceRefresh)
+        await refreshBridgeDeviceLink(
+            forceRefresh: forceBridgeDeviceRefresh,
+            shouldCommit: { true }
+        )
         try await migrateDefaultZoneIfNeeded(store: store)
 
         let remoteRecords = try await fetchChangedTextRecords()
@@ -347,8 +350,14 @@ final class ICloudTextSyncEngine: @unchecked Sendable {
     /// Bridge records are onboarding/UI metadata, not authorization or text
     /// synchronization state. A slow query here must never hold open a text
     /// upload, download, or the visible sync progress indicator.
-    func refreshBridgeDeviceLinkIfNeeded(forceRefresh: Bool = false) async {
-        await refreshBridgeDeviceLink(forceRefresh: forceRefresh)
+    func refreshBridgeDeviceLinkIfNeeded(
+        forceRefresh: Bool = false,
+        shouldCommit: @escaping @Sendable () async -> Bool = { true }
+    ) async {
+        await refreshBridgeDeviceLink(
+            forceRefresh: forceRefresh,
+            shouldCommit: shouldCommit
+        )
     }
 
     /// Proves that an unscoped legacy library belongs to the current account.
@@ -405,22 +414,29 @@ final class ICloudTextSyncEngine: @unchecked Sendable {
         }
     }
 
-    private func refreshBridgeDeviceLink(forceRefresh: Bool = false) async {
+    private func refreshBridgeDeviceLink(
+        forceRefresh: Bool = false,
+        shouldCommit: @escaping @Sendable () async -> Bool
+    ) async {
         guard MuesliBridgeDeviceIdentity.shouldRefresh(
             defaults: defaults,
             forceRefresh: forceRefresh
         ) else { return }
 
         do {
+            guard await shouldCommit(), !Task.isCancelled else { return }
             try await upsertLocalBridgeDeviceRecord()
             let records = try await fetchBridgeDeviceRecords()
+            guard await shouldCommit(), !Task.isCancelled else { return }
             MuesliBridgeDeviceIdentity.updateRemoteDevices(from: records, defaults: defaults)
             MuesliBridgeDeviceIdentity.markRefreshed(defaults: defaults)
         } catch {
             Self.logger.error(
                 "bridge_refresh_failed error_type=\(String(describing: type(of: error)), privacy: .public)"
             )
-            MuesliBridgeDeviceIdentity.markRefreshFailed(defaults: defaults)
+            if await shouldCommit(), !Task.isCancelled {
+                MuesliBridgeDeviceIdentity.markRefreshFailed(defaults: defaults)
+            }
         }
     }
 
@@ -989,7 +1005,8 @@ final class ICloudTextSyncEngine: @unchecked Sendable {
         return false
     }
 
-    private static func isMissingProvenanceRecord(_ error: Error) -> Bool {
+    static func isMissingProvenanceRecord(_ error: Error, depth: Int = 0) -> Bool {
+        guard depth < 8 else { return false }
         if let ckError = error as? CKError {
             switch ckError.code {
             case .unknownItem, .zoneNotFound, .userDeletedZone:
@@ -997,7 +1014,9 @@ final class ICloudTextSyncEngine: @unchecked Sendable {
             case .partialFailure:
                 guard let errors = ckError.partialErrorsByItemID?.values,
                       !errors.isEmpty else { return false }
-                return errors.allSatisfy(isMissingProvenanceRecord)
+                return errors.allSatisfy {
+                    isMissingProvenanceRecord($0, depth: depth + 1)
+                }
             default:
                 return false
             }
@@ -1013,7 +1032,7 @@ final class ICloudTextSyncEngine: @unchecked Sendable {
             }
         }
         if let underlying = nsError.userInfo[NSUnderlyingErrorKey] as? Error {
-            return isMissingProvenanceRecord(underlying)
+            return isMissingProvenanceRecord(underlying, depth: depth + 1)
         }
         return false
     }

--- a/Muesli/ICloudTextSyncEngine.swift
+++ b/Muesli/ICloudTextSyncEngine.swift
@@ -26,6 +26,67 @@ private final class DeliveredRecordCounter: @unchecked Sendable {
     }
 }
 
+/// Makes callback-based CloudKit operations obey Swift task cancellation while
+/// resuming their continuation exactly once, even if CloudKit calls back late.
+final class MuesliCancellableCloudKitOperation<Value>: @unchecked Sendable {
+    private let lock = NSLock()
+    private var operation: CKOperation?
+    private var continuation: CheckedContinuation<Value, any Error>?
+    private var isCancelled = false
+
+    func install(
+        operation: CKOperation,
+        continuation: CheckedContinuation<Value, any Error>
+    ) {
+        lock.lock()
+        if isCancelled {
+            lock.unlock()
+            operation.cancel()
+            continuation.resume(throwing: CancellationError())
+            return
+        }
+        self.operation = operation
+        self.continuation = continuation
+        lock.unlock()
+    }
+
+    func cancel() {
+        lock.lock()
+        isCancelled = true
+        let operation = operation
+        let continuation = continuation
+        self.operation = nil
+        self.continuation = nil
+        lock.unlock()
+        operation?.cancel()
+        continuation?.resume(throwing: CancellationError())
+    }
+
+    func succeed(_ value: sending Value) {
+        lock.lock()
+        guard let continuation else {
+            lock.unlock()
+            return
+        }
+        self.operation = nil
+        self.continuation = nil
+        lock.unlock()
+        continuation.resume(returning: value)
+    }
+
+    func fail(_ error: any Error) {
+        lock.lock()
+        guard let continuation else {
+            lock.unlock()
+            return
+        }
+        self.operation = nil
+        self.continuation = nil
+        lock.unlock()
+        continuation.resume(throwing: error)
+    }
+}
+
 private struct ICloudTextZoneChangesPage {
     let records: [CKRecord]
     let serverChangeToken: CKServerChangeToken
@@ -425,7 +486,7 @@ final class ICloudTextSyncEngine: @unchecked Sendable {
 
         do {
             guard await shouldCommit(), !Task.isCancelled else { return }
-            try await upsertLocalBridgeDeviceRecord()
+            try await upsertLocalBridgeDeviceRecord(shouldCommit: shouldCommit)
             let records = try await fetchBridgeDeviceRecords()
             guard await shouldCommit(), !Task.isCancelled else { return }
             MuesliBridgeDeviceIdentity.updateRemoteDevices(from: records, defaults: defaults)
@@ -440,7 +501,11 @@ final class ICloudTextSyncEngine: @unchecked Sendable {
         }
     }
 
-    private func upsertLocalBridgeDeviceRecord() async throws {
+    private func upsertLocalBridgeDeviceRecord(
+        shouldCommit: @escaping @Sendable () async -> Bool
+    ) async throws {
+        try Task.checkCancellation()
+        guard await shouldCommit() else { throw CancellationError() }
         let snapshot = MuesliBridgeDeviceIdentity.local(defaults: defaults)
         let recordID = CKRecord.ID(
             recordName: "bridge-device-\(snapshot.deviceID)",
@@ -448,6 +513,8 @@ final class ICloudTextSyncEngine: @unchecked Sendable {
         )
         let record = (try? await fetchRecord(id: recordID))
             ?? CKRecord(recordType: Schema.bridgeDeviceRecordType, recordID: recordID)
+        try Task.checkCancellation()
+        guard await shouldCommit() else { throw CancellationError() }
         if record["createdAt"] == nil {
             record["createdAt"] = Date() as NSDate
         }
@@ -808,30 +875,39 @@ final class ICloudTextSyncEngine: @unchecked Sendable {
 
     private func save(records: [CKRecord]) async throws -> [CKRecord] {
         guard !records.isEmpty else { return [] }
-        return try await withCheckedThrowingContinuation { continuation in
-            let operation = CKModifyRecordsOperation(recordsToSave: records, recordIDsToDelete: nil)
-            operation.savePolicy = .changedKeys
-            let lock = NSLock()
-            var savedRecords: [CKRecord] = []
-            operation.perRecordSaveBlock = { _, result in
-                if case .success(let record) = result {
-                    lock.lock()
-                    savedRecords.append(record)
-                    lock.unlock()
+        let cancellation = MuesliCancellableCloudKitOperation<[CKRecord]>()
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                let operation = CKModifyRecordsOperation(
+                    recordsToSave: records,
+                    recordIDsToDelete: nil
+                )
+                operation.savePolicy = .changedKeys
+                let lock = NSLock()
+                var savedRecords: [CKRecord] = []
+                operation.perRecordSaveBlock = { _, result in
+                    if case .success(let record) = result {
+                        lock.lock()
+                        savedRecords.append(record)
+                        lock.unlock()
+                    }
                 }
-            }
-            operation.modifyRecordsResultBlock = { result in
-                switch result {
-                case .success:
-                    lock.lock()
-                    let records = savedRecords
-                    lock.unlock()
-                    continuation.resume(returning: records)
-                case .failure(let error):
-                    continuation.resume(throwing: error)
+                operation.modifyRecordsResultBlock = { result in
+                    switch result {
+                    case .success:
+                        lock.lock()
+                        let records = savedRecords
+                        lock.unlock()
+                        cancellation.succeed(records)
+                    case .failure(let error):
+                        cancellation.fail(error)
+                    }
                 }
+                cancellation.install(operation: operation, continuation: continuation)
+                database.add(operation)
             }
-            database.add(operation)
+        } onCancel: {
+            cancellation.cancel()
         }
     }
 

--- a/Muesli/ICloudTextSyncEngine.swift
+++ b/Muesli/ICloudTextSyncEngine.swift
@@ -329,8 +329,7 @@ final class ICloudTextSyncEngine: @unchecked Sendable {
     /// Bridge discovery and the one-time default-zone import still use their
     /// existing operations; custom-zone fetches and uploads belong to CKSyncEngine.
     func prepareForCKSyncEngine(
-        store: SharedStore,
-        forceBridgeDeviceRefresh: Bool = false
+        store: SharedStore
     ) async throws -> Bool {
         let syncZoneWasRecreated = try await ensureSyncZone()
         if syncZoneWasRecreated {
@@ -339,9 +338,17 @@ final class ICloudTextSyncEngine: @unchecked Sendable {
             // Clear them before migration builds any CKRecord instances.
             try store.resetTextRecordCloudMetadataForZoneRecreation()
         }
-        await refreshBridgeDeviceLink(forceRefresh: forceBridgeDeviceRefresh)
         try await migrateDefaultZoneIfNeeded(store: store)
         return syncZoneWasRecreated
+    }
+
+    /// Refreshes the optional companion-presence hint outside text transport.
+    ///
+    /// Bridge records are onboarding/UI metadata, not authorization or text
+    /// synchronization state. A slow query here must never hold open a text
+    /// upload, download, or the visible sync progress indicator.
+    func refreshBridgeDeviceLinkIfNeeded(forceRefresh: Bool = false) async {
+        await refreshBridgeDeviceLink(forceRefresh: forceRefresh)
     }
 
     /// Proves that an unscoped legacy library belongs to the current account.
@@ -929,9 +936,9 @@ final class ICloudTextSyncEngine: @unchecked Sendable {
         return SyncTextRecordKind(rawValue: raw)
     }
 
-    private static func isSyncZoneMissing(_ error: Error) -> Bool {
+    static func isSyncZoneMissing(_ error: Error) -> Bool {
         if let ckError = error as? CKError {
-            if ckError.code == .unknownItem {
+            if ckError.code == .unknownItem || ckError.code == .zoneNotFound {
                 return true
             }
             if ckError.code == .partialFailure,

--- a/Muesli/Info.plist
+++ b/Muesli/Info.plist
@@ -50,6 +50,7 @@
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>audio</string>
+		<string>remote-notification</string>
 	</array>
 	<key>UIFileSharingEnabled</key>
 	<true/>

--- a/Muesli/ModelBackgroundDownloadService.swift
+++ b/Muesli/ModelBackgroundDownloadService.swift
@@ -11,7 +11,7 @@ protocol ModelBackgroundDownloadServiceDelegate: AnyObject {
 final class ModelBackgroundDownloadService: NSObject, @unchecked Sendable {
     static let shared = ModelBackgroundDownloadService()
 
-    private static let sessionIdentifier = "com.phequals7.muesli.ios.model-downloads"
+    private static let sessionIdentifier = "\(Bundle.main.bundleIdentifier ?? "com.phequals7.muesli.ios").model-downloads"
 
     @MainActor weak var delegate: ModelBackgroundDownloadServiceDelegate?
 
@@ -62,20 +62,45 @@ final class ModelBackgroundDownloadService: NSObject, @unchecked Sendable {
             return WhisperKitTranscriptionRuntime.isModelDownloaded(whisperVariant)
         }
 
-        if model == .parakeetRealtimeEou120m {
-            guard let modelDirectory = storageDirectory(for: model) else { return false }
-            return ModelNames.ParakeetEOU.requiredModels.allSatisfy { modelName in
-                FileManager.default.fileExists(
-                    atPath: modelDirectory.appendingPathComponent(modelName).path
-                )
-            }
-        }
-
         guard let spec = ModelDownloadSpec(model: model) else { return false }
-        return spec.requiredModels.allSatisfy { modelName in
-            FileManager.default.fileExists(
-                atPath: spec.repoRoot.appendingPathComponent(modelName).path
-            )
+        return containsCompleteFluidAudioArtifacts(
+            at: spec.repoRoot,
+            modelNames: spec.requiredModels,
+            supportingFiles: spec.requiredSupportingFiles
+        )
+    }
+
+    static func supportsBackgroundDownload(_ model: LocalTranscriptionModel) -> Bool {
+        ModelDownloadSpec(model: model) != nil
+    }
+
+    static func containsCompleteFluidAudioArtifacts(
+        at root: URL,
+        modelNames: Set<String>,
+        supportingFiles: Set<String>
+    ) -> Bool {
+        let fileManager = FileManager.default
+        let modelsAreComplete = modelNames.allSatisfy { modelName in
+            let modelDirectory = root.appendingPathComponent(modelName, isDirectory: true)
+            var isDirectory: ObjCBool = false
+            guard fileManager.fileExists(atPath: modelDirectory.path, isDirectory: &isDirectory),
+                  isDirectory.boolValue
+            else { return false }
+
+            let coreMLData = modelDirectory.appendingPathComponent("coremldata.bin")
+            guard let values = try? coreMLData.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey]) else {
+                return false
+            }
+            return values.isRegularFile == true && (values.fileSize ?? 0) > 0
+        }
+        guard modelsAreComplete else { return false }
+
+        return supportingFiles.allSatisfy { fileName in
+            let file = root.appendingPathComponent(fileName)
+            guard let values = try? file.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey]) else {
+                return false
+            }
+            return values.isRegularFile == true && (values.fileSize ?? 0) > 0
         }
     }
 
@@ -133,11 +158,12 @@ final class ModelBackgroundDownloadService: NSObject, @unchecked Sendable {
             throw error
         }
         let missingFiles = files.filter { file in
-            !FileManager.default.fileExists(atPath: spec.destinationURL(for: file.localPath).path)
+            !Self.localDownloadMatches(file, in: spec)
         }
 
         guard !missingFiles.isEmpty else {
             clearRequestedAttempt(ifMatching: attempt)
+            try Self.finalizeDownloadedModel(model)
             return false
         }
 
@@ -285,6 +311,19 @@ final class ModelBackgroundDownloadService: NSObject, @unchecked Sendable {
         return files
     }
 
+    private static func localDownloadMatches(
+        _ file: ModelDownloadFile,
+        in spec: ModelDownloadSpec
+    ) -> Bool {
+        let destination = spec.destinationURL(for: file.localPath)
+        guard let values = try? destination.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey]),
+              values.isRegularFile == true
+        else { return false }
+
+        guard file.size > 0 else { return true }
+        return Int64(values.fileSize ?? -1) == file.size
+    }
+
     private func updateProgress(task: URLSessionTask, bytesWritten: Int64) {
         var snapshot: (LocalTranscriptionModel, Double)?
         stateQueue.sync {
@@ -386,9 +425,31 @@ final class ModelBackgroundDownloadService: NSObject, @unchecked Sendable {
             return
         }
 
-        Task { @MainActor in
-            delegate?.modelBackgroundDownloadDidFinish(model: model)
-            handler?()
+        do {
+            try Self.finalizeDownloadedModel(model)
+            Task { @MainActor in
+                delegate?.modelBackgroundDownloadDidFinish(model: model)
+                handler?()
+            }
+        } catch {
+            Task { @MainActor in
+                delegate?.modelBackgroundDownloadDidFail(
+                    model: model,
+                    message: "Download finished, but the model files are incomplete. Try again."
+                )
+                handler?()
+            }
+        }
+    }
+
+    private static func finalizeDownloadedModel(_ model: LocalTranscriptionModel) throws {
+        if let whisperVariant = model.whisperVariant {
+            try WhisperKitTranscriptionRuntime.markDownloadComplete(
+                at: WhisperKitTranscriptionRuntime.modelDirectory(for: whisperVariant)
+            )
+        }
+        guard isModelDownloaded(model) else {
+            throw ModelBackgroundDownloadError.incompleteDownload
         }
     }
 
@@ -506,7 +567,9 @@ extension ModelBackgroundDownloadService: URLSessionDownloadDelegate {
                 self.attemptOutcomes
                     .drainCompletedAttempts()
                     .compactMap { LocalTranscriptionModel(rawValue: $0.modelRawValue) }
-            )
+            ).filter { model in
+                (try? Self.finalizeDownloadedModel(model)) != nil
+            }
             self.backgroundCompletionHandler = nil
             DispatchQueue.main.async {
                 completedModels.forEach { model in
@@ -672,16 +735,23 @@ private struct DownloadFailureResult {
 
 private struct ModelDownloadSpec {
     let model: LocalTranscriptionModel
-    let repoFolderName: String
     let remotePath: String
     let subPath: String?
     let requiredModels: Set<String>
+    let requiredSupportingFiles: Set<String>
+    let repoRoot: URL
 
     init?(model: LocalTranscriptionModel) {
         self.model = model
+        let fluidAudioModelsRoot = FileManager.default.urls(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask
+        )[0]
+            .appendingPathComponent("FluidAudio", isDirectory: true)
+            .appendingPathComponent("Models", isDirectory: true)
+
         switch model {
         case .parakeetTdtCtc110m:
-            repoFolderName = "parakeet-tdt-ctc-110m"
             remotePath = "FluidInference/parakeet-tdt-ctc-110m-coreml"
             subPath = nil
             requiredModels = [
@@ -689,8 +759,12 @@ private struct ModelDownloadSpec {
                 "Decoder.mlmodelc",
                 "JointDecision.mlmodelc"
             ]
+            requiredSupportingFiles = ["parakeet_vocab.json"]
+            repoRoot = fluidAudioModelsRoot.appendingPathComponent(
+                "parakeet-tdt-ctc-110m",
+                isDirectory: true
+            )
         case .parakeetV3:
-            repoFolderName = "parakeet-tdt-0.6b-v3-coreml"
             remotePath = "FluidInference/parakeet-tdt-0.6b-v3-coreml"
             subPath = nil
             requiredModels = [
@@ -699,20 +773,34 @@ private struct ModelDownloadSpec {
                 "Decoder.mlmodelc",
                 "JointDecisionv3.mlmodelc"
             ]
-        case .parakeetRealtimeEou120m,
-             .whisperTinyEnglish, .whisperSmallEnglish, .whisperMediumEnglish, .whisperLargeTurbo:
-            return nil
+            requiredSupportingFiles = ["parakeet_vocab.json"]
+            repoRoot = fluidAudioModelsRoot.appendingPathComponent(
+                "parakeet-tdt-0.6b-v3-coreml",
+                isDirectory: true
+            )
+        case .parakeetRealtimeEou120m:
+            remotePath = "FluidInference/parakeet-realtime-eou-120m-coreml"
+            subPath = "320ms"
+            requiredModels = ModelNames.ParakeetEOU.requiredModels.filter { $0.hasSuffix(".mlmodelc") }
+            requiredSupportingFiles = [ModelNames.ParakeetEOU.vocab]
+            repoRoot = fluidAudioModelsRoot
+                .appendingPathComponent("parakeet-eou-streaming", isDirectory: true)
+                .appendingPathComponent("320ms", isDirectory: true)
+        case .whisperTinyEnglish, .whisperSmallEnglish, .whisperMediumEnglish, .whisperLargeTurbo:
+            guard let whisperVariant = model.whisperVariant else { return nil }
+            let modelFolderName = whisperVariant.hasPrefix("openai_whisper-")
+                ? whisperVariant
+                : "openai_whisper-\(whisperVariant)"
+            remotePath = "argmaxinc/whisperkit-coreml"
+            subPath = modelFolderName
+            requiredModels = [
+                "MelSpectrogram.mlmodelc",
+                "AudioEncoder.mlmodelc",
+                "TextDecoder.mlmodelc",
+            ]
+            requiredSupportingFiles = []
+            repoRoot = WhisperKitTranscriptionRuntime.modelDirectory(for: whisperVariant)
         }
-    }
-
-    var modelsRoot: URL {
-        FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
-            .appendingPathComponent("FluidAudio", isDirectory: true)
-            .appendingPathComponent("Models", isDirectory: true)
-    }
-
-    var repoRoot: URL {
-        modelsRoot.appendingPathComponent(repoFolderName, isDirectory: true)
     }
 
     func destinationURL(for localPath: String) -> URL {
@@ -738,7 +826,12 @@ private struct ModelDownloadSpec {
     func shouldDownloadFile(_ path: String) -> Bool {
         let local = localPath(forRemotePath: path)
         return requiredModels.contains { local.hasPrefix("\($0)/") }
+            || requiredSupportingFiles.contains(local)
             || local.hasSuffix(".json")
             || local.hasSuffix(".txt")
     }
+}
+
+private enum ModelBackgroundDownloadError: Error {
+    case incompleteDownload
 }

--- a/Muesli/ModelPreparationState.swift
+++ b/Muesli/ModelPreparationState.swift
@@ -22,3 +22,14 @@ struct ModelPreparationState: Equatable {
         phase == .ready
     }
 }
+
+enum ModelPreparationAction: Equatable {
+    case startBackgroundDownload
+    case warmDownloadedModel
+}
+
+enum ModelPreparationPolicy {
+    static func action(isDownloaded: Bool) -> ModelPreparationAction {
+        isDownloaded ? .warmDownloadedModel : .startBackgroundDownload
+    }
+}

--- a/Muesli/MuesliAppDelegate.swift
+++ b/Muesli/MuesliAppDelegate.swift
@@ -2,6 +2,8 @@ import CloudKit
 import UIKit
 
 enum MuesliCKSyncBackgroundFetch {
+    static let cloudKitBudget: Duration = .seconds(20)
+
     static func shouldFetch(isCloudKitNotification: Bool, syncEnabled: Bool) -> Bool {
         isCloudKitNotification && syncEnabled
     }
@@ -26,11 +28,15 @@ final class MuesliAppDelegate: NSObject, UIApplicationDelegate {
         // Create/restore CKSyncEngine independently of SwiftUI view ownership so
         // automatic CloudKit push handling is available from process launch.
         let runtime = MuesliCKSyncRuntime.shared
-        if MuesliCKSyncLaunchPolicy.shouldPrepare(
+        if let initialIntent = MuesliCKSyncLaunchPolicy.initialIntent(
             syncEnabled: MuesliPreferences.iCloudSyncEnabled
         ) {
             Task {
-                try? await runtime.prepare()
+                // Startup convergence replays SQLite's durable outbox even if
+                // CKSyncEngine restored no pending state, then fetches remote work.
+                if initialIntent == .manual {
+                    _ = try? await runtime.syncManually()
+                }
             }
         }
         return true
@@ -54,7 +60,9 @@ final class MuesliAppDelegate: NSObject, UIApplicationDelegate {
         // starts a sync operation from inside its callbacks.
         Task {
             let result = await MuesliCKSyncBackgroundFetch.run {
-                try await MuesliCKSyncRuntime.shared.fetchRemoteChanges()
+                try await MuesliCKSyncRuntime.shared.fetchRemoteChanges(
+                    deadline: MuesliCKSyncBackgroundFetch.cloudKitBudget
+                )
             }
             await MainActor.run {
                 completionHandler(result)

--- a/Muesli/MuesliAppDelegate.swift
+++ b/Muesli/MuesliAppDelegate.swift
@@ -1,6 +1,67 @@
+import CloudKit
 import UIKit
 
+enum MuesliCKSyncBackgroundFetch {
+    static func shouldFetch(isCloudKitNotification: Bool, syncEnabled: Bool) -> Bool {
+        isCloudKitNotification && syncEnabled
+    }
+
+    static func run(
+        fetch: @Sendable () async throws -> ICloudTextSyncResult
+    ) async -> UIBackgroundFetchResult {
+        do {
+            let result = try await fetch()
+            return result.downloaded > 0 ? .newData : .noData
+        } catch {
+            return .failed
+        }
+    }
+}
+
 final class MuesliAppDelegate: NSObject, UIApplicationDelegate {
+    func application(
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+    ) -> Bool {
+        // Create/restore CKSyncEngine independently of SwiftUI view ownership so
+        // automatic CloudKit push handling is available from process launch.
+        let runtime = MuesliCKSyncRuntime.shared
+        if MuesliCKSyncLaunchPolicy.shouldPrepare(
+            syncEnabled: MuesliPreferences.iCloudSyncEnabled
+        ) {
+            Task {
+                try? await runtime.prepare()
+            }
+        }
+        return true
+    }
+
+    func application(
+        _ application: UIApplication,
+        didReceiveRemoteNotification userInfo: [AnyHashable: Any],
+        fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void
+    ) {
+        guard MuesliCKSyncBackgroundFetch.shouldFetch(
+            isCloudKitNotification: CKNotification(fromRemoteNotificationDictionary: userInfo) != nil,
+            syncEnabled: MuesliPreferences.iCloudSyncEnabled
+        ) else {
+            completionHandler(.noData)
+            return
+        }
+
+        // Forward the trigger to the process-wide request coordinator. The
+        // CKSyncEngine delegate only reconciles events; it never recursively
+        // starts a sync operation from inside its callbacks.
+        Task {
+            let result = await MuesliCKSyncBackgroundFetch.run {
+                try await MuesliCKSyncRuntime.shared.fetchRemoteChanges()
+            }
+            await MainActor.run {
+                completionHandler(result)
+            }
+        }
+    }
+
     func application(
         _ application: UIApplication,
         handleEventsForBackgroundURLSession identifier: String,

--- a/Muesli/MuesliCKSyncEngine.swift
+++ b/Muesli/MuesliCKSyncEngine.swift
@@ -107,6 +107,7 @@ actor MuesliCKSyncEngine: CKSyncEngineDelegate {
     private let store: SharedStore
     private let onRemoteChanges: @Sendable () async -> Void
     private let onProgress: @Sendable (MuesliCKSyncProgress) async -> Void
+    private let legacyAccountRecordVerifier: (@Sendable (Set<String>) async throws -> Bool)?
     private var container: CKContainer?
     private var preflight: ICloudTextSyncEngine?
     private var engine: CKSyncEngine?
@@ -119,12 +120,14 @@ actor MuesliCKSyncEngine: CKSyncEngineDelegate {
         store: SharedStore = SharedStore(),
         container: CKContainer? = nil,
         onRemoteChanges: @escaping @Sendable () async -> Void = {},
-        onProgress: @escaping @Sendable (MuesliCKSyncProgress) async -> Void = { _ in }
+        onProgress: @escaping @Sendable (MuesliCKSyncProgress) async -> Void = { _ in },
+        legacyAccountRecordVerifier: (@Sendable (Set<String>) async throws -> Bool)? = nil
     ) {
         self.store = store
         self.container = container
         self.onRemoteChanges = onRemoteChanges
         self.onProgress = onProgress
+        self.legacyAccountRecordVerifier = legacyAccountRecordVerifier
     }
 
     /// Fetches private-zone changes, then drains the durable local outbox.
@@ -202,8 +205,9 @@ actor MuesliCKSyncEngine: CKSyncEngineDelegate {
     private func prepareEngine(
         forceBridgeDeviceRefresh: Bool
     ) async throws -> (syncZoneWasRecreated: Bool, engine: CKSyncEngine) {
+        let preflight = resolvedPreflight()
         let currentUser = try await resolvedContainer().userRecordID()
-        guard try authorizeAccount(currentUser) else {
+        guard try await authorizeAccount(currentUser, preflight: preflight) else {
             if let engine {
                 engine.state.remove(
                     pendingRecordZoneChanges: engine.state.pendingRecordZoneChanges
@@ -211,15 +215,6 @@ actor MuesliCKSyncEngine: CKSyncEngineDelegate {
             }
             try store.clearCloudSyncStateData(forKey: Self.stateKey)
             throw MuesliCKSyncError.accountChanged
-        }
-
-        let preflight: ICloudTextSyncEngine
-        if let existing = self.preflight {
-            preflight = existing
-        } else {
-            let created = ICloudTextSyncEngine(container: resolvedContainer())
-            self.preflight = created
-            preflight = created
         }
 
         let syncZoneWasRecreated = try await preflight.prepareForCKSyncEngine(
@@ -278,6 +273,13 @@ actor MuesliCKSyncEngine: CKSyncEngineDelegate {
         if let container { return container }
         let created = CKContainer(identifier: ICloudTextSyncEngine.Schema.containerIdentifier)
         container = created
+        return created
+    }
+
+    private func resolvedPreflight() -> ICloudTextSyncEngine {
+        if let preflight { return preflight }
+        let created = ICloudTextSyncEngine(container: resolvedContainer())
+        preflight = created
         return created
     }
 
@@ -418,17 +420,17 @@ actor MuesliCKSyncEngine: CKSyncEngineDelegate {
                 conflictBaseRecords.removeAll()
                 switch change.changeType {
                 case .signIn(let currentUser):
-                    _ = try handleAccountChange(
+                    _ = try await handleAccountChange(
                         currentUser: currentUser,
                         state: syncEngine.state
                     )
                 case .switchAccounts(_, let currentUser):
-                    _ = try handleAccountChange(
+                    _ = try await handleAccountChange(
                         currentUser: currentUser,
                         state: syncEngine.state
                     )
                 case .signOut:
-                    _ = try handleAccountChange(
+                    _ = try await handleAccountChange(
                         currentUser: nil,
                         state: syncEngine.state
                     )
@@ -540,7 +542,7 @@ actor MuesliCKSyncEngine: CKSyncEngineDelegate {
     func handleAccountChange(
         currentUser: CKRecord.ID?,
         state: any MuesliCKSyncPendingState
-    ) throws -> Bool {
+    ) async throws -> Bool {
         // This runs inside CKSyncEngine's own delegate callback. Cancelling the
         // same engine here is re-entrant and CloudKit deliberately traps. Keep
         // live engine inert; discard account-specific pending work and state.
@@ -552,7 +554,7 @@ actor MuesliCKSyncEngine: CKSyncEngineDelegate {
             return false
         }
 
-        guard try authorizeAccount(currentUser) else { return false }
+        guard try await authorizeAccount(currentUser) else { return false }
         _ = try registerNextDirtyBatch(state: state)
         return true
     }
@@ -563,9 +565,40 @@ actor MuesliCKSyncEngine: CKSyncEngineDelegate {
         return "sha256:" + digest.map { String(format: "%02x", $0) }.joined()
     }
 
-    private func authorizeAccount(_ userRecordID: CKRecord.ID) throws -> Bool {
+    private func authorizeAccount(
+        _ userRecordID: CKRecord.ID,
+        preflight: ICloudTextSyncEngine? = nil
+    ) async throws -> Bool {
+        accountBoundaryBlocked = true
+        let requestedScope = Self.accountScope(for: userRecordID)
+
+        if let persistedScope = try store.cloudSyncStateData(forKey: Self.accountScopeKey) {
+            let matches = persistedScope == Data(requestedScope.utf8)
+            accountBoundaryBlocked = !matches
+            if !matches {
+                Self.logger.error("account_boundary_blocked")
+            }
+            return matches
+        }
+
+        let legacyRecordNames = try store.textRecordNamesRequiringAccountVerification()
+        if !legacyRecordNames.isEmpty {
+            let verified: Bool
+            if let legacyAccountRecordVerifier {
+                verified = try await legacyAccountRecordVerifier(legacyRecordNames)
+            } else {
+                verified = try await (preflight ?? resolvedPreflight()).syncZoneContainsAnyTextRecord(
+                    named: legacyRecordNames
+                )
+            }
+            guard verified else {
+                Self.logger.error("account_provenance_unverified")
+                return false
+            }
+        }
+
         let matches = try store.claimCloudSyncAccountScope(
-            Self.accountScope(for: userRecordID),
+            requestedScope,
             forKey: Self.accountScopeKey
         )
         accountBoundaryBlocked = !matches

--- a/Muesli/MuesliCKSyncEngine.swift
+++ b/Muesli/MuesliCKSyncEngine.swift
@@ -254,7 +254,7 @@ actor MuesliCKSyncRuntime {
     private var activeWaiters: [UUID: Waiter] = [:]
     private var deadlineTasks: [UUID: Task<Void, Never>] = [:]
     private var runningGeneration: Int?
-    private var cleanupGeneration: Int?
+    private var outstandingEngineCleanups = 0
     private var bridgePendingForceRefresh = false
     private var bridgeWaiters: [UUID: CheckedContinuation<Void, Never>] = [:]
     private var bridgeTask: Task<Void, Never>?
@@ -342,7 +342,6 @@ actor MuesliCKSyncRuntime {
 
     func cancel() async {
         generation += 1
-        let cancellationGeneration = generation
         _ = intents.take()
         let cancelledWaiters = Array(pendingWaiters.values) + Array(activeWaiters.values)
         pendingWaiters.removeAll()
@@ -350,9 +349,10 @@ actor MuesliCKSyncRuntime {
         for task in deadlineTasks.values { task.cancel() }
         deadlineTasks.removeAll()
         runningGeneration = nil
-        cleanupGeneration = cancellationGeneration
+        outstandingEngineCleanups += 1
         bridgePendingForceRefresh = false
-        bridgeTask?.cancel()
+        let bridgeTaskToCancel = bridgeTask
+        bridgeTaskToCancel?.cancel()
         bridgeTask = nil
         let cancelledBridgeWaiters = bridgeWaiters.values
         bridgeWaiters.removeAll()
@@ -360,10 +360,12 @@ actor MuesliCKSyncRuntime {
         // the background fetch completion path cannot wait on cancellation I/O.
         cancelledWaiters.forEach { $0.continuation.resume(throwing: CancellationError()) }
         cancelledBridgeWaiters.forEach { $0.resume() }
+        // Do not release the generation barrier until the retired bridge task
+        // has observed cancellation and its CKOperations have completed cleanup.
+        await bridgeTaskToCancel?.value
         await cancelEngine()
-        guard generation == cancellationGeneration,
-              cleanupGeneration == cancellationGeneration else { return }
-        cleanupGeneration = nil
+        outstandingEngineCleanups -= 1
+        guard outstandingEngineCleanups == 0 else { return }
         startDrainIfNeeded()
         startBridgeRefreshIfNeeded()
     }
@@ -403,7 +405,7 @@ actor MuesliCKSyncRuntime {
     }
 
     private func startDrainIfNeeded() {
-        guard cleanupGeneration == nil,
+        guard outstandingEngineCleanups == 0,
               runningGeneration == nil,
               !intents.pending.isEmpty else { return }
         let drainGeneration = generation
@@ -412,7 +414,9 @@ actor MuesliCKSyncRuntime {
     }
 
     private func drain(generation drainGeneration: Int) async {
-        while drainGeneration == generation, cleanupGeneration == nil, !intents.pending.isEmpty {
+        while drainGeneration == generation,
+              outstandingEngineCleanups == 0,
+              !intents.pending.isEmpty {
             let intent = intents.take()
             let batchWaiterIDs = Set(pendingWaiters.keys)
             for waiterID in batchWaiterIDs {
@@ -471,7 +475,7 @@ actor MuesliCKSyncRuntime {
     }
 
     private func startBridgeRefreshIfNeeded() {
-        guard cleanupGeneration == nil,
+        guard outstandingEngineCleanups == 0,
               bridgeTask == nil,
               !bridgeWaiters.isEmpty else { return }
         let bridgeGeneration = generation
@@ -479,13 +483,16 @@ actor MuesliCKSyncRuntime {
     }
 
     private func drainBridgeRefresh(generation bridgeGeneration: Int) async {
-        while bridgeGeneration == generation, cleanupGeneration == nil, !bridgeWaiters.isEmpty {
+        while bridgeGeneration == generation,
+              outstandingEngineCleanups == 0,
+              !bridgeWaiters.isEmpty {
             let forceRefresh = bridgePendingForceRefresh
             bridgePendingForceRefresh = false
             await refreshBridge(forceRefresh) { [weak self] in
                 await self?.isCurrentGeneration(bridgeGeneration) == true
             }
-            guard bridgeGeneration == generation, cleanupGeneration == nil else { return }
+            guard bridgeGeneration == generation,
+                  outstandingEngineCleanups == 0 else { return }
             if bridgePendingForceRefresh { continue }
             let completed = bridgeWaiters.values
             bridgeWaiters.removeAll()
@@ -497,7 +504,7 @@ actor MuesliCKSyncRuntime {
     }
 
     private func isCurrentGeneration(_ observedGeneration: Int) -> Bool {
-        observedGeneration == generation && cleanupGeneration == nil
+        observedGeneration == generation && outstandingEngineCleanups == 0
     }
 }
 

--- a/Muesli/MuesliCKSyncEngine.swift
+++ b/Muesli/MuesliCKSyncEngine.swift
@@ -12,18 +12,97 @@ protocol MuesliCKSyncPendingState: AnyObject, Sendable {
 
 extension CKSyncEngine.State: MuesliCKSyncPendingState {}
 
-/// Runs fetch-first sync and stops upload paging when CloudKit makes no progress.
+struct MuesliCKSyncIntent: OptionSet, Equatable, Sendable {
+    let rawValue: UInt8
+
+    static let send = Self(rawValue: 1 << 0)
+    static let fetch = Self(rawValue: 1 << 1)
+    static let manual: Self = [.send, .fetch]
+}
+
+enum MuesliCKSyncOperation: Equatable, Sendable {
+    case send
+    case fetch
+}
+
+/// One cross-platform operation contract: outgoing first, incoming second.
+enum MuesliCKSyncPlan {
+    static func operations(for intent: MuesliCKSyncIntent) -> [MuesliCKSyncOperation] {
+        var operations: [MuesliCKSyncOperation] = []
+        if intent.contains(.send) { operations.append(.send) }
+        if intent.contains(.fetch) { operations.append(.fetch) }
+        return operations
+    }
+}
+
+enum MuesliCKSyncLaunchPolicy {
+    static func shouldPrepare(syncEnabled: Bool) -> Bool { syncEnabled }
+}
+
+struct MuesliCKSyncIntentAccumulator: Equatable, Sendable {
+    private(set) var pending: MuesliCKSyncIntent = []
+
+    mutating func insert(_ intent: MuesliCKSyncIntent) {
+        pending.formUnion(intent)
+    }
+
+    mutating func take() -> MuesliCKSyncIntent {
+        let value = pending
+        pending = []
+        return value
+    }
+}
+
+/// Coalesces one-time/account/zone/migration preparation across concurrent triggers.
+actor MuesliCKSyncPreparationGate {
+    private var isPrepared = false
+    private var inFlight: Task<Bool, Error>?
+    private var generation = 0
+
+    func prepare(
+        using operation: @escaping @Sendable () async throws -> Bool
+    ) async throws -> Bool {
+        if isPrepared { return false }
+        let observedGeneration = generation
+        if let inFlight {
+            let value = try await inFlight.value
+            guard observedGeneration == generation else { throw CancellationError() }
+            return value
+        }
+
+        let task = Task { try await operation() }
+        inFlight = task
+        do {
+            let zoneWasRecreated = try await task.value
+            guard observedGeneration == generation else { throw CancellationError() }
+            isPrepared = true
+            inFlight = nil
+            return zoneWasRecreated
+        } catch {
+            if observedGeneration == generation {
+                inFlight = nil
+            }
+            throw error
+        }
+    }
+
+    func invalidate() {
+        generation += 1
+        inFlight?.cancel()
+        inFlight = nil
+        isPrepared = false
+    }
+}
+
+/// Drains outgoing pages and stops when CloudKit makes no progress.
 enum MuesliCKSyncCycle {
-    static func run(
+    static func sendLocalChanges(
         maximumUploadBatches: Int,
         isolation: isolated (any Actor)? = #isolation,
-        fetch: () async throws -> Void,
         registerNextBatch: () async throws -> Int,
         uploadedCount: () async -> Int,
         send: () async throws -> Void
     ) async throws {
-        try await fetch()
-
         for _ in 0..<max(maximumUploadBatches, 0) {
             let registered = try await registerNextBatch()
             guard registered > 0 else { break }
@@ -79,6 +158,138 @@ enum MuesliCKSyncProgress: Equatable, Sendable {
     }
 }
 
+extension Notification.Name {
+    static let muesliCKSyncRemoteChanges = Notification.Name("muesli.cksync.remote-changes")
+    static let muesliCKSyncProgress = Notification.Name("muesli.cksync.progress")
+}
+
+enum MuesliCKSyncNotificationKey {
+    static let progress = "progress"
+}
+
+/// Process-wide owner for the persistent engine and merged trigger intent.
+///
+/// App launch, foregrounding, APNs, local commits, and manual refresh can race.
+/// The runtime unions their requested directions and drains them through one
+/// engine so no trigger overwrites another while a network operation is active.
+actor MuesliCKSyncRuntime {
+    static let shared = MuesliCKSyncRuntime()
+
+    private let engine: MuesliCKSyncEngine
+    private struct Waiter {
+        let generation: Int
+        let continuation: CheckedContinuation<ICloudTextSyncResult, any Error>
+    }
+    private var intents = MuesliCKSyncIntentAccumulator()
+    private var waiters: [Waiter] = []
+    private var isRunning = false
+    private var generation = 0
+
+    init(engine: MuesliCKSyncEngine? = nil) {
+        self.engine = engine ?? MuesliCKSyncEngine(
+            onRemoteChanges: {
+                await MainActor.run {
+                    NotificationCenter.default.post(name: .muesliCKSyncRemoteChanges, object: nil)
+                }
+            },
+            onProgress: { progress in
+                await MainActor.run {
+                    NotificationCenter.default.post(
+                        name: .muesliCKSyncProgress,
+                        object: nil,
+                        userInfo: [MuesliCKSyncNotificationKey.progress: progress]
+                    )
+                }
+            }
+        )
+    }
+
+    func prepare() async throws {
+        _ = try await engine.prepare()
+    }
+
+    func sendLocalChanges() async throws -> ICloudTextSyncResult {
+        try await enqueue(.send)
+    }
+
+    func fetchRemoteChanges() async throws -> ICloudTextSyncResult {
+        try await enqueue(.fetch)
+    }
+
+    func syncManually() async throws -> ICloudTextSyncResult {
+        try await enqueue(.manual)
+    }
+
+    func refreshBridgeDevice(forceRefresh: Bool) async {
+        await engine.refreshBridgeDevice(forceRefresh: forceRefresh)
+    }
+
+    func cancel() async {
+        generation += 1
+        _ = intents.take()
+        let cancelledWaiters = waiters
+        waiters.removeAll()
+        isRunning = false
+        await engine.cancel()
+        cancelledWaiters.forEach { $0.continuation.resume(throwing: CancellationError()) }
+    }
+
+    private func enqueue(
+        _ intent: MuesliCKSyncIntent
+    ) async throws -> ICloudTextSyncResult {
+        try await withCheckedThrowingContinuation { continuation in
+            intents.insert(intent)
+            waiters.append(Waiter(generation: generation, continuation: continuation))
+            guard !isRunning else { return }
+            isRunning = true
+            let drainGeneration = generation
+            Task { await self.drain(generation: drainGeneration) }
+        }
+    }
+
+    private func drain(generation drainGeneration: Int) async {
+        var totalUploaded = 0
+        var totalDownloaded = 0
+        do {
+            while !intents.pending.isEmpty {
+                let intent = intents.take()
+                let result: ICloudTextSyncResult
+                if intent == .manual {
+                    result = try await engine.syncManually()
+                } else if intent == .send {
+                    result = try await engine.sendLocalChanges()
+                } else {
+                    result = try await engine.fetchRemoteChanges()
+                }
+                totalUploaded += result.uploaded
+                totalDownloaded += result.downloaded
+            }
+            completeWaiters(generation: drainGeneration, with: .success(ICloudTextSyncResult(
+                uploaded: totalUploaded,
+                downloaded: totalDownloaded
+            )))
+        } catch {
+            completeWaiters(generation: drainGeneration, with: .failure(error))
+        }
+    }
+
+    private func completeWaiters(
+        generation completedGeneration: Int,
+        with result: Result<ICloudTextSyncResult, any Error>
+    ) {
+        let completedWaiters = waiters.filter { $0.generation == completedGeneration }
+        waiters.removeAll { $0.generation == completedGeneration }
+        guard completedGeneration == generation else { return }
+        isRunning = false
+        for waiter in completedWaiters {
+            switch result {
+            case .success(let value): waiter.continuation.resume(returning: value)
+            case .failure(let error): waiter.continuation.resume(throwing: error)
+            }
+        }
+    }
+}
+
 /// Owns the one CKSyncEngine instance for the private text-record zone.
 ///
 /// SQLite's `sync_dirty` flags remain the durable outbox. Before every send,
@@ -108,6 +319,7 @@ actor MuesliCKSyncEngine: CKSyncEngineDelegate {
     private let onRemoteChanges: @Sendable () async -> Void
     private let onProgress: @Sendable (MuesliCKSyncProgress) async -> Void
     private let legacyAccountRecordVerifier: (@Sendable (Set<String>) async throws -> Bool)?
+    private let preparationGate = MuesliCKSyncPreparationGate()
     private var container: CKContainer?
     private var preflight: ICloudTextSyncEngine?
     private var engine: CKSyncEngine?
@@ -130,39 +342,86 @@ actor MuesliCKSyncEngine: CKSyncEngineDelegate {
         self.legacyAccountRecordVerifier = legacyAccountRecordVerifier
     }
 
-    /// Fetches private-zone changes, then drains the durable local outbox.
-    func sync(forceBridgeDeviceRefresh: Bool = false) async throws -> ICloudTextSyncResult {
+    /// Initializes the persistent engine and performs account/zone/migration work once.
+    @discardableResult
+    func prepare() async throws -> Bool {
+        let zoneWasRecreated = try await preparationGate.prepare { [weak self] in
+            guard let self else { throw CancellationError() }
+            return try await self.performPreparation()
+        }
+        _ = try makeEngineIfNeeded()
+        return zoneWasRecreated
+    }
+
+    /// Registers SQLite's durable outbox and sends it without a fetch-first round trip.
+    func sendLocalChanges() async throws -> ICloudTextSyncResult {
+        try await runWithZoneRecovery(intent: .send)
+    }
+
+    /// Fetches incoming zone changes without scanning or sending the local outbox.
+    func fetchRemoteChanges() async throws -> ICloudTextSyncResult {
+        try await runWithZoneRecovery(intent: .fetch)
+    }
+
+    /// User-requested convergence: flush outgoing work first, then fetch incoming work.
+    func syncManually() async throws -> ICloudTextSyncResult {
+        try await runWithZoneRecovery(intent: .manual)
+    }
+
+    private func runWithZoneRecovery(
+        intent: MuesliCKSyncIntent
+    ) async throws -> ICloudTextSyncResult {
+        do {
+            return try await run(intent: intent)
+        } catch {
+            guard ICloudTextSyncEngine.isSyncZoneMissing(error) else {
+                if Self.invalidatesPreparation(error) {
+                    await invalidatePreparation(cancelEngine: false, clearEngineState: false)
+                }
+                throw error
+            }
+
+            // One bounded retry recreates a same-account zone through preflight.
+            // That path clears obsolete CKRecord metadata before requeueing text.
+            await invalidatePreparation(cancelEngine: true, clearEngineState: true)
+            return try await run(intent: intent)
+        }
+    }
+
+    private func run(intent: MuesliCKSyncIntent) async throws -> ICloudTextSyncResult {
         uploaded = 0
         downloaded = 0
 
         await reportProgress(.preparing)
-        let (_, syncEngine) = try await prepareEngine(
-            forceBridgeDeviceRefresh: forceBridgeDeviceRefresh
-        )
-        await reportProgress(.fetching)
-        try await MuesliCKSyncCycle.run(
-            maximumUploadBatches: Self.maximumUploadBatchesPerSync,
-            fetch: {
+        _ = try await prepare()
+        let syncEngine = try makeEngineIfNeeded()
+
+        for operation in MuesliCKSyncPlan.operations(for: intent) {
+            switch operation {
+            case .send:
+                await reportProgress(.uploading(uploaded))
+                try await MuesliCKSyncCycle.sendLocalChanges(
+                    maximumUploadBatches: Self.maximumUploadBatchesPerSync,
+                    registerNextBatch: {
+                        try self.registerNextDirtyBatch(state: syncEngine.state)
+                    },
+                    uploadedCount: { self.uploaded },
+                    send: {
+                        let options = CKSyncEngine.SendChangesOptions(
+                            scope: .zoneIDs([ICloudTextSyncEngine.Schema.syncZoneID])
+                        )
+                        try await syncEngine.sendChanges(options)
+                    }
+                )
+
+            case .fetch:
+                await reportProgress(.fetching)
                 let options = CKSyncEngine.FetchChangesOptions(
                     scope: .zoneIDs([ICloudTextSyncEngine.Schema.syncZoneID])
                 )
                 try await syncEngine.fetchChanges(options)
-            },
-            registerNextBatch: {
-                let registered = try self.registerNextDirtyBatch(state: syncEngine.state)
-                if registered > 0 {
-                    await self.reportProgress(.uploading(self.uploaded))
-                }
-                return registered
-            },
-            uploadedCount: { self.uploaded },
-            send: {
-                let options = CKSyncEngine.SendChangesOptions(
-                    scope: .zoneIDs([ICloudTextSyncEngine.Schema.syncZoneID])
-                )
-                try await syncEngine.sendChanges(options)
             }
-        )
+        }
 
         return ICloudTextSyncResult(uploaded: uploaded, downloaded: downloaded)
     }
@@ -186,25 +445,17 @@ actor MuesliCKSyncEngine: CKSyncEngineDelegate {
         await onProgress(progress)
     }
 
-    /// Prepares the account boundary, custom zone, migration, and engine state.
-    @discardableResult
-    func prepare(forceBridgeDeviceRefresh: Bool = false) async throws -> Bool {
-        let (syncZoneWasRecreated, _) = try await prepareEngine(
-            forceBridgeDeviceRefresh: forceBridgeDeviceRefresh
-        )
-        return syncZoneWasRecreated
-    }
-
     /// Cancels outstanding CloudKit operations and discards the live engine.
     func cancel() async {
-        let engineToCancel = engine
-        engine = nil
-        await engineToCancel?.cancelOperations()
+        await invalidatePreparation(cancelEngine: true, clearEngineState: false)
     }
 
-    private func prepareEngine(
-        forceBridgeDeviceRefresh: Bool
-    ) async throws -> (syncZoneWasRecreated: Bool, engine: CKSyncEngine) {
+    /// Companion presence is ancillary UI state and never blocks text transport.
+    func refreshBridgeDevice(forceRefresh: Bool = false) async {
+        await resolvedPreflight().refreshBridgeDeviceLinkIfNeeded(forceRefresh: forceRefresh)
+    }
+
+    private func performPreparation() async throws -> Bool {
         let preflight = resolvedPreflight()
         let currentUser = try await resolvedContainer().userRecordID()
         guard try await authorizeAccount(currentUser, preflight: preflight) else {
@@ -217,10 +468,7 @@ actor MuesliCKSyncEngine: CKSyncEngineDelegate {
             throw MuesliCKSyncError.accountChanged
         }
 
-        let syncZoneWasRecreated = try await preflight.prepareForCKSyncEngine(
-            store: store,
-            forceBridgeDeviceRefresh: forceBridgeDeviceRefresh
-        )
+        let syncZoneWasRecreated = try await preflight.prepareForCKSyncEngine(store: store)
         if syncZoneWasRecreated {
             let engineToCancel = engine
             engine = nil
@@ -234,7 +482,31 @@ actor MuesliCKSyncEngine: CKSyncEngineDelegate {
         if repaired > 0 {
             _ = try registerNextDirtyBatch(state: syncEngine.state)
         }
-        return (syncZoneWasRecreated, syncEngine)
+        return syncZoneWasRecreated
+    }
+
+    private func invalidatePreparation(
+        cancelEngine: Bool,
+        clearEngineState: Bool
+    ) async {
+        await preparationGate.invalidate()
+        guard cancelEngine else { return }
+        let engineToCancel = engine
+        engine = nil
+        await engineToCancel?.cancelOperations()
+        if clearEngineState {
+            try? store.clearCloudSyncStateData(forKey: Self.stateKey)
+        }
+    }
+
+    private static func invalidatesPreparation(_ error: Error) -> Bool {
+        guard let ckError = error as? CKError else { return false }
+        switch ckError.code {
+        case .notAuthenticated, .permissionFailure:
+            return true
+        default:
+            return false
+        }
     }
 
     private func makeEngineIfNeeded() throws -> CKSyncEngine {
@@ -549,6 +821,7 @@ actor MuesliCKSyncEngine: CKSyncEngineDelegate {
         state.remove(pendingRecordZoneChanges: state.pendingRecordZoneChanges)
         try store.clearCloudSyncStateData(forKey: Self.stateKey)
         conflictBaseRecords.removeAll()
+        await preparationGate.invalidate()
         guard let currentUser else {
             accountBoundaryBlocked = true
             return false

--- a/Muesli/MuesliCKSyncEngine.swift
+++ b/Muesli/MuesliCKSyncEngine.swift
@@ -73,6 +73,9 @@ actor MuesliCKSyncEngine: CKSyncEngineDelegate {
     private static let subscriptionID = "muesli-ios-cksyncengine-private-v1"
     private static let uploadBatchSize = 200
     private static let maximumUploadBatchesPerSync = 50
+    private static var dictationTimingRepairKey: String {
+        "cksyncengine.dictation-timing-repair.\(ICloudTextSyncEngine.cloudSyncStateKeyComponent).v1"
+    }
 
     private let store: SharedStore
     private let onRemoteChanges: @Sendable () async -> Void
@@ -217,6 +220,12 @@ actor MuesliCKSyncEngine: CKSyncEngineDelegate {
         configuration.subscriptionID = Self.subscriptionID
         let created = CKSyncEngine(configuration)
         engine = created
+        let repaired = try store.requeueDictationsWithRecoverableTimingIfNeeded(
+            repairKey: Self.dictationTimingRepairKey
+        )
+        if repaired > 0 {
+            _ = try registerNextDirtyBatch(state: created.state)
+        }
         return created
     }
 

--- a/Muesli/MuesliCKSyncEngine.swift
+++ b/Muesli/MuesliCKSyncEngine.swift
@@ -66,6 +66,27 @@ struct MuesliCKSyncIntentAccumulator: Equatable, Sendable {
     }
 }
 
+/// Publishes one UI invalidation after a complete CloudKit fetch, regardless of
+/// how many record-zone pages the engine delivered. SQLite still commits every
+/// page immediately; only the presentation notification is deferred.
+struct MuesliCKSyncRemoteChangePublication: Equatable, Sendable {
+    private(set) var hasAppliedChanges = false
+
+    mutating func beginFetch() {
+        hasAppliedChanges = false
+    }
+
+    mutating func recordAppliedChanges(_ count: Int) {
+        if count > 0 { hasAppliedChanges = true }
+    }
+
+    mutating func completeFetch() -> Bool {
+        let shouldPublish = hasAppliedChanges
+        hasAppliedChanges = false
+        return shouldPublish
+    }
+}
+
 /// Coalesces one-time/account/zone/migration preparation across concurrent triggers.
 actor MuesliCKSyncPreparationGate {
     private var isPrepared = false
@@ -544,6 +565,7 @@ actor MuesliCKSyncEngine: CKSyncEngineDelegate {
     private var conflictBaseRecords: [CKRecord.ID: CKRecord] = [:]
     private var uploaded = 0
     private var downloaded = 0
+    private var remoteChangePublication = MuesliCKSyncRemoteChangePublication()
     private var accountBoundaryBlocked = true
     private var requiresOutgoingConvergenceAfterZoneRecovery = false
 
@@ -911,8 +933,8 @@ actor MuesliCKSyncEngine: CKSyncEngineDelegate {
                     state: syncEngine.state
                 )
                 if applied > 0 {
+                    remoteChangePublication.recordAppliedChanges(applied)
                     await reportProgress(.downloading(downloaded))
-                    await onRemoteChanges()
                 }
                 // Muesli represents deletion as a saved tombstone. Hard-delete
                 // notifications are intentionally ignored by this record contract.
@@ -969,10 +991,17 @@ actor MuesliCKSyncEngine: CKSyncEngineDelegate {
                     await invalidatePreparation(cancelEngine: false, clearEngineState: true)
                 }
 
+            case .willFetchChanges:
+                downloaded = 0
+                remoteChangePublication.beginFetch()
+
+            case .didFetchChanges:
+                if remoteChangePublication.completeFetch() {
+                    await onRemoteChanges()
+                }
+
             case .sentDatabaseChanges,
-                 .willFetchChanges,
                  .willFetchRecordZoneChanges,
-                 .didFetchChanges,
                  .willSendChanges,
                  .didSendChanges:
                 break

--- a/Muesli/MuesliCKSyncEngine.swift
+++ b/Muesli/MuesliCKSyncEngine.swift
@@ -36,7 +36,20 @@ enum MuesliCKSyncPlan {
 }
 
 enum MuesliCKSyncLaunchPolicy {
-    static func shouldPrepare(syncEnabled: Bool) -> Bool { syncEnabled }
+    static func initialIntent(syncEnabled: Bool) -> MuesliCKSyncIntent? {
+        syncEnabled ? .manual : nil
+    }
+}
+
+enum MuesliCKSyncAutomaticEventPolicy {
+    static func lostSyncZone(in deletedZoneIDs: [CKRecordZone.ID]) -> Bool {
+        deletedZoneIDs.contains(ICloudTextSyncEngine.Schema.syncZoneID)
+    }
+
+    static func lostSyncZone(zoneID: CKRecordZone.ID, error: Error?) -> Bool {
+        zoneID == ICloudTextSyncEngine.Schema.syncZoneID
+            && error.map(ICloudTextSyncEngine.isSyncZoneMissing) == true
+    }
 }
 
 struct MuesliCKSyncIntentAccumulator: Equatable, Sendable {
@@ -120,6 +133,7 @@ enum MuesliCKSyncRecoveryRunner {
     static func run<Value>(
         isolation: isolated (any Actor)? = #isolation,
         operation: () async throws -> Value,
+        recoveryOperation: (() async throws -> Value)? = nil,
         isZoneMissing: (any Error) -> Bool,
         invalidatesPreparation: (any Error) -> Bool,
         invalidate: (any Error) async -> Void
@@ -136,6 +150,9 @@ enum MuesliCKSyncRecoveryRunner {
 
             await invalidate(error)
             do {
+                if let recoveryOperation {
+                    return try await recoveryOperation()
+                }
                 return try await operation()
             } catch {
                 // A successful retry may prepare a fresh engine before its
@@ -148,6 +165,10 @@ enum MuesliCKSyncRecoveryRunner {
             }
         }
     }
+}
+
+enum MuesliCKSyncRuntimeError: Error {
+    case deadlineExceeded
 }
 
 /// Send failure normalized away from CKSyncEngine event wrappers.
@@ -218,15 +239,25 @@ actor MuesliCKSyncRuntime {
 
     private let prepareEngine: @Sendable () async throws -> Void
     private let executeIntent: ExecuteIntent
-    private let refreshBridge: @Sendable (Bool) async -> Void
+    private let refreshBridge: @Sendable (
+        Bool,
+        @escaping @Sendable () async -> Bool
+    ) async -> Void
     private let cancelEngine: @Sendable () async -> Void
     private struct Waiter {
+        let id: UUID
         let generation: Int
         let continuation: CheckedContinuation<ICloudTextSyncResult, any Error>
     }
     private var intents = MuesliCKSyncIntentAccumulator()
-    private var waiters: [Waiter] = []
-    private var isRunning = false
+    private var pendingWaiters: [UUID: Waiter] = [:]
+    private var activeWaiters: [UUID: Waiter] = [:]
+    private var deadlineTasks: [UUID: Task<Void, Never>] = [:]
+    private var runningGeneration: Int?
+    private var cleanupGeneration: Int?
+    private var bridgePendingForceRefresh = false
+    private var bridgeWaiters: [UUID: CheckedContinuation<Void, Never>] = [:]
+    private var bridgeTask: Task<Void, Never>?
     private var generation = 0
 
     init(engine: MuesliCKSyncEngine? = nil) {
@@ -256,8 +287,11 @@ actor MuesliCKSyncRuntime {
                 return try await resolvedEngine.fetchRemoteChanges()
             }
         }
-        refreshBridge = { forceRefresh in
-            await resolvedEngine.refreshBridgeDevice(forceRefresh: forceRefresh)
+        refreshBridge = { forceRefresh, shouldCommit in
+            await resolvedEngine.refreshBridgeDevice(
+                forceRefresh: forceRefresh,
+                shouldCommit: shouldCommit
+            )
         }
         cancelEngine = { await resolvedEngine.cancel() }
     }
@@ -266,7 +300,10 @@ actor MuesliCKSyncRuntime {
     init(
         prepare: @escaping @Sendable () async throws -> Void = {},
         execute: @escaping ExecuteIntent,
-        refreshBridge: @escaping @Sendable (Bool) async -> Void = { _ in },
+        refreshBridge: @escaping @Sendable (
+            Bool,
+            @escaping @Sendable () async -> Bool
+        ) async -> Void = { _, _ in },
         cancel: @escaping @Sendable () async -> Void = {}
     ) {
         prepareEngine = prepare
@@ -287,82 +324,180 @@ actor MuesliCKSyncRuntime {
         try await enqueue(.fetch)
     }
 
+    func fetchRemoteChanges(deadline: Duration) async throws -> ICloudTextSyncResult {
+        try await enqueue(.fetch, deadline: deadline)
+    }
+
     func syncManually() async throws -> ICloudTextSyncResult {
         try await enqueue(.manual)
     }
 
     func refreshBridgeDevice(forceRefresh: Bool) async {
-        await refreshBridge(forceRefresh)
+        await withCheckedContinuation { continuation in
+            bridgePendingForceRefresh = bridgePendingForceRefresh || forceRefresh
+            bridgeWaiters[UUID()] = continuation
+            startBridgeRefreshIfNeeded()
+        }
     }
 
     func cancel() async {
         generation += 1
+        let cancellationGeneration = generation
         _ = intents.take()
-        let cancelledWaiters = waiters
-        waiters.removeAll()
-        isRunning = false
+        let cancelledWaiters = Array(pendingWaiters.values) + Array(activeWaiters.values)
+        pendingWaiters.removeAll()
+        activeWaiters.removeAll()
+        for task in deadlineTasks.values { task.cancel() }
+        deadlineTasks.removeAll()
+        runningGeneration = nil
+        cleanupGeneration = cancellationGeneration
+        bridgePendingForceRefresh = false
+        bridgeTask?.cancel()
+        bridgeTask = nil
+        let cancelledBridgeWaiters = bridgeWaiters.values
+        bridgeWaiters.removeAll()
         // Release APNs/UI callers before CloudKit cancellation. This guarantees
         // the background fetch completion path cannot wait on cancellation I/O.
         cancelledWaiters.forEach { $0.continuation.resume(throwing: CancellationError()) }
+        cancelledBridgeWaiters.forEach { $0.resume() }
         await cancelEngine()
+        guard generation == cancellationGeneration,
+              cleanupGeneration == cancellationGeneration else { return }
+        cleanupGeneration = nil
+        startDrainIfNeeded()
+        startBridgeRefreshIfNeeded()
     }
 
     private func enqueue(
-        _ intent: MuesliCKSyncIntent
+        _ intent: MuesliCKSyncIntent,
+        deadline: Duration? = nil
     ) async throws -> ICloudTextSyncResult {
-        try await withCheckedThrowingContinuation { continuation in
-            intents.insert(intent)
-            waiters.append(Waiter(generation: generation, continuation: continuation))
-            guard !isRunning else { return }
-            isRunning = true
-            let drainGeneration = generation
-            Task { await self.drain(generation: drainGeneration) }
+        let waiterID = UUID()
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                intents.insert(intent)
+                pendingWaiters[waiterID] = Waiter(
+                    id: waiterID,
+                    generation: generation,
+                    continuation: continuation
+                )
+                if let deadline {
+                    deadlineTasks[waiterID] = Task { [weak self] in
+                        do {
+                            try await Task.sleep(for: deadline)
+                        } catch {
+                            return
+                        }
+                        await self?.expireWaiter(waiterID)
+                    }
+                }
+                if Task.isCancelled {
+                    removeWaiter(waiterID, throwing: CancellationError())
+                    return
+                }
+                startDrainIfNeeded()
+            }
+        } onCancel: {
+            Task { await self.removeWaiter(waiterID, throwing: CancellationError()) }
         }
     }
 
+    private func startDrainIfNeeded() {
+        guard cleanupGeneration == nil,
+              runningGeneration == nil,
+              !intents.pending.isEmpty else { return }
+        let drainGeneration = generation
+        runningGeneration = drainGeneration
+        Task { await self.drain(generation: drainGeneration) }
+    }
+
     private func drain(generation drainGeneration: Int) async {
-        var totalUploaded = 0
-        var totalDownloaded = 0
-        do {
-            while drainGeneration == generation, !intents.pending.isEmpty {
-                let intent = intents.take()
-                let result = try await executeIntent(intent)
-                totalUploaded += result.uploaded
-                totalDownloaded += result.downloaded
+        while drainGeneration == generation, cleanupGeneration == nil, !intents.pending.isEmpty {
+            let intent = intents.take()
+            let batchWaiterIDs = Set(pendingWaiters.keys)
+            for waiterID in batchWaiterIDs {
+                activeWaiters[waiterID] = pendingWaiters.removeValue(forKey: waiterID)
             }
-            guard drainGeneration == generation else { return }
-            completeWaiters(generation: drainGeneration, with: .success(ICloudTextSyncResult(
-                uploaded: totalUploaded,
-                downloaded: totalDownloaded
-            )))
-        } catch {
-            guard drainGeneration == generation else { return }
-            // Every current-generation waiter receives this failure, so discard
-            // their merged intent too. A later trigger must not replay stale work
-            // after the callers that requested it have already been released.
-            _ = intents.take()
-            completeWaiters(generation: drainGeneration, with: .failure(error))
+
+            do {
+                let result = try await executeIntent(intent)
+                guard drainGeneration == generation else { return }
+                completeWaiters(batchWaiterIDs, with: .success(result))
+            } catch {
+                guard drainGeneration == generation else { return }
+                // Requests arriving while the failed operation was suspended
+                // own a later batch. Fail only the callers of this active batch.
+                completeWaiters(batchWaiterIDs, with: .failure(error))
+            }
         }
+
+        guard runningGeneration == drainGeneration else { return }
+        runningGeneration = nil
+        startDrainIfNeeded()
     }
 
     func pendingIntentForTesting() -> MuesliCKSyncIntent {
         intents.pending
     }
 
+    func waiterCountForTesting() -> Int {
+        pendingWaiters.count + activeWaiters.count
+    }
+
+    private func expireWaiter(_ waiterID: UUID) {
+        removeWaiter(waiterID, throwing: MuesliCKSyncRuntimeError.deadlineExceeded)
+    }
+
+    private func removeWaiter(_ waiterID: UUID, throwing error: any Error) {
+        let waiter = pendingWaiters.removeValue(forKey: waiterID)
+            ?? activeWaiters.removeValue(forKey: waiterID)
+        deadlineTasks.removeValue(forKey: waiterID)?.cancel()
+        waiter?.continuation.resume(throwing: error)
+    }
+
     private func completeWaiters(
-        generation completedGeneration: Int,
+        _ waiterIDs: Set<UUID>,
         with result: Result<ICloudTextSyncResult, any Error>
     ) {
-        let completedWaiters = waiters.filter { $0.generation == completedGeneration }
-        waiters.removeAll { $0.generation == completedGeneration }
-        guard completedGeneration == generation else { return }
-        isRunning = false
-        for waiter in completedWaiters {
+        for waiterID in waiterIDs {
+            guard let waiter = activeWaiters.removeValue(forKey: waiterID),
+                  waiter.generation == generation else { continue }
+            deadlineTasks.removeValue(forKey: waiterID)?.cancel()
             switch result {
             case .success(let value): waiter.continuation.resume(returning: value)
             case .failure(let error): waiter.continuation.resume(throwing: error)
             }
         }
+    }
+
+    private func startBridgeRefreshIfNeeded() {
+        guard cleanupGeneration == nil,
+              bridgeTask == nil,
+              !bridgeWaiters.isEmpty else { return }
+        let bridgeGeneration = generation
+        bridgeTask = Task { await self.drainBridgeRefresh(generation: bridgeGeneration) }
+    }
+
+    private func drainBridgeRefresh(generation bridgeGeneration: Int) async {
+        while bridgeGeneration == generation, cleanupGeneration == nil, !bridgeWaiters.isEmpty {
+            let forceRefresh = bridgePendingForceRefresh
+            bridgePendingForceRefresh = false
+            await refreshBridge(forceRefresh) { [weak self] in
+                await self?.isCurrentGeneration(bridgeGeneration) == true
+            }
+            guard bridgeGeneration == generation, cleanupGeneration == nil else { return }
+            if bridgePendingForceRefresh { continue }
+            let completed = bridgeWaiters.values
+            bridgeWaiters.removeAll()
+            completed.forEach { $0.resume() }
+        }
+        guard bridgeGeneration == generation else { return }
+        bridgeTask = nil
+        startBridgeRefreshIfNeeded()
+    }
+
+    private func isCurrentGeneration(_ observedGeneration: Int) -> Bool {
+        observedGeneration == generation && cleanupGeneration == nil
     }
 }
 
@@ -403,6 +538,7 @@ actor MuesliCKSyncEngine: CKSyncEngineDelegate {
     private var uploaded = 0
     private var downloaded = 0
     private var accountBoundaryBlocked = true
+    private var requiresOutgoingConvergenceAfterZoneRecovery = false
 
     init(
         store: SharedStore = SharedStore(),
@@ -449,6 +585,12 @@ actor MuesliCKSyncEngine: CKSyncEngineDelegate {
     ) async throws -> ICloudTextSyncResult {
         try await MuesliCKSyncRecoveryRunner.run(
             operation: { try await self.run(intent: intent) },
+            recoveryOperation: {
+                // Recreating the zone resets every local row's CloudKit
+                // metadata. A fetch-only retry must therefore flush the rebuilt
+                // outbox before fetching or those rows remain local indefinitely.
+                try await self.run(intent: intent.contains(.fetch) ? .manual : intent)
+            },
             isZoneMissing: ICloudTextSyncEngine.isSyncZoneMissing,
             invalidatesPreparation: Self.invalidatesPreparation,
             invalidate: { error in
@@ -456,6 +598,9 @@ actor MuesliCKSyncEngine: CKSyncEngineDelegate {
                 // Zone loss must also retire serialized CKSyncEngine state;
                 // account-context failures only retire cached preparation so
                 // the next attempt proves the account boundary again.
+                if zoneIsMissing {
+                    self.requiresOutgoingConvergenceAfterZoneRecovery = true
+                }
                 await self.invalidatePreparation(
                     cancelEngine: zoneIsMissing,
                     clearEngineState: zoneIsMissing
@@ -472,7 +617,14 @@ actor MuesliCKSyncEngine: CKSyncEngineDelegate {
         _ = try await prepare()
         let syncEngine = try makeEngineIfNeeded()
 
-        for operation in MuesliCKSyncPlan.operations(for: intent) {
+        let effectiveIntent: MuesliCKSyncIntent
+        if requiresOutgoingConvergenceAfterZoneRecovery, intent.contains(.fetch) {
+            effectiveIntent = intent.union(.send)
+        } else {
+            effectiveIntent = intent
+        }
+
+        for operation in MuesliCKSyncPlan.operations(for: effectiveIntent) {
             switch operation {
             case .send:
                 await reportProgress(.uploading(uploaded))
@@ -489,6 +641,7 @@ actor MuesliCKSyncEngine: CKSyncEngineDelegate {
                         try await syncEngine.sendChanges(options)
                     }
                 )
+                requiresOutgoingConvergenceAfterZoneRecovery = false
 
             case .fetch:
                 await reportProgress(.fetching)
@@ -527,8 +680,14 @@ actor MuesliCKSyncEngine: CKSyncEngineDelegate {
     }
 
     /// Companion presence is ancillary UI state and never blocks text transport.
-    func refreshBridgeDevice(forceRefresh: Bool = false) async {
-        await resolvedPreflight().refreshBridgeDeviceLinkIfNeeded(forceRefresh: forceRefresh)
+    func refreshBridgeDevice(
+        forceRefresh: Bool = false,
+        shouldCommit: @escaping @Sendable () async -> Bool = { true }
+    ) async {
+        await resolvedPreflight().refreshBridgeDeviceLinkIfNeeded(
+            forceRefresh: forceRefresh,
+            shouldCommit: shouldCommit
+        )
     }
 
     private func performPreparation() async throws -> Bool {
@@ -566,13 +725,13 @@ actor MuesliCKSyncEngine: CKSyncEngineDelegate {
         clearEngineState: Bool
     ) async {
         await preparationGate.invalidate()
+        if clearEngineState {
+            try? store.clearCloudSyncStateData(forKey: Self.stateKey)
+        }
         guard cancelEngine else { return }
         let engineToCancel = engine
         engine = nil
         await engineToCancel?.cancelOperations()
-        if clearEngineState {
-            try? store.clearCloudSyncStateData(forKey: Self.stateKey)
-        }
     }
 
     static func invalidatesPreparation(_ error: Error) -> Bool {
@@ -784,11 +943,28 @@ actor MuesliCKSyncEngine: CKSyncEngineDelegate {
                     break
                 }
 
-            case .fetchedDatabaseChanges,
-                 .sentDatabaseChanges,
+            case .fetchedDatabaseChanges(let changes):
+                if MuesliCKSyncAutomaticEventPolicy.lostSyncZone(
+                    in: changes.deletions.map(\.zoneID)
+                ) {
+                    // Delegate callbacks only retire stale state. The next
+                    // external APNs/foreground/manual trigger owns recovery.
+                    requiresOutgoingConvergenceAfterZoneRecovery = true
+                    await invalidatePreparation(cancelEngine: false, clearEngineState: true)
+                }
+
+            case .didFetchRecordZoneChanges(let changes):
+                if MuesliCKSyncAutomaticEventPolicy.lostSyncZone(
+                    zoneID: changes.zoneID,
+                    error: changes.error
+                ) {
+                    requiresOutgoingConvergenceAfterZoneRecovery = true
+                    await invalidatePreparation(cancelEngine: false, clearEngineState: true)
+                }
+
+            case .sentDatabaseChanges,
                  .willFetchChanges,
                  .willFetchRecordZoneChanges,
-                 .didFetchRecordZoneChanges,
                  .didFetchChanges,
                  .willSendChanges,
                  .didSendChanges:

--- a/Muesli/MuesliCKSyncEngine.swift
+++ b/Muesli/MuesliCKSyncEngine.swift
@@ -536,7 +536,7 @@ actor MuesliCKSyncEngine: CKSyncEngineDelegate {
     private let store: SharedStore
     private let onRemoteChanges: @Sendable () async -> Void
     private let onProgress: @Sendable (MuesliCKSyncProgress) async -> Void
-    private let legacyAccountRecordVerifier: (@Sendable (Set<String>) async throws -> Bool)?
+    private let legacyAccountRecordVerifier: (@Sendable (Set<String>) async throws -> Set<String>)?
     private let preparationGate = MuesliCKSyncPreparationGate()
     private var container: CKContainer?
     private var preflight: ICloudTextSyncEngine?
@@ -552,7 +552,7 @@ actor MuesliCKSyncEngine: CKSyncEngineDelegate {
         container: CKContainer? = nil,
         onRemoteChanges: @escaping @Sendable () async -> Void = {},
         onProgress: @escaping @Sendable (MuesliCKSyncProgress) async -> Void = { _ in },
-        legacyAccountRecordVerifier: (@Sendable (Set<String>) async throws -> Bool)? = nil
+        legacyAccountRecordVerifier: (@Sendable (Set<String>) async throws -> Set<String>)? = nil
     ) {
         self.store = store
         self.container = container
@@ -1113,15 +1113,15 @@ actor MuesliCKSyncEngine: CKSyncEngineDelegate {
 
         let legacyRecordNames = try store.textRecordNamesRequiringAccountVerification()
         if !legacyRecordNames.isEmpty {
-            let verified: Bool
+            let matchedRecordNames: Set<String>
             if let legacyAccountRecordVerifier {
-                verified = try await legacyAccountRecordVerifier(legacyRecordNames)
+                matchedRecordNames = try await legacyAccountRecordVerifier(legacyRecordNames)
             } else {
-                verified = try await (preflight ?? resolvedPreflight()).syncZoneContainsAnyTextRecord(
+                matchedRecordNames = try await (preflight ?? resolvedPreflight()).matchingSyncZoneTextRecordNames(
                     named: legacyRecordNames
                 )
             }
-            guard verified else {
+            guard matchedRecordNames == legacyRecordNames else {
                 Self.logger.error("account_provenance_unverified")
                 return false
             }

--- a/Muesli/MuesliCKSyncEngine.swift
+++ b/Muesli/MuesliCKSyncEngine.swift
@@ -1,6 +1,9 @@
 import CloudKit
+import CryptoKit
 import Foundation
+import OSLog
 
+/// Minimal pending-state surface used by the engine and deterministic tests.
 protocol MuesliCKSyncPendingState: AnyObject, Sendable {
     var pendingRecordZoneChanges: [CKSyncEngine.PendingRecordZoneChange] { get }
     func add(pendingRecordZoneChanges: [CKSyncEngine.PendingRecordZoneChange])
@@ -9,6 +12,7 @@ protocol MuesliCKSyncPendingState: AnyObject, Sendable {
 
 extension CKSyncEngine.State: MuesliCKSyncPendingState {}
 
+/// Runs fetch-first sync and stops upload paging when CloudKit makes no progress.
 enum MuesliCKSyncCycle {
     static func run(
         maximumUploadBatches: Int,
@@ -30,16 +34,31 @@ enum MuesliCKSyncCycle {
     }
 }
 
+/// Send failure normalized away from CKSyncEngine event wrappers.
 struct MuesliCKSyncFailedRecordSave: Sendable {
     let record: CKRecord
     let error: CKError
 }
 
+/// Locally materialized records and obsolete pending saves found in one read.
 struct MuesliCKSyncRecordBatch: Sendable {
     let recordsToSave: [CKRecord]
     let staleChanges: [CKSyncEngine.PendingRecordZoneChange]
 }
 
+/// Safety errors that require an account or user action before sync resumes.
+enum MuesliCKSyncError: LocalizedError {
+    case accountChanged
+
+    var errorDescription: String? {
+        switch self {
+        case .accountChanged:
+            "iCloud sync is paused because this Muesli library belongs to a different iCloud account."
+        }
+    }
+}
+
+/// Privacy-safe progress phases exposed to diagnostics and the settings UI.
 enum MuesliCKSyncProgress: Equatable, Sendable {
     case preparing
     case fetching
@@ -70,9 +89,17 @@ actor MuesliCKSyncEngine: CKSyncEngineDelegate {
         "cksyncengine.private.MuesliSyncZone.\(ICloudTextSyncEngine.cloudSyncStateKeyComponent).v1"
     }
 
+    static var accountScopeKey: String {
+        "cksyncengine.private.MuesliSyncZone.\(ICloudTextSyncEngine.cloudSyncStateKeyComponent).account-owner.v1"
+    }
+
     private static let subscriptionID = "muesli-ios-cksyncengine-private-v1"
     private static let uploadBatchSize = 200
     private static let maximumUploadBatchesPerSync = 50
+    private static let logger = Logger(
+        subsystem: "com.mueslihq.muesli",
+        category: "cksyncengine"
+    )
     private static var dictationTimingRepairKey: String {
         "cksyncengine.dictation-timing-repair.\(ICloudTextSyncEngine.cloudSyncStateKeyComponent).v1"
     }
@@ -86,6 +113,7 @@ actor MuesliCKSyncEngine: CKSyncEngineDelegate {
     private var conflictBaseRecords: [CKRecord.ID: CKRecord] = [:]
     private var uploaded = 0
     private var downloaded = 0
+    private var accountBoundaryBlocked = true
 
     init(
         store: SharedStore = SharedStore(),
@@ -99,6 +127,7 @@ actor MuesliCKSyncEngine: CKSyncEngineDelegate {
         self.onProgress = onProgress
     }
 
+    /// Fetches private-zone changes, then drains the durable local outbox.
     func sync(forceBridgeDeviceRefresh: Bool = false) async throws -> ICloudTextSyncResult {
         uploaded = 0
         downloaded = 0
@@ -144,14 +173,17 @@ actor MuesliCKSyncEngine: CKSyncEngineDelegate {
         case .preparing, .fetching:
             count = nil
         }
-        let countSuffix = count.map { " count=\($0)" } ?? ""
-        fputs(
-            "[muesli-ios] CKSyncEngine phase=\(progress.diagnosticValue)\(countSuffix)\n",
-            stderr
-        )
+        if let count {
+            Self.logger.debug(
+                "phase=\(progress.diagnosticValue, privacy: .public) count=\(count, privacy: .public)"
+            )
+        } else {
+            Self.logger.debug("phase=\(progress.diagnosticValue, privacy: .public)")
+        }
         await onProgress(progress)
     }
 
+    /// Prepares the account boundary, custom zone, migration, and engine state.
     @discardableResult
     func prepare(forceBridgeDeviceRefresh: Bool = false) async throws -> Bool {
         let (syncZoneWasRecreated, _) = try await prepareEngine(
@@ -160,6 +192,7 @@ actor MuesliCKSyncEngine: CKSyncEngineDelegate {
         return syncZoneWasRecreated
     }
 
+    /// Cancels outstanding CloudKit operations and discards the live engine.
     func cancel() async {
         let engineToCancel = engine
         engine = nil
@@ -169,6 +202,17 @@ actor MuesliCKSyncEngine: CKSyncEngineDelegate {
     private func prepareEngine(
         forceBridgeDeviceRefresh: Bool
     ) async throws -> (syncZoneWasRecreated: Bool, engine: CKSyncEngine) {
+        let currentUser = try await resolvedContainer().userRecordID()
+        guard try authorizeAccount(currentUser) else {
+            if let engine {
+                engine.state.remove(
+                    pendingRecordZoneChanges: engine.state.pendingRecordZoneChanges
+                )
+            }
+            try store.clearCloudSyncStateData(forKey: Self.stateKey)
+            throw MuesliCKSyncError.accountChanged
+        }
+
         let preflight: ICloudTextSyncEngine
         if let existing = self.preflight {
             preflight = existing
@@ -188,7 +232,14 @@ actor MuesliCKSyncEngine: CKSyncEngineDelegate {
             await engineToCancel?.cancelOperations()
             try store.clearCloudSyncStateData(forKey: Self.stateKey)
         }
-        return (syncZoneWasRecreated, try makeEngineIfNeeded())
+        let syncEngine = try makeEngineIfNeeded()
+        let repaired = try store.requeueDictationsWithRecoverableTimingIfNeeded(
+            repairKey: Self.dictationTimingRepairKey
+        )
+        if repaired > 0 {
+            _ = try registerNextDirtyBatch(state: syncEngine.state)
+        }
+        return (syncZoneWasRecreated, syncEngine)
     }
 
     private func makeEngineIfNeeded() throws -> CKSyncEngine {
@@ -220,12 +271,6 @@ actor MuesliCKSyncEngine: CKSyncEngineDelegate {
         configuration.subscriptionID = Self.subscriptionID
         let created = CKSyncEngine(configuration)
         engine = created
-        let repaired = try store.requeueDictationsWithRecoverableTimingIfNeeded(
-            repairKey: Self.dictationTimingRepairKey
-        )
-        if repaired > 0 {
-            _ = try registerNextDirtyBatch(state: created.state)
-        }
         return created
     }
 
@@ -236,7 +281,9 @@ actor MuesliCKSyncEngine: CKSyncEngineDelegate {
         return created
     }
 
+    /// Registers one bounded page of SQLite outbox rows with CKSyncEngine.
     func registerNextDirtyBatch(state: any MuesliCKSyncPendingState) throws -> Int {
+        guard !accountBoundaryBlocked else { return 0 }
         let dirtyRecords = try store.textRecordsNeedingSync(limit: Self.uploadBatchSize)
         guard !dirtyRecords.isEmpty else { return 0 }
 
@@ -256,10 +303,12 @@ actor MuesliCKSyncEngine: CKSyncEngineDelegate {
         return dirtyRecords.count
     }
 
+    /// Supplies CloudKit with a size-aware batch backed by one SQLite page read.
     func nextRecordZoneChangeBatch(
         _ context: CKSyncEngine.SendChangesContext,
         syncEngine: CKSyncEngine
     ) async -> CKSyncEngine.RecordZoneChangeBatch? {
+        guard !accountBoundaryBlocked else { return nil }
         let pending = syncEngine.state.pendingRecordZoneChanges.filter {
             context.options.scope.contains($0)
         }
@@ -268,9 +317,19 @@ actor MuesliCKSyncEngine: CKSyncEngineDelegate {
             syncEngine.state.remove(pendingRecordZoneChanges: batch.staleChanges)
         }
         guard !batch.recordsToSave.isEmpty else { return nil }
-        return CKSyncEngine.RecordZoneChangeBatch(recordsToSave: batch.recordsToSave)
+        let recordsByID = Dictionary(
+            uniqueKeysWithValues: batch.recordsToSave.map { ($0.recordID, $0) }
+        )
+        let saveChanges = batch.recordsToSave.map {
+            CKSyncEngine.PendingRecordZoneChange.saveRecord($0.recordID)
+        }
+        return await CKSyncEngine.RecordZoneChangeBatch(
+            pendingChanges: saveChanges,
+            recordProvider: { recordsByID[$0] }
+        )
     }
 
+    /// Materializes the latest local version for each pending record save.
     func makeRecordBatch(
         pendingChanges: [CKSyncEngine.PendingRecordZoneChange]
     ) -> MuesliCKSyncRecordBatch {
@@ -299,9 +358,8 @@ actor MuesliCKSyncEngine: CKSyncEngineDelegate {
         } catch {
             // Keep pending saves intact on transient SQLite failures. Diagnostics
             // contain only the error category, never record IDs or authored text.
-            fputs(
-                "[muesli-ios] CKSyncEngine local batch read failed: \(String(describing: type(of: error)))\n",
-                stderr
+            Self.logger.error(
+                "local_batch_read_failed error_type=\(String(describing: type(of: error)), privacy: .public)"
             )
             return MuesliCKSyncRecordBatch(recordsToSave: [], staleChanges: [])
         }
@@ -324,6 +382,7 @@ actor MuesliCKSyncEngine: CKSyncEngineDelegate {
         )
     }
 
+    /// Persists engine state and reconciles CloudKit events with SQLite.
     func handleEvent(_ event: CKSyncEngine.Event, syncEngine: CKSyncEngine) async {
         do {
             switch event {
@@ -332,6 +391,7 @@ actor MuesliCKSyncEngine: CKSyncEngineDelegate {
                 try store.saveCloudSyncStateData(data, forKey: Self.stateKey)
 
             case .fetchedRecordZoneChanges(let changes):
+                guard !accountBoundaryBlocked else { break }
                 let applied = try handleFetchedRecords(
                     changes.modifications.map(\.record),
                     state: syncEngine.state
@@ -344,6 +404,7 @@ actor MuesliCKSyncEngine: CKSyncEngineDelegate {
                 // notifications are intentionally ignored by this record contract.
 
             case .sentRecordZoneChanges(let changes):
+                guard !accountBoundaryBlocked else { break }
                 try handleSentRecordChanges(
                     savedRecords: changes.savedRecords,
                     failedRecordSaves: changes.failedRecordSaves.map {
@@ -356,14 +417,19 @@ actor MuesliCKSyncEngine: CKSyncEngineDelegate {
             case .accountChange(let change):
                 conflictBaseRecords.removeAll()
                 switch change.changeType {
-                case .signIn, .switchAccounts:
-                    try handleAccountChange(
-                        requiresMetadataReset: true,
+                case .signIn(let currentUser):
+                    _ = try handleAccountChange(
+                        currentUser: currentUser,
+                        state: syncEngine.state
+                    )
+                case .switchAccounts(_, let currentUser):
+                    _ = try handleAccountChange(
+                        currentUser: currentUser,
                         state: syncEngine.state
                     )
                 case .signOut:
-                    try handleAccountChange(
-                        requiresMetadataReset: false,
+                    _ = try handleAccountChange(
+                        currentUser: nil,
                         state: syncEngine.state
                     )
                 @unknown default:
@@ -384,14 +450,14 @@ actor MuesliCKSyncEngine: CKSyncEngineDelegate {
                 break
             }
         } catch {
-            fputs(
-                "[muesli-ios] CKSyncEngine event failed: \(String(describing: type(of: error)))\n",
-                stderr
+            Self.logger.error(
+                "event_failed error_type=\(String(describing: type(of: error)), privacy: .public)"
             )
         }
     }
 
     @discardableResult
+    /// Applies fetched text records while preserving newer dirty local edits.
     func handleFetchedRecords(
         _ cloudRecords: [CKRecord],
         state: any MuesliCKSyncPendingState
@@ -424,6 +490,7 @@ actor MuesliCKSyncEngine: CKSyncEngineDelegate {
         return appliedRecordIDs.count
     }
 
+    /// Acknowledges exact uploaded versions and retains retryable failures.
     func handleSentRecordChanges(
         savedRecords: [CKRecord],
         failedRecordSaves: [MuesliCKSyncFailedRecordSave],
@@ -468,19 +535,43 @@ actor MuesliCKSyncEngine: CKSyncEngineDelegate {
         }
     }
 
+    /// Applies an account event without ever migrating local text across accounts.
+    @discardableResult
     func handleAccountChange(
-        requiresMetadataReset: Bool,
+        currentUser: CKRecord.ID?,
         state: any MuesliCKSyncPendingState
-    ) throws {
+    ) throws -> Bool {
         // This runs inside CKSyncEngine's own delegate callback. Cancelling the
         // same engine here is re-entrant and CloudKit deliberately traps. Keep
-        // the live engine and its account-change state; discard only the stale
-        // serialization that belongs to the previous account.
+        // live engine inert; discard account-specific pending work and state.
+        state.remove(pendingRecordZoneChanges: state.pendingRecordZoneChanges)
         try store.clearCloudSyncStateData(forKey: Self.stateKey)
         conflictBaseRecords.removeAll()
-        guard requiresMetadataReset else { return }
+        guard let currentUser else {
+            accountBoundaryBlocked = true
+            return false
+        }
 
-        try store.resetTextRecordCloudMetadataForAccountChange()
+        guard try authorizeAccount(currentUser) else { return false }
         _ = try registerNextDirtyBatch(state: state)
+        return true
+    }
+
+    /// Hashes the per-container user ID before it reaches local persistence.
+    static func accountScope(for userRecordID: CKRecord.ID) -> String {
+        let digest = SHA256.hash(data: Data(userRecordID.recordName.utf8))
+        return "sha256:" + digest.map { String(format: "%02x", $0) }.joined()
+    }
+
+    private func authorizeAccount(_ userRecordID: CKRecord.ID) throws -> Bool {
+        let matches = try store.claimCloudSyncAccountScope(
+            Self.accountScope(for: userRecordID),
+            forKey: Self.accountScopeKey
+        )
+        accountBoundaryBlocked = !matches
+        if !matches {
+            Self.logger.error("account_boundary_blocked")
+        }
+        return matches
     }
 }

--- a/Muesli/MuesliCKSyncEngine.swift
+++ b/Muesli/MuesliCKSyncEngine.swift
@@ -40,6 +40,26 @@ struct MuesliCKSyncRecordBatch: Sendable {
     let staleChanges: [CKSyncEngine.PendingRecordZoneChange]
 }
 
+enum MuesliCKSyncProgress: Equatable, Sendable {
+    case preparing
+    case fetching
+    case downloading(Int)
+    case uploading(Int)
+
+    var diagnosticValue: String {
+        switch self {
+        case .preparing:
+            "preparing"
+        case .fetching:
+            "fetching"
+        case .downloading:
+            "downloading"
+        case .uploading:
+            "uploading"
+        }
+    }
+}
+
 /// Owns the one CKSyncEngine instance for the private text-record zone.
 ///
 /// SQLite's `sync_dirty` flags remain the durable outbox. Before every send,
@@ -56,6 +76,7 @@ actor MuesliCKSyncEngine: CKSyncEngineDelegate {
 
     private let store: SharedStore
     private let onRemoteChanges: @Sendable () async -> Void
+    private let onProgress: @Sendable (MuesliCKSyncProgress) async -> Void
     private var container: CKContainer?
     private var preflight: ICloudTextSyncEngine?
     private var engine: CKSyncEngine?
@@ -66,20 +87,24 @@ actor MuesliCKSyncEngine: CKSyncEngineDelegate {
     init(
         store: SharedStore = SharedStore(),
         container: CKContainer? = nil,
-        onRemoteChanges: @escaping @Sendable () async -> Void = {}
+        onRemoteChanges: @escaping @Sendable () async -> Void = {},
+        onProgress: @escaping @Sendable (MuesliCKSyncProgress) async -> Void = { _ in }
     ) {
         self.store = store
         self.container = container
         self.onRemoteChanges = onRemoteChanges
+        self.onProgress = onProgress
     }
 
     func sync(forceBridgeDeviceRefresh: Bool = false) async throws -> ICloudTextSyncResult {
         uploaded = 0
         downloaded = 0
 
+        await reportProgress(.preparing)
         let (_, syncEngine) = try await prepareEngine(
             forceBridgeDeviceRefresh: forceBridgeDeviceRefresh
         )
+        await reportProgress(.fetching)
         try await MuesliCKSyncCycle.run(
             maximumUploadBatches: Self.maximumUploadBatchesPerSync,
             fetch: {
@@ -89,7 +114,11 @@ actor MuesliCKSyncEngine: CKSyncEngineDelegate {
                 try await syncEngine.fetchChanges(options)
             },
             registerNextBatch: {
-                try self.registerNextDirtyBatch(state: syncEngine.state)
+                let registered = try self.registerNextDirtyBatch(state: syncEngine.state)
+                if registered > 0 {
+                    await self.reportProgress(.uploading(self.uploaded))
+                }
+                return registered
             },
             uploadedCount: { self.uploaded },
             send: {
@@ -101,6 +130,23 @@ actor MuesliCKSyncEngine: CKSyncEngineDelegate {
         )
 
         return ICloudTextSyncResult(uploaded: uploaded, downloaded: downloaded)
+    }
+
+    private func reportProgress(_ progress: MuesliCKSyncProgress) async {
+        // Phase and count only: never include record IDs or authored text.
+        let count: Int?
+        switch progress {
+        case .downloading(let value), .uploading(let value):
+            count = value
+        case .preparing, .fetching:
+            count = nil
+        }
+        let countSuffix = count.map { " count=\($0)" } ?? ""
+        fputs(
+            "[muesli-ios] CKSyncEngine phase=\(progress.diagnosticValue)\(countSuffix)\n",
+            stderr
+        )
+        await onProgress(progress)
     }
 
     @discardableResult
@@ -281,7 +327,10 @@ actor MuesliCKSyncEngine: CKSyncEngineDelegate {
                     changes.modifications.map(\.record),
                     state: syncEngine.state
                 )
-                if applied > 0 { await onRemoteChanges() }
+                if applied > 0 {
+                    await reportProgress(.downloading(downloaded))
+                    await onRemoteChanges()
+                }
                 // Muesli represents deletion as a saved tombstone. Hard-delete
                 // notifications are intentionally ignored by this record contract.
 
@@ -293,6 +342,7 @@ actor MuesliCKSyncEngine: CKSyncEngineDelegate {
                     },
                     state: syncEngine.state
                 )
+                await reportProgress(.uploading(uploaded))
 
             case .accountChange(let change):
                 conflictBaseRecords.removeAll()

--- a/Muesli/MuesliCKSyncEngine.swift
+++ b/Muesli/MuesliCKSyncEngine.swift
@@ -113,6 +113,43 @@ enum MuesliCKSyncCycle {
     }
 }
 
+/// Applies one bounded zone-recreation retry and makes every preparation
+/// invalidation explicit. Keeping the policy outside the CloudKit actor makes
+/// second-attempt failures deterministic to exercise in tests.
+enum MuesliCKSyncRecoveryRunner {
+    static func run<Value>(
+        isolation: isolated (any Actor)? = #isolation,
+        operation: () async throws -> Value,
+        isZoneMissing: (any Error) -> Bool,
+        invalidatesPreparation: (any Error) -> Bool,
+        invalidate: (any Error) async -> Void
+    ) async throws -> Value {
+        do {
+            return try await operation()
+        } catch {
+            guard isZoneMissing(error) else {
+                if invalidatesPreparation(error) {
+                    await invalidate(error)
+                }
+                throw error
+            }
+
+            await invalidate(error)
+            do {
+                return try await operation()
+            } catch {
+                // A successful retry may prepare a fresh engine before its
+                // send/fetch discovers another zone or account-context error.
+                // Retire that preparation too instead of publishing it as ready.
+                if invalidatesPreparation(error) {
+                    await invalidate(error)
+                }
+                throw error
+            }
+        }
+    }
+}
+
 /// Send failure normalized away from CKSyncEngine event wrappers.
 struct MuesliCKSyncFailedRecordSave: Sendable {
     let record: CKRecord
@@ -175,7 +212,14 @@ enum MuesliCKSyncNotificationKey {
 actor MuesliCKSyncRuntime {
     static let shared = MuesliCKSyncRuntime()
 
-    private let engine: MuesliCKSyncEngine
+    typealias ExecuteIntent = @Sendable (
+        MuesliCKSyncIntent
+    ) async throws -> ICloudTextSyncResult
+
+    private let prepareEngine: @Sendable () async throws -> Void
+    private let executeIntent: ExecuteIntent
+    private let refreshBridge: @Sendable (Bool) async -> Void
+    private let cancelEngine: @Sendable () async -> Void
     private struct Waiter {
         let generation: Int
         let continuation: CheckedContinuation<ICloudTextSyncResult, any Error>
@@ -186,7 +230,7 @@ actor MuesliCKSyncRuntime {
     private var generation = 0
 
     init(engine: MuesliCKSyncEngine? = nil) {
-        self.engine = engine ?? MuesliCKSyncEngine(
+        let resolvedEngine = engine ?? MuesliCKSyncEngine(
             onRemoteChanges: {
                 await MainActor.run {
                     NotificationCenter.default.post(name: .muesliCKSyncRemoteChanges, object: nil)
@@ -202,10 +246,37 @@ actor MuesliCKSyncRuntime {
                 }
             }
         )
+        prepareEngine = { _ = try await resolvedEngine.prepare() }
+        executeIntent = { intent in
+            if intent == .manual {
+                return try await resolvedEngine.syncManually()
+            } else if intent == .send {
+                return try await resolvedEngine.sendLocalChanges()
+            } else {
+                return try await resolvedEngine.fetchRemoteChanges()
+            }
+        }
+        refreshBridge = { forceRefresh in
+            await resolvedEngine.refreshBridgeDevice(forceRefresh: forceRefresh)
+        }
+        cancelEngine = { await resolvedEngine.cancel() }
+    }
+
+    /// Test seam for request ownership and cancellation without CloudKit I/O.
+    init(
+        prepare: @escaping @Sendable () async throws -> Void = {},
+        execute: @escaping ExecuteIntent,
+        refreshBridge: @escaping @Sendable (Bool) async -> Void = { _ in },
+        cancel: @escaping @Sendable () async -> Void = {}
+    ) {
+        prepareEngine = prepare
+        executeIntent = execute
+        self.refreshBridge = refreshBridge
+        cancelEngine = cancel
     }
 
     func prepare() async throws {
-        _ = try await engine.prepare()
+        try await prepareEngine()
     }
 
     func sendLocalChanges() async throws -> ICloudTextSyncResult {
@@ -221,7 +292,7 @@ actor MuesliCKSyncRuntime {
     }
 
     func refreshBridgeDevice(forceRefresh: Bool) async {
-        await engine.refreshBridgeDevice(forceRefresh: forceRefresh)
+        await refreshBridge(forceRefresh)
     }
 
     func cancel() async {
@@ -230,8 +301,10 @@ actor MuesliCKSyncRuntime {
         let cancelledWaiters = waiters
         waiters.removeAll()
         isRunning = false
-        await engine.cancel()
+        // Release APNs/UI callers before CloudKit cancellation. This guarantees
+        // the background fetch completion path cannot wait on cancellation I/O.
         cancelledWaiters.forEach { $0.continuation.resume(throwing: CancellationError()) }
+        await cancelEngine()
     }
 
     private func enqueue(
@@ -251,26 +324,29 @@ actor MuesliCKSyncRuntime {
         var totalUploaded = 0
         var totalDownloaded = 0
         do {
-            while !intents.pending.isEmpty {
+            while drainGeneration == generation, !intents.pending.isEmpty {
                 let intent = intents.take()
-                let result: ICloudTextSyncResult
-                if intent == .manual {
-                    result = try await engine.syncManually()
-                } else if intent == .send {
-                    result = try await engine.sendLocalChanges()
-                } else {
-                    result = try await engine.fetchRemoteChanges()
-                }
+                let result = try await executeIntent(intent)
                 totalUploaded += result.uploaded
                 totalDownloaded += result.downloaded
             }
+            guard drainGeneration == generation else { return }
             completeWaiters(generation: drainGeneration, with: .success(ICloudTextSyncResult(
                 uploaded: totalUploaded,
                 downloaded: totalDownloaded
             )))
         } catch {
+            guard drainGeneration == generation else { return }
+            // Every current-generation waiter receives this failure, so discard
+            // their merged intent too. A later trigger must not replay stale work
+            // after the callers that requested it have already been released.
+            _ = intents.take()
             completeWaiters(generation: drainGeneration, with: .failure(error))
         }
+    }
+
+    func pendingIntentForTesting() -> MuesliCKSyncIntent {
+        intents.pending
     }
 
     private func completeWaiters(
@@ -371,21 +447,21 @@ actor MuesliCKSyncEngine: CKSyncEngineDelegate {
     private func runWithZoneRecovery(
         intent: MuesliCKSyncIntent
     ) async throws -> ICloudTextSyncResult {
-        do {
-            return try await run(intent: intent)
-        } catch {
-            guard ICloudTextSyncEngine.isSyncZoneMissing(error) else {
-                if Self.invalidatesPreparation(error) {
-                    await invalidatePreparation(cancelEngine: false, clearEngineState: false)
-                }
-                throw error
+        try await MuesliCKSyncRecoveryRunner.run(
+            operation: { try await self.run(intent: intent) },
+            isZoneMissing: ICloudTextSyncEngine.isSyncZoneMissing,
+            invalidatesPreparation: Self.invalidatesPreparation,
+            invalidate: { error in
+                let zoneIsMissing = ICloudTextSyncEngine.isSyncZoneMissing(error)
+                // Zone loss must also retire serialized CKSyncEngine state;
+                // account-context failures only retire cached preparation so
+                // the next attempt proves the account boundary again.
+                await self.invalidatePreparation(
+                    cancelEngine: zoneIsMissing,
+                    clearEngineState: zoneIsMissing
+                )
             }
-
-            // One bounded retry recreates a same-account zone through preflight.
-            // That path clears obsolete CKRecord metadata before requeueing text.
-            await invalidatePreparation(cancelEngine: true, clearEngineState: true)
-            return try await run(intent: intent)
-        }
+        )
     }
 
     private func run(intent: MuesliCKSyncIntent) async throws -> ICloudTextSyncResult {
@@ -499,14 +575,12 @@ actor MuesliCKSyncEngine: CKSyncEngineDelegate {
         }
     }
 
-    private static func invalidatesPreparation(_ error: Error) -> Bool {
-        guard let ckError = error as? CKError else { return false }
-        switch ckError.code {
-        case .notAuthenticated, .permissionFailure:
-            return true
-        default:
-            return false
-        }
+    static func invalidatesPreparation(_ error: Error) -> Bool {
+        ICloudTextSyncEngine.isSyncZoneMissing(error)
+            || ICloudTextSyncEngine.containsCloudKitError(
+                error,
+                codes: [.notAuthenticated, .permissionFailure]
+            )
     }
 
     private func makeEngineIfNeeded() throws -> CKSyncEngine {

--- a/Muesli/MuesliCKSyncEngine.swift
+++ b/Muesli/MuesliCKSyncEngine.swift
@@ -348,9 +348,15 @@ actor MuesliCKSyncEngine: CKSyncEngineDelegate {
                 conflictBaseRecords.removeAll()
                 switch change.changeType {
                 case .signIn, .switchAccounts:
-                    try await handleAccountChange(requiresMetadataReset: true)
+                    try handleAccountChange(
+                        requiresMetadataReset: true,
+                        state: syncEngine.state
+                    )
                 case .signOut:
-                    try await handleAccountChange(requiresMetadataReset: false)
+                    try handleAccountChange(
+                        requiresMetadataReset: false,
+                        state: syncEngine.state
+                    )
                 @unknown default:
                     break
                 }
@@ -453,14 +459,19 @@ actor MuesliCKSyncEngine: CKSyncEngineDelegate {
         }
     }
 
-    func handleAccountChange(requiresMetadataReset: Bool) async throws {
-        let engineToCancel = engine
-        engine = nil
-        await engineToCancel?.cancelOperations()
+    func handleAccountChange(
+        requiresMetadataReset: Bool,
+        state: any MuesliCKSyncPendingState
+    ) throws {
+        // This runs inside CKSyncEngine's own delegate callback. Cancelling the
+        // same engine here is re-entrant and CloudKit deliberately traps. Keep
+        // the live engine and its account-change state; discard only the stale
+        // serialization that belongs to the previous account.
         try store.clearCloudSyncStateData(forKey: Self.stateKey)
         conflictBaseRecords.removeAll()
-        if requiresMetadataReset {
-            try store.resetTextRecordCloudMetadataForAccountChange()
-        }
+        guard requiresMetadataReset else { return }
+
+        try store.resetTextRecordCloudMetadataForAccountChange()
+        _ = try registerNextDirtyBatch(state: state)
     }
 }

--- a/Muesli/MuesliCKSyncEngine.swift
+++ b/Muesli/MuesliCKSyncEngine.swift
@@ -1,0 +1,416 @@
+import CloudKit
+import Foundation
+
+protocol MuesliCKSyncPendingState: AnyObject, Sendable {
+    var pendingRecordZoneChanges: [CKSyncEngine.PendingRecordZoneChange] { get }
+    func add(pendingRecordZoneChanges: [CKSyncEngine.PendingRecordZoneChange])
+    func remove(pendingRecordZoneChanges: [CKSyncEngine.PendingRecordZoneChange])
+}
+
+extension CKSyncEngine.State: MuesliCKSyncPendingState {}
+
+enum MuesliCKSyncCycle {
+    static func run(
+        maximumUploadBatches: Int,
+        isolation: isolated (any Actor)? = #isolation,
+        fetch: () async throws -> Void,
+        registerNextBatch: () async throws -> Int,
+        uploadedCount: () async -> Int,
+        send: () async throws -> Void
+    ) async throws {
+        try await fetch()
+
+        for _ in 0..<max(maximumUploadBatches, 0) {
+            let registered = try await registerNextBatch()
+            guard registered > 0 else { break }
+            let uploadedBeforeSend = await uploadedCount()
+            try await send()
+            guard await uploadedCount() > uploadedBeforeSend else { break }
+        }
+    }
+}
+
+struct MuesliCKSyncFailedRecordSave: Sendable {
+    let record: CKRecord
+    let error: CKError
+}
+
+struct MuesliCKSyncRecordBatch: Sendable {
+    let recordsToSave: [CKRecord]
+    let staleChanges: [CKSyncEngine.PendingRecordZoneChange]
+}
+
+/// Owns the one CKSyncEngine instance for the private text-record zone.
+///
+/// SQLite's `sync_dirty` flags remain the durable outbox. Before every send,
+/// dirty rows are rediscovered and registered by stable CloudKit record ID, so
+/// a crash between a local edit and CKSyncEngine state serialization loses no work.
+actor MuesliCKSyncEngine: CKSyncEngineDelegate {
+    static var stateKey: String {
+        "cksyncengine.private.MuesliSyncZone.\(ICloudTextSyncEngine.cloudSyncStateKeyComponent).v1"
+    }
+
+    private static let subscriptionID = "muesli-ios-cksyncengine-private-v1"
+    private static let uploadBatchSize = 200
+    private static let maximumUploadBatchesPerSync = 50
+
+    private let store: SharedStore
+    private let onRemoteChanges: @Sendable () async -> Void
+    private var container: CKContainer?
+    private var preflight: ICloudTextSyncEngine?
+    private var engine: CKSyncEngine?
+    private var conflictBaseRecords: [CKRecord.ID: CKRecord] = [:]
+    private var uploaded = 0
+    private var downloaded = 0
+
+    init(
+        store: SharedStore = SharedStore(),
+        container: CKContainer? = nil,
+        onRemoteChanges: @escaping @Sendable () async -> Void = {}
+    ) {
+        self.store = store
+        self.container = container
+        self.onRemoteChanges = onRemoteChanges
+    }
+
+    func sync(forceBridgeDeviceRefresh: Bool = false) async throws -> ICloudTextSyncResult {
+        uploaded = 0
+        downloaded = 0
+
+        let (_, syncEngine) = try await prepareEngine(
+            forceBridgeDeviceRefresh: forceBridgeDeviceRefresh
+        )
+        try await MuesliCKSyncCycle.run(
+            maximumUploadBatches: Self.maximumUploadBatchesPerSync,
+            fetch: {
+                let options = CKSyncEngine.FetchChangesOptions(
+                    scope: .zoneIDs([ICloudTextSyncEngine.Schema.syncZoneID])
+                )
+                try await syncEngine.fetchChanges(options)
+            },
+            registerNextBatch: {
+                try self.registerNextDirtyBatch(state: syncEngine.state)
+            },
+            uploadedCount: { self.uploaded },
+            send: {
+                let options = CKSyncEngine.SendChangesOptions(
+                    scope: .zoneIDs([ICloudTextSyncEngine.Schema.syncZoneID])
+                )
+                try await syncEngine.sendChanges(options)
+            }
+        )
+
+        return ICloudTextSyncResult(uploaded: uploaded, downloaded: downloaded)
+    }
+
+    @discardableResult
+    func prepare(forceBridgeDeviceRefresh: Bool = false) async throws -> Bool {
+        let (syncZoneWasRecreated, _) = try await prepareEngine(
+            forceBridgeDeviceRefresh: forceBridgeDeviceRefresh
+        )
+        return syncZoneWasRecreated
+    }
+
+    func cancel() async {
+        let engineToCancel = engine
+        engine = nil
+        await engineToCancel?.cancelOperations()
+    }
+
+    private func prepareEngine(
+        forceBridgeDeviceRefresh: Bool
+    ) async throws -> (syncZoneWasRecreated: Bool, engine: CKSyncEngine) {
+        let preflight: ICloudTextSyncEngine
+        if let existing = self.preflight {
+            preflight = existing
+        } else {
+            let created = ICloudTextSyncEngine(container: resolvedContainer())
+            self.preflight = created
+            preflight = created
+        }
+
+        let syncZoneWasRecreated = try await preflight.prepareForCKSyncEngine(
+            store: store,
+            forceBridgeDeviceRefresh: forceBridgeDeviceRefresh
+        )
+        if syncZoneWasRecreated {
+            let engineToCancel = engine
+            engine = nil
+            await engineToCancel?.cancelOperations()
+            try store.clearCloudSyncStateData(forKey: Self.stateKey)
+        }
+        return (syncZoneWasRecreated, try makeEngineIfNeeded())
+    }
+
+    private func makeEngineIfNeeded() throws -> CKSyncEngine {
+        if let engine { return engine }
+
+        let serialization: CKSyncEngine.State.Serialization?
+        if let data = try store.cloudSyncStateData(forKey: Self.stateKey) {
+            do {
+                serialization = try PropertyListDecoder().decode(
+                    CKSyncEngine.State.Serialization.self,
+                    from: data
+                )
+            } catch {
+                // A corrupt cursor is recoverable. Starting with nil performs a
+                // full private-database replay while every local row stays intact.
+                try store.clearCloudSyncStateData(forKey: Self.stateKey)
+                serialization = nil
+            }
+        } else {
+            serialization = nil
+        }
+
+        var configuration = CKSyncEngine.Configuration(
+            database: resolvedContainer().privateCloudDatabase,
+            stateSerialization: serialization,
+            delegate: self
+        )
+        configuration.automaticallySync = true
+        configuration.subscriptionID = Self.subscriptionID
+        let created = CKSyncEngine(configuration)
+        engine = created
+        return created
+    }
+
+    private func resolvedContainer() -> CKContainer {
+        if let container { return container }
+        let created = CKContainer(identifier: ICloudTextSyncEngine.Schema.containerIdentifier)
+        container = created
+        return created
+    }
+
+    func registerNextDirtyBatch(state: any MuesliCKSyncPendingState) throws -> Int {
+        let dirtyRecords = try store.textRecordsNeedingSync(limit: Self.uploadBatchSize)
+        guard !dirtyRecords.isEmpty else { return 0 }
+
+        let alreadyPending = Set(state.pendingRecordZoneChanges.compactMap { change -> CKRecord.ID? in
+            guard case .saveRecord(let recordID) = change else { return nil }
+            return recordID
+        })
+        let additions = dirtyRecords.compactMap { record -> CKSyncEngine.PendingRecordZoneChange? in
+            let recordID = CKRecord.ID(
+                recordName: record.id,
+                zoneID: ICloudTextSyncEngine.Schema.syncZoneID
+            )
+            guard !alreadyPending.contains(recordID) else { return nil }
+            return .saveRecord(recordID)
+        }
+        state.add(pendingRecordZoneChanges: additions)
+        return dirtyRecords.count
+    }
+
+    func nextRecordZoneChangeBatch(
+        _ context: CKSyncEngine.SendChangesContext,
+        syncEngine: CKSyncEngine
+    ) async -> CKSyncEngine.RecordZoneChangeBatch? {
+        let pending = syncEngine.state.pendingRecordZoneChanges.filter {
+            context.options.scope.contains($0)
+        }
+        let batch = makeRecordBatch(pendingChanges: pending)
+        if !batch.staleChanges.isEmpty {
+            syncEngine.state.remove(pendingRecordZoneChanges: batch.staleChanges)
+        }
+        guard !batch.recordsToSave.isEmpty else { return nil }
+        return CKSyncEngine.RecordZoneChangeBatch(recordsToSave: batch.recordsToSave)
+    }
+
+    func makeRecordBatch(
+        pendingChanges: [CKSyncEngine.PendingRecordZoneChange]
+    ) -> MuesliCKSyncRecordBatch {
+        makeRecordBatch(
+            pendingChanges: pendingChanges,
+            loadRecords: { try store.textRecordsForSync(recordNames: $0) }
+        )
+    }
+
+    func makeRecordBatch(
+        pendingChanges: [CKSyncEngine.PendingRecordZoneChange],
+        loadRecords: ([String]) throws -> [String: SyncTextRecord]
+    ) -> MuesliCKSyncRecordBatch {
+        let relevantChanges: [(CKSyncEngine.PendingRecordZoneChange, CKRecord.ID)] =
+            pendingChanges.compactMap { change in
+                guard case .saveRecord(let recordID) = change,
+                      recordID.zoneID == ICloudTextSyncEngine.Schema.syncZoneID else {
+                    return nil
+                }
+                return (change, recordID)
+            }
+
+        let localRecords: [String: SyncTextRecord]
+        do {
+            localRecords = try loadRecords(relevantChanges.map { $0.1.recordName })
+        } catch {
+            // Keep pending saves intact on transient SQLite failures. Diagnostics
+            // contain only the error category, never record IDs or authored text.
+            fputs(
+                "[muesli-ios] CKSyncEngine local batch read failed: \(String(describing: type(of: error)))\n",
+                stderr
+            )
+            return MuesliCKSyncRecordBatch(recordsToSave: [], staleChanges: [])
+        }
+
+        var recordsToSave: [CKRecord] = []
+        var staleChanges: [CKSyncEngine.PendingRecordZoneChange] = []
+        for (change, recordID) in relevantChanges {
+            guard let localRecord = localRecords[recordID.recordName] else {
+                staleChanges.append(change)
+                continue
+            }
+            recordsToSave.append(ICloudTextSyncEngine.syncZoneCloudRecord(
+                from: localRecord,
+                baseRecord: conflictBaseRecords[recordID]
+            ))
+        }
+        return MuesliCKSyncRecordBatch(
+            recordsToSave: recordsToSave,
+            staleChanges: staleChanges
+        )
+    }
+
+    func handleEvent(_ event: CKSyncEngine.Event, syncEngine: CKSyncEngine) async {
+        do {
+            switch event {
+            case .stateUpdate(let update):
+                let data = try PropertyListEncoder().encode(update.stateSerialization)
+                try store.saveCloudSyncStateData(data, forKey: Self.stateKey)
+
+            case .fetchedRecordZoneChanges(let changes):
+                let applied = try handleFetchedRecords(
+                    changes.modifications.map(\.record),
+                    state: syncEngine.state
+                )
+                if applied > 0 { await onRemoteChanges() }
+                // Muesli represents deletion as a saved tombstone. Hard-delete
+                // notifications are intentionally ignored by this record contract.
+
+            case .sentRecordZoneChanges(let changes):
+                try handleSentRecordChanges(
+                    savedRecords: changes.savedRecords,
+                    failedRecordSaves: changes.failedRecordSaves.map {
+                        MuesliCKSyncFailedRecordSave(record: $0.record, error: $0.error)
+                    },
+                    state: syncEngine.state
+                )
+
+            case .accountChange(let change):
+                conflictBaseRecords.removeAll()
+                switch change.changeType {
+                case .signIn, .switchAccounts:
+                    try await handleAccountChange(requiresMetadataReset: true)
+                case .signOut:
+                    try await handleAccountChange(requiresMetadataReset: false)
+                @unknown default:
+                    break
+                }
+
+            case .fetchedDatabaseChanges,
+                 .sentDatabaseChanges,
+                 .willFetchChanges,
+                 .willFetchRecordZoneChanges,
+                 .didFetchRecordZoneChanges,
+                 .didFetchChanges,
+                 .willSendChanges,
+                 .didSendChanges:
+                break
+
+            @unknown default:
+                break
+            }
+        } catch {
+            fputs(
+                "[muesli-ios] CKSyncEngine event failed: \(String(describing: type(of: error)))\n",
+                stderr
+            )
+        }
+    }
+
+    @discardableResult
+    func handleFetchedRecords(
+        _ cloudRecords: [CKRecord],
+        state: any MuesliCKSyncPendingState
+    ) throws -> Int {
+        let records = cloudRecords
+            .filter {
+                $0.recordID.zoneID == ICloudTextSyncEngine.Schema.syncZoneID
+                    && $0.recordType == ICloudTextSyncEngine.Schema.textRecordType
+            }
+            .compactMap(ICloudTextSyncEngine.syncTextRecord(from:))
+        let appliedRecordIDs = Set(try store.upsertSyncedTextRecords(records).map(\.id))
+        for record in records {
+            if !appliedRecordIDs.contains(record.id) {
+                try store.updateTextRecordCloudMetadata(
+                    kind: record.kind,
+                    recordName: record.id,
+                    changeTag: record.cloudChangeTag,
+                    systemFields: record.cloudSystemFields
+                )
+                continue
+            }
+            downloaded += 1
+            state.remove(pendingRecordZoneChanges: [
+                .saveRecord(CKRecord.ID(
+                    recordName: record.id,
+                    zoneID: ICloudTextSyncEngine.Schema.syncZoneID
+                )),
+            ])
+        }
+        return appliedRecordIDs.count
+    }
+
+    func handleSentRecordChanges(
+        savedRecords: [CKRecord],
+        failedRecordSaves: [MuesliCKSyncFailedRecordSave],
+        state: any MuesliCKSyncPendingState
+    ) throws {
+        for savedRecord in savedRecords {
+            guard let syncRecord = ICloudTextSyncEngine.syncTextRecord(from: savedRecord) else { continue }
+            if try store.markTextRecordSynced(
+                kind: syncRecord.kind,
+                recordName: syncRecord.id,
+                changeTag: savedRecord.recordChangeTag,
+                systemFields: ICloudTextSyncEngine.encodedSystemFields(for: savedRecord),
+                recordUpdatedAt: syncRecord.updatedAt
+            ) {
+                uploaded += 1
+            }
+            state.remove(pendingRecordZoneChanges: [.saveRecord(savedRecord.recordID)])
+            conflictBaseRecords[savedRecord.recordID] = nil
+        }
+
+        for failure in failedRecordSaves {
+            let recordID = failure.record.recordID
+            guard recordID.zoneID == ICloudTextSyncEngine.Schema.syncZoneID else { continue }
+            let pending = CKSyncEngine.PendingRecordZoneChange.saveRecord(recordID)
+
+            if failure.error.code == .serverRecordChanged,
+               let serverRecord = failure.error.serverRecord,
+               let remote = ICloudTextSyncEngine.syncTextRecord(from: serverRecord),
+               let local = try store.textRecordsForSync(recordNames: [recordID.recordName])[recordID.recordName] {
+                if remote.updatedAt > local.updatedAt {
+                    _ = try store.upsertSyncedTextRecord(remote)
+                    state.remove(pendingRecordZoneChanges: [pending])
+                } else {
+                    conflictBaseRecords[recordID] = serverRecord
+                    state.add(pendingRecordZoneChanges: [pending])
+                }
+            } else {
+                // CKSyncEngine owns retry timing/backoff; SQLite keeps the save
+                // discoverable even if engine state is later reconstructed.
+                state.add(pendingRecordZoneChanges: [pending])
+            }
+        }
+    }
+
+    func handleAccountChange(requiresMetadataReset: Bool) async throws {
+        let engineToCancel = engine
+        engine = nil
+        await engineToCancel?.cancelOperations()
+        try store.clearCloudSyncStateData(forKey: Self.stateKey)
+        conflictBaseRecords.removeAll()
+        if requiresMetadataReset {
+            try store.resetTextRecordCloudMetadataForAccountChange()
+        }
+    }
+}

--- a/Muesli/SettingsView.swift
+++ b/Muesli/SettingsView.swift
@@ -103,7 +103,7 @@ struct SettingsView: View {
                         AppTelemetry.signal("bridge_enable_started", parameters: ["platform": "ios", "source": "settings"])
                         coordinator.syncICloudTextIfEnabled(reason: "settings_toggle")
                     } else {
-                        coordinator.iCloudSyncStatusText = "iCloud sync is off."
+                        coordinator.disableICloudTextSync()
                     }
                     refreshAppleSyncSettings()
                 }

--- a/Muesli/VoiceNoteTimeline.swift
+++ b/Muesli/VoiceNoteTimeline.swift
@@ -116,20 +116,75 @@ enum VoiceNoteTimelineBuilder {
     }
 }
 
-/// A view-owned memoizer. Array values are copy-on-write, so retaining the last
-/// exact input is cheap and avoids rebuilding a large timeline for unrelated UI
-/// changes such as sync or clipboard status updates.
-@MainActor
-final class VoiceNoteTimelineCache {
-    private var cachedInput: VoiceNoteTimelineInput?
-    private var cachedItems: [VoiceNoteTimelineItem] = []
-    private(set) var rebuildCount = 0
+/// One immutable presentation boundary for the home timeline.
+///
+/// Timelines are derived only when persisted history actually changes. Sync
+/// progress, clipboard state, and the rotating CloudKit glyph can therefore
+/// invalidate their own small views without rebuilding or re-diffing thousands
+/// of variable-height voice-note rows.
+struct VoiceNoteHistoryPresentation: Equatable {
+    static let empty = VoiceNoteHistoryPresentation(
+        revision: 0,
+        history: [],
+        sessions: []
+    )
 
-    func items(for input: VoiceNoteTimelineInput) -> [VoiceNoteTimelineItem] {
-        guard cachedInput != input else { return cachedItems }
-        cachedInput = input
-        cachedItems = VoiceNoteTimelineBuilder.build(from: input)
-        rebuildCount += 1
-        return cachedItems
+    let revision: UInt64
+    let history: [DictationResult]
+    let sessions: [RecordingSession]
+    private let allTimeline: [VoiceNoteTimelineItem]
+    private let iPhoneTimeline: [VoiceNoteTimelineItem]
+    private let macTimeline: [VoiceNoteTimelineItem]
+
+    init(
+        revision: UInt64,
+        history: [DictationResult],
+        sessions: [RecordingSession]
+    ) {
+        self.revision = revision
+        self.history = history
+        self.sessions = sessions
+        allTimeline = VoiceNoteTimelineBuilder.build(from: .init(
+            history: history,
+            sessions: sessions,
+            sourceFilter: .all
+        ))
+        iPhoneTimeline = VoiceNoteTimelineBuilder.build(from: .init(
+            history: history,
+            sessions: sessions,
+            sourceFilter: .thisIPhone
+        ))
+        macTimeline = VoiceNoteTimelineBuilder.build(from: .init(
+            history: history,
+            sessions: sessions,
+            sourceFilter: .fromMac
+        ))
+    }
+
+    func timeline(for filter: DictationSourceFilter) -> [VoiceNoteTimelineItem] {
+        switch filter {
+        case .all:
+            allTimeline
+        case .thisIPhone:
+            iPhoneTimeline
+        case .fromMac:
+            macTimeline
+        }
+    }
+
+    func matches(history: [DictationResult], sessions: [RecordingSession]) -> Bool {
+        self.history == history && self.sessions == sessions
+    }
+
+    func updated(
+        history: [DictationResult],
+        sessions: [RecordingSession]
+    ) -> VoiceNoteHistoryPresentation {
+        guard !matches(history: history, sessions: sessions) else { return self }
+        return VoiceNoteHistoryPresentation(
+            revision: revision &+ 1,
+            history: history,
+            sessions: sessions
+        )
     }
 }

--- a/Muesli/WhisperKitTranscriptionRuntime.swift
+++ b/Muesli/WhisperKitTranscriptionRuntime.swift
@@ -20,23 +20,11 @@ actor WhisperKitTranscriptionRuntime {
 
         try Self.prepareDownloadStorage()
 
-        let modelFolder: URL
-        if Self.isModelDownloaded(variant) {
-            progress?(0.92, "Loading downloaded Whisper model...")
-            modelFolder = Self.modelDirectory(for: variant)
-        } else {
-            let estimatedBytes = Self.estimatedDownloadBytes(for: variant)
-            progress?(0.02, "Starting \(Self.formattedSize(estimatedBytes)) download...")
-            modelFolder = try await WhisperKit.download(variant: variant) { downloadProgress in
-                let fraction = min(max(downloadProgress.fractionCompleted, 0), 1)
-                let downloadedBytes = Int64(Double(estimatedBytes) * fraction)
-                progress?(
-                    max(fraction * 0.9, 0.02),
-                    "\(Self.formattedSize(downloadedBytes)) of \(Self.formattedSize(estimatedBytes))"
-                )
-            }
-            try Self.markDownloadComplete(at: modelFolder)
+        guard Self.isModelDownloaded(variant) else {
+            throw WhisperKitRuntimeError.incompleteDownload
         }
+        progress?(0.92, "Loading downloaded Whisper model...")
+        let modelFolder = Self.modelDirectory(for: variant)
 
         progress?(0.94, "Optimizing WhisperKit for this iPhone...")
         let configuration = WhisperKitConfig(
@@ -167,31 +155,6 @@ actor WhisperKitTranscriptionRuntime {
         return false
     }
 
-    private static func estimatedDownloadBytes(for variant: String) -> Int64 {
-        switch variant {
-        case "tiny.en":
-            153 * 1_000_000
-        case "small.en":
-            250 * 1_000_000
-        case "medium.en":
-            1_500 * 1_000_000
-        case "large-v3-v20240930_626MB":
-            626 * 1_000_000
-        default:
-            250 * 1_000_000
-        }
-    }
-
-    private static func formattedSize(_ bytes: Int64) -> String {
-        let megabytes = Double(bytes) / 1_000_000
-        if megabytes >= 1_000 {
-            return String(format: "%.1f GB", megabytes / 1_000)
-        }
-        if megabytes >= 100 {
-            return "\(Int(megabytes.rounded())) MB"
-        }
-        return String(format: "%.1f MB", megabytes)
-    }
 }
 
 private enum WhisperKitRuntimeError: LocalizedError {

--- a/Shared/DictationModels.swift
+++ b/Shared/DictationModels.swift
@@ -121,6 +121,7 @@ struct SyncTextRecord: Codable, Sendable, Equatable, Identifiable {
     var wordCount: Int
     var isDeleted: Bool
     var cloudChangeTag: String?
+    var cloudSystemFields: Data? = nil
 }
 
 enum SyncOrigin: Sendable, Equatable {

--- a/Shared/SharedStore.swift
+++ b/Shared/SharedStore.swift
@@ -280,6 +280,13 @@ struct SharedStore: Sendable {
         try database().textRecordsForSyncMigration(limit: limit)
     }
 
+    /// Stable record names that prove this library has completed CloudKit sync
+    /// before. The names stay in process and are used only for an account-bound
+    /// existence check; authored text is never read for that check.
+    func textRecordNamesRequiringAccountVerification() throws -> Set<String> {
+        try database().textRecordNamesRequiringAccountVerification()
+    }
+
     @discardableResult
     func upsertSyncedTextRecord(_ record: SyncTextRecord) throws -> Bool {
         try database().upsertSyncedTextRecord(record)
@@ -1290,6 +1297,41 @@ private struct SharedStoreDatabase {
             } read: { syncMeetingRecord($0, layout: Self.syncMeetingDetailedLayout) }
             records.append(contentsOf: meetingRows)
             return records
+        }
+    }
+
+    func textRecordNamesRequiringAccountVerification() throws -> Set<String> {
+        try withDatabase { db in
+            let names = try queryRows(
+                """
+                SELECT cloud_record_name
+                FROM result_history
+                WHERE cloud_record_name IS NOT NULL
+                  AND (
+                      cloud_change_tag IS NOT NULL
+                      OR cloud_system_fields IS NOT NULL
+                      OR last_synced_at IS NOT NULL
+                      OR sync_dirty = 0
+                  )
+                UNION
+                SELECT cloud_record_name
+                FROM recording_sessions
+                WHERE cloud_record_name IS NOT NULL
+                  AND kind = ?
+                  AND (
+                      cloud_change_tag IS NOT NULL
+                      OR cloud_system_fields IS NOT NULL
+                      OR last_synced_at IS NOT NULL
+                      OR sync_dirty = 0
+                  )
+                """,
+                db: db
+            ) { statement in
+                try bind(RecordingSessionKind.meeting.rawValue, to: statement, at: 1)
+            } read: { statement in
+                sqliteColumnString(statement, 0)
+            }
+            return Set(names.compactMap { $0 })
         }
     }
 

--- a/Shared/SharedStore.swift
+++ b/Shared/SharedStore.swift
@@ -257,6 +257,14 @@ struct SharedStore: Sendable {
         try database().textRecordsNeedingSync(limit: limit)
     }
 
+    func hasTextRecordsNeedingSync() throws -> Bool {
+        try database().hasTextRecordsNeedingSync()
+    }
+
+    func textRecordsForSync(recordNames: [String]) throws -> [String: SyncTextRecord] {
+        try database().textRecordsForSync(recordNames: recordNames)
+    }
+
     /// Row counts for diagnostics, without decoding any payloads.
     ///
     /// The dirty counts are raw flag counts, not the uploader's queue.
@@ -272,12 +280,63 @@ struct SharedStore: Sendable {
         try database().textRecordsForSyncMigration(limit: limit)
     }
 
-    func upsertSyncedTextRecord(_ record: SyncTextRecord) throws {
+    @discardableResult
+    func upsertSyncedTextRecord(_ record: SyncTextRecord) throws -> Bool {
         try database().upsertSyncedTextRecord(record)
     }
 
-    func markTextRecordSynced(kind: SyncTextRecordKind, recordName: String, changeTag: String?) throws {
-        try database().markTextRecordSynced(kind: kind, recordName: recordName, changeTag: changeTag)
+    @discardableResult
+    func upsertSyncedTextRecords(_ records: [SyncTextRecord]) throws -> [SyncTextRecord] {
+        try database().upsertSyncedTextRecords(records)
+    }
+
+    @discardableResult
+    func markTextRecordSynced(
+        kind: SyncTextRecordKind,
+        recordName: String,
+        changeTag: String?,
+        systemFields: Data? = nil,
+        recordUpdatedAt: Date,
+        syncedAt: Date = Date()
+    ) throws -> Bool {
+        try database().markTextRecordSynced(
+            kind: kind,
+            recordName: recordName,
+            changeTag: changeTag,
+            systemFields: systemFields,
+            recordUpdatedAt: recordUpdatedAt,
+            syncedAt: syncedAt
+        )
+    }
+
+    func updateTextRecordCloudMetadata(
+        kind: SyncTextRecordKind,
+        recordName: String,
+        changeTag: String?,
+        systemFields: Data?
+    ) throws {
+        try database().updateTextRecordCloudMetadata(
+            kind: kind,
+            recordName: recordName,
+            changeTag: changeTag,
+            systemFields: systemFields
+        )
+    }
+
+    func resetTextRecordCloudMetadataForAccountChange() throws {
+        try database().resetTextRecordCloudMetadataForAccountChange()
+    }
+
+    func cloudSyncStateData(forKey key: String) throws -> Data? {
+        try database().cloudSyncStateData(forKey: key)
+    }
+
+    func saveCloudSyncStateData(_ data: Data, forKey key: String) throws {
+        try database().saveCloudSyncStateData(data, forKey: key)
+    }
+
+    func clearCloudSyncStateData(forKey key: String) throws {
+        try database().clearCloudSyncStateData(forKey: key)
     }
 
     func newAudioFileURL(sessionID: UUID) throws -> URL {
@@ -485,7 +544,7 @@ private enum SharedStoreDatabaseError: Error, LocalizedError {
 
 private struct SharedStoreDatabase {
     private static let databaseFileName = "Muesli.sqlite"
-    private static let schemaVersion = 4
+    private static let schemaVersion = 5
 
     private static let initializationLock = NSLock()
     nonisolated(unsafe) private static var initializedDatabasePaths: Set<String> = []
@@ -889,13 +948,183 @@ private struct SharedStoreDatabase {
         }
     }
 
+    func hasTextRecordsNeedingSync() throws -> Bool {
+        try withDatabase { db in
+            let sql = """
+            SELECT 1
+            FROM result_history
+            WHERE sync_dirty = 1 AND cloud_record_name IS NOT NULL
+            UNION ALL
+            SELECT 1
+            FROM recording_sessions s
+            LEFT JOIN transcripts t ON t.session_id = s.id
+            WHERE (s.sync_dirty = 1 OR t.sync_dirty = 1)
+              AND s.cloud_record_name IS NOT NULL
+              AND s.kind = ?
+              AND (s.deleted_at IS NOT NULL OR s.phase IN ('completed', 'failed', 'cancelled'))
+            LIMIT 1
+            """
+            return try queryRows(sql, db: db) { statement in
+                try bind(RecordingSessionKind.meeting.rawValue, to: statement, at: 1)
+            } read: { _ in true }.first ?? false
+        }
+    }
+
+    func textRecordsForSync(recordNames: [String]) throws -> [String: SyncTextRecord] {
+        let recordNames = Array(Set(recordNames.filter { !$0.isEmpty }))
+        guard !recordNames.isEmpty else { return [:] }
+
+        return try withDatabase { db in
+            let placeholders = Array(repeating: "?", count: recordNames.count).joined(separator: ", ")
+            var records: [String: SyncTextRecord] = [:]
+            let bindRecordNames: (OpaquePointer) throws -> Void = { statement in
+                for (offset, recordName) in recordNames.enumerated() {
+                    try bind(recordName, to: statement, at: Int32(offset + 1))
+                }
+            }
+
+            let dictations = try queryRows(
+                """
+                SELECT cloud_record_name, text, engine_identifier, created_at, updated_at,
+                       deleted_at, cloud_change_tag, cloud_system_fields, payload
+                FROM result_history
+                WHERE cloud_record_name IN (\(placeholders))
+                """,
+                db: db,
+                bindValues: bindRecordNames,
+                read: { statement in
+                    let text = sqliteColumnString(statement, 1) ?? ""
+                    let payload = sqliteColumnData(statement, 8)
+                    let result = payload.flatMap { try? decoder.decode(DictationResult.self, from: $0) }
+                    return SyncTextRecord(
+                        id: sqliteColumnString(statement, 0) ?? UUID().uuidString,
+                        kind: .dictation,
+                        title: nil,
+                        text: text,
+                        speakerTranscript: nil,
+                        summaryText: nil,
+                        manualNotes: nil,
+                        source: Self.syncPlatformSource(result?.source),
+                        localSource: Self.syncSource(result?.source),
+                        engineIdentifier: sqliteColumnString(statement, 2),
+                        createdAt: Date(timeIntervalSince1970: sqlite3_column_double(statement, 3)),
+                        updatedAt: Date(timeIntervalSince1970: sqlite3_column_double(statement, 4)),
+                        startedAt: nil,
+                        endedAt: nil,
+                        durationSeconds: 0,
+                        wordCount: Self.wordCount(text),
+                        isDeleted: sqlite3_column_type(statement, 5) != SQLITE_NULL,
+                        cloudChangeTag: sqliteColumnString(statement, 6),
+                        cloudSystemFields: sqliteColumnData(statement, 7)
+                    )
+                }
+            )
+            for record in dictations { records[record.id] = record }
+
+            let meetings = try queryRows(
+                """
+                SELECT s.cloud_record_name, s.title, s.created_at, s.started_at, s.ended_at,
+                       s.engine_identifier, s.updated_at, s.deleted_at, s.cloud_change_tag,
+                       s.payload, t.text, t.speaker_transcript, t.summary_text, t.updated_at,
+                       t.deleted_at, s.manual_notes, s.manual_notes_updated_at, s.cloud_system_fields
+                FROM recording_sessions s
+                LEFT JOIN transcripts t ON t.session_id = s.id
+                WHERE s.cloud_record_name IN (\(placeholders))
+                  AND s.kind = '\(RecordingSessionKind.meeting.rawValue)'
+                """,
+                db: db,
+                bindValues: bindRecordNames,
+                read: { statement in
+                    let started = Self.optionalDate(statement, 3)
+                    let ended = Self.optionalDate(statement, 4)
+                    let text = sqliteColumnString(statement, 10) ?? ""
+                    let summary = sqliteColumnString(statement, 12)
+                    let manualNotesUpdatedAt = sqlite3_column_double(statement, 16)
+                    let updated = max(
+                        sqlite3_column_double(statement, 6),
+                        sqlite3_column_double(statement, 13),
+                        manualNotesUpdatedAt
+                    )
+                    let payload = sqliteColumnData(statement, 9)
+                    let session = payload.flatMap { try? decoder.decode(RecordingSession.self, from: $0) }
+                    let manualNotes = session?.manualNotes ?? sqliteColumnString(statement, 15)
+                    return SyncTextRecord(
+                        id: sqliteColumnString(statement, 0) ?? UUID().uuidString,
+                        kind: .meeting,
+                        title: sqliteColumnString(statement, 1),
+                        text: text,
+                        speakerTranscript: sqliteColumnString(statement, 11),
+                        summaryText: summary,
+                        manualNotes: manualNotes,
+                        source: Self.syncPlatformSource(session?.source),
+                        localSource: Self.syncSource(session?.source, fallback: "meeting"),
+                        engineIdentifier: sqliteColumnString(statement, 5),
+                        createdAt: Date(timeIntervalSince1970: sqlite3_column_double(statement, 2)),
+                        updatedAt: Date(timeIntervalSince1970: updated),
+                        manualNotesUpdatedAt: manualNotesUpdatedAt > 0 ? Date(timeIntervalSince1970: manualNotesUpdatedAt) : nil,
+                        startedAt: started,
+                        endedAt: ended,
+                        durationSeconds: started.map { (ended ?? Date()).timeIntervalSince($0) } ?? 0,
+                        wordCount: Self.wordCount(text + " " + (summary ?? "") + " " + (manualNotes ?? "")),
+                        isDeleted: sqlite3_column_type(statement, 7) != SQLITE_NULL
+                            || sqlite3_column_type(statement, 14) != SQLITE_NULL,
+                        cloudChangeTag: sqliteColumnString(statement, 8),
+                        cloudSystemFields: sqliteColumnData(statement, 17)
+                    )
+                }
+            )
+            for record in meetings { records[record.id] = record }
+            return records
+        }
+    }
+
+    func cloudSyncStateData(forKey key: String) throws -> Data? {
+        try withDatabase { db in
+            try queryRows(
+                "SELECT value FROM cloud_sync_state WHERE key = ? LIMIT 1",
+                db: db
+            ) { statement in
+                try bind(key, to: statement, at: 1)
+            } read: { statement in
+                sqliteColumnData(statement, 0)
+            }.first ?? nil
+        }
+    }
+
+    func saveCloudSyncStateData(_ data: Data, forKey key: String) throws {
+        try withDatabase { db in
+            try execute(
+                """
+                INSERT INTO cloud_sync_state (key, value, updated_at)
+                VALUES (?, ?, ?)
+                ON CONFLICT(key) DO UPDATE SET
+                    value = excluded.value,
+                    updated_at = excluded.updated_at
+                """,
+                db: db
+            ) { statement in
+                try bind(key, to: statement, at: 1)
+                try bind(data, to: statement, at: 2)
+                try bind(Date().timeIntervalSince1970, to: statement, at: 3)
+            }
+        }
+    }
+
+    func clearCloudSyncStateData(forKey key: String) throws {
+        try withDatabase { db in
+            try execute("DELETE FROM cloud_sync_state WHERE key = ?", db: db) { statement in
+                try bind(key, to: statement, at: 1)
+            }
+        }
+    }
+
     func textRecordsNeedingSync(limit: Int = 200) throws -> [SyncTextRecord] {
         try withDatabase { db in
             var records: [SyncTextRecord] = []
             let dictationRows = try queryRows(
                 """
                 SELECT cloud_record_name, text, engine_identifier, created_at, updated_at,
-                       deleted_at, session_id, cloud_change_tag, payload
+                       deleted_at, session_id, cloud_change_tag, cloud_system_fields, payload
                 FROM result_history
                 WHERE sync_dirty = 1 AND cloud_record_name IS NOT NULL
                 ORDER BY updated_at DESC
@@ -905,7 +1134,7 @@ private struct SharedStoreDatabase {
             ) { statement in
                 try bind(limit, to: statement, at: 1)
             } read: { statement in
-                let payload = sqliteColumnData(statement, 8)
+                let payload = sqliteColumnData(statement, 9)
                 let result = payload.flatMap { try? decoder.decode(DictationResult.self, from: $0) }
                 return SyncTextRecord(
                     id: sqliteColumnString(statement, 0) ?? UUID().uuidString,
@@ -925,7 +1154,8 @@ private struct SharedStoreDatabase {
                     durationSeconds: 0,
                     wordCount: Self.wordCount(sqliteColumnString(statement, 1) ?? ""),
                     isDeleted: sqlite3_column_type(statement, 5) != SQLITE_NULL,
-                    cloudChangeTag: sqliteColumnString(statement, 7)
+                    cloudChangeTag: sqliteColumnString(statement, 7),
+                    cloudSystemFields: sqliteColumnData(statement, 8)
                 )
             }
             records.append(contentsOf: dictationRows)
@@ -940,7 +1170,7 @@ private struct SharedStoreDatabase {
                        s.updated_at, s.deleted_at, s.cloud_change_tag, s.payload,
                        t.text, t.speaker_transcript, t.summary_text, t.summary_backend,
                        t.summary_model, t.updated_at, t.deleted_at, s.manual_notes,
-                       s.manual_notes_updated_at
+                       s.manual_notes_updated_at, s.cloud_system_fields
                 FROM recording_sessions s
                 LEFT JOIN transcripts t ON t.session_id = s.id
                 WHERE (s.sync_dirty = 1 OR t.sync_dirty = 1)
@@ -983,7 +1213,8 @@ private struct SharedStoreDatabase {
                     durationSeconds: started.map { (ended ?? Date()).timeIntervalSince($0) } ?? 0,
                     wordCount: Self.wordCount(text + " " + (summary ?? "") + " " + (manualNotes ?? "")),
                     isDeleted: sqlite3_column_type(statement, 11) != SQLITE_NULL || sqlite3_column_type(statement, 20) != SQLITE_NULL,
-                    cloudChangeTag: sqliteColumnString(statement, 12)
+                    cloudChangeTag: sqliteColumnString(statement, 12),
+                    cloudSystemFields: sqliteColumnData(statement, 23)
                 )
             }
             records.append(contentsOf: meetingRows)
@@ -997,7 +1228,7 @@ private struct SharedStoreDatabase {
             let dictationRows = try queryRows(
                 """
                 SELECT cloud_record_name, text, engine_identifier, created_at, updated_at,
-                       deleted_at, session_id, cloud_change_tag, payload
+                       deleted_at, session_id, cloud_change_tag, cloud_system_fields, payload
                 FROM result_history
                 WHERE cloud_record_name IS NOT NULL
                 ORDER BY updated_at DESC
@@ -1007,7 +1238,7 @@ private struct SharedStoreDatabase {
             ) { statement in
                 try bind(limit, to: statement, at: 1)
             } read: { statement in
-                let payload = sqliteColumnData(statement, 8)
+                let payload = sqliteColumnData(statement, 9)
                 let result = payload.flatMap { try? decoder.decode(DictationResult.self, from: $0) }
                 return SyncTextRecord(
                     id: sqliteColumnString(statement, 0) ?? UUID().uuidString,
@@ -1027,7 +1258,8 @@ private struct SharedStoreDatabase {
                     durationSeconds: 0,
                     wordCount: Self.wordCount(sqliteColumnString(statement, 1) ?? ""),
                     isDeleted: sqlite3_column_type(statement, 5) != SQLITE_NULL,
-                    cloudChangeTag: sqliteColumnString(statement, 7)
+                    cloudChangeTag: sqliteColumnString(statement, 7),
+                    cloudSystemFields: sqliteColumnData(statement, 8)
                 )
             }
             records.append(contentsOf: dictationRows)
@@ -1042,7 +1274,7 @@ private struct SharedStoreDatabase {
                        s.updated_at, s.deleted_at, s.cloud_change_tag, s.payload,
                        t.text, t.speaker_transcript, t.summary_text, t.summary_backend,
                        t.summary_model, t.updated_at, t.deleted_at, s.manual_notes,
-                       s.manual_notes_updated_at
+                       s.manual_notes_updated_at, s.cloud_system_fields
                 FROM recording_sessions s
                 LEFT JOIN transcripts t ON t.session_id = s.id
                 WHERE s.cloud_record_name IS NOT NULL
@@ -1083,7 +1315,8 @@ private struct SharedStoreDatabase {
                     durationSeconds: started.map { (ended ?? Date()).timeIntervalSince($0) } ?? 0,
                     wordCount: Self.wordCount(text + " " + (summary ?? "") + " " + (manualNotes ?? "")),
                     isDeleted: sqlite3_column_type(statement, 11) != SQLITE_NULL || sqlite3_column_type(statement, 20) != SQLITE_NULL,
-                    cloudChangeTag: sqliteColumnString(statement, 12)
+                    cloudChangeTag: sqliteColumnString(statement, 12),
+                    cloudSystemFields: sqliteColumnData(statement, 23)
                 )
             }
             records.append(contentsOf: meetingRows)
@@ -1091,47 +1324,184 @@ private struct SharedStoreDatabase {
         }
     }
 
-    func upsertSyncedTextRecord(_ record: SyncTextRecord) throws {
-        try withDatabase { db in
-            switch record.kind {
-            case .dictation:
-                try upsertSyncedDictation(record, db: db)
-            case .meeting:
-                try upsertSyncedMeeting(record, db: db)
+    @discardableResult
+    func upsertSyncedTextRecord(_ record: SyncTextRecord) throws -> Bool {
+        try !upsertSyncedTextRecords([record]).isEmpty
+    }
+
+    @discardableResult
+    func upsertSyncedTextRecords(_ records: [SyncTextRecord]) throws -> [SyncTextRecord] {
+        guard !records.isEmpty else { return [] }
+        return try withDatabase { db in
+            var applied: [SyncTextRecord] = []
+            try transaction(db: db) {
+                for record in records {
+                    let didApply: Bool
+                    switch record.kind {
+                    case .dictation:
+                        didApply = try upsertSyncedDictation(record, db: db)
+                    case .meeting:
+                        didApply = try upsertSyncedMeeting(record, db: db)
+                    }
+                    if didApply { applied.append(record) }
+                }
             }
+            return applied
         }
     }
 
-    func markTextRecordSynced(kind: SyncTextRecordKind, recordName: String, changeTag: String?) throws {
+    @discardableResult
+    func markTextRecordSynced(
+        kind: SyncTextRecordKind,
+        recordName: String,
+        changeTag: String?,
+        systemFields: Data?,
+        recordUpdatedAt: Date,
+        syncedAt: Date
+    ) throws -> Bool {
         try withDatabase { db in
-            let now = Date().timeIntervalSince1970
+            let uploadedAt = recordUpdatedAt.timeIntervalSince1970
+            let now = syncedAt.timeIntervalSince1970
+            var didAcknowledge = false
+            try transaction(db: db) {
+                switch kind {
+                case .dictation:
+                    try execute(
+                        """
+                        UPDATE result_history
+                        SET cloud_change_tag = ?, cloud_system_fields = ?, last_synced_at = ?, sync_dirty = 0
+                        WHERE cloud_record_name = ? AND updated_at <= ?
+                        """,
+                        db: db
+                    ) { statement in
+                        try bind(changeTag, to: statement, at: 1)
+                        try bind(systemFields, to: statement, at: 2)
+                        try bind(now, to: statement, at: 3)
+                        try bind(recordName, to: statement, at: 4)
+                        try bind(uploadedAt, to: statement, at: 5)
+                    }
+                    didAcknowledge = sqlite3_changes(db) > 0
+
+                case .meeting:
+                    let sessionID = try queryRows(
+                        """
+                        SELECT s.id
+                        FROM recording_sessions s
+                        WHERE s.cloud_record_name = ?
+                          AND s.updated_at <= ?
+                          AND s.manual_notes_updated_at <= ?
+                          AND NOT EXISTS (
+                              SELECT 1 FROM transcripts t
+                              WHERE t.session_id = s.id AND t.updated_at > ?
+                          )
+                        LIMIT 1
+                        """,
+                        db: db
+                    ) { statement in
+                        try bind(recordName, to: statement, at: 1)
+                        try bind(uploadedAt, to: statement, at: 2)
+                        try bind(uploadedAt, to: statement, at: 3)
+                        try bind(uploadedAt, to: statement, at: 4)
+                    } read: { statement in
+                        sqliteColumnString(statement, 0)
+                    }.first ?? nil
+                    guard let sessionID else { return }
+
+                    try execute(
+                        """
+                        UPDATE recording_sessions
+                        SET cloud_change_tag = ?, cloud_system_fields = ?, last_synced_at = ?, sync_dirty = 0
+                        WHERE id = ?
+                        """,
+                        db: db
+                    ) { statement in
+                        try bind(changeTag, to: statement, at: 1)
+                        try bind(systemFields, to: statement, at: 2)
+                        try bind(now, to: statement, at: 3)
+                        try bind(sessionID, to: statement, at: 4)
+                    }
+                    try execute(
+                        """
+                        UPDATE transcripts
+                        SET cloud_change_tag = ?, last_synced_at = ?, sync_dirty = 0
+                        WHERE session_id = ?
+                        """,
+                        db: db
+                    ) { statement in
+                        try bind(changeTag, to: statement, at: 1)
+                        try bind(now, to: statement, at: 2)
+                        try bind(sessionID, to: statement, at: 3)
+                    }
+                    didAcknowledge = true
+                }
+            }
+            return didAcknowledge
+        }
+    }
+
+    func updateTextRecordCloudMetadata(
+        kind: SyncTextRecordKind,
+        recordName: String,
+        changeTag: String?,
+        systemFields: Data?
+    ) throws {
+        try withDatabase { db in
             let table = kind == .dictation ? "result_history" : "recording_sessions"
             try execute(
                 """
                 UPDATE \(table)
-                SET cloud_change_tag = ?, last_synced_at = ?, sync_dirty = 0
+                SET cloud_change_tag = ?, cloud_system_fields = ?
                 WHERE cloud_record_name = ?
                 """,
                 db: db
             ) { statement in
                 try bind(changeTag, to: statement, at: 1)
-                try bind(now, to: statement, at: 2)
+                try bind(systemFields, to: statement, at: 2)
                 try bind(recordName, to: statement, at: 3)
             }
-            if kind == .meeting {
-                try execute(
+        }
+    }
+
+    func resetTextRecordCloudMetadataForAccountChange() throws {
+        try withDatabase { db in
+            try transaction(db: db) {
+                try exec(
+                    """
+                    UPDATE result_history
+                    SET cloud_change_tag = NULL,
+                        cloud_system_fields = NULL,
+                        last_synced_at = NULL,
+                        sync_dirty = 1
+                    WHERE cloud_record_name IS NOT NULL
+                    """,
+                    db: db
+                )
+                try exec(
+                    """
+                    UPDATE recording_sessions
+                    SET cloud_change_tag = NULL,
+                        cloud_system_fields = NULL,
+                        last_synced_at = NULL,
+                        sync_dirty = 1
+                    WHERE cloud_record_name IS NOT NULL
+                      AND (deleted_at IS NOT NULL OR phase IN ('completed', 'failed', 'cancelled'))
+                    """,
+                    db: db
+                )
+                try exec(
                     """
                     UPDATE transcripts
-                    SET last_synced_at = ?, sync_dirty = 0
+                    SET cloud_change_tag = NULL,
+                        last_synced_at = NULL,
+                        sync_dirty = 1
                     WHERE session_id IN (
-                        SELECT id FROM recording_sessions WHERE cloud_record_name = ?
+                        SELECT id FROM recording_sessions
+                        WHERE cloud_record_name IS NOT NULL
+                          AND (deleted_at IS NOT NULL OR phase IN ('completed', 'failed', 'cancelled'))
                     )
                     """,
                     db: db
-                ) { statement in
-                    try bind(now, to: statement, at: 1)
-                    try bind(recordName, to: statement, at: 2)
-                }
+                )
             }
         }
     }
@@ -1188,6 +1558,7 @@ private struct SharedStoreDatabase {
             ("result_history", "deleted_at", "ALTER TABLE result_history ADD COLUMN deleted_at REAL"),
             ("result_history", "cloud_record_name", "ALTER TABLE result_history ADD COLUMN cloud_record_name TEXT"),
             ("result_history", "cloud_change_tag", "ALTER TABLE result_history ADD COLUMN cloud_change_tag TEXT"),
+            ("result_history", "cloud_system_fields", "ALTER TABLE result_history ADD COLUMN cloud_system_fields BLOB"),
             ("result_history", "last_synced_at", "ALTER TABLE result_history ADD COLUMN last_synced_at REAL"),
             ("result_history", "sync_dirty", "ALTER TABLE result_history ADD COLUMN sync_dirty INTEGER NOT NULL DEFAULT 1"),
 
@@ -1205,6 +1576,7 @@ private struct SharedStoreDatabase {
             ("recording_sessions", "deleted_at", "ALTER TABLE recording_sessions ADD COLUMN deleted_at REAL"),
             ("recording_sessions", "cloud_record_name", "ALTER TABLE recording_sessions ADD COLUMN cloud_record_name TEXT"),
             ("recording_sessions", "cloud_change_tag", "ALTER TABLE recording_sessions ADD COLUMN cloud_change_tag TEXT"),
+            ("recording_sessions", "cloud_system_fields", "ALTER TABLE recording_sessions ADD COLUMN cloud_system_fields BLOB"),
             ("recording_sessions", "last_synced_at", "ALTER TABLE recording_sessions ADD COLUMN last_synced_at REAL"),
             ("recording_sessions", "sync_dirty", "ALTER TABLE recording_sessions ADD COLUMN sync_dirty INTEGER NOT NULL DEFAULT 1"),
 
@@ -1783,10 +2155,17 @@ private struct SharedStoreDatabase {
         }
     }
 
-    private func upsertSyncedDictation(_ record: SyncTextRecord, db: OpaquePointer) throws {
-        if let localUpdatedAt = try localUpdatedAt(table: "result_history", recordName: record.id, db: db),
-           localUpdatedAt > record.updatedAt.timeIntervalSince1970 {
-            return
+    private func upsertSyncedDictation(_ record: SyncTextRecord, db: OpaquePointer) throws -> Bool {
+        if let local = try localSyncMetadata(
+            table: "result_history",
+            recordName: record.id,
+            db: db
+        ) {
+            let remoteUpdatedAt = record.updatedAt.timeIntervalSince1970
+            if local.updatedAt > remoteUpdatedAt
+                || (local.updatedAt == remoteUpdatedAt && local.isDirty) {
+                return false
+            }
         }
 
         let existingLink = try queryRows(
@@ -1818,9 +2197,10 @@ private struct SharedStoreDatabase {
             """
             INSERT INTO result_history (
                 id, request_id, session_id, text, engine_identifier, created_at, updated_at,
-                deleted_at, cloud_record_name, cloud_change_tag, last_synced_at, sync_dirty, payload
+                deleted_at, cloud_record_name, cloud_change_tag, cloud_system_fields,
+                last_synced_at, sync_dirty, payload
             )
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?)
             ON CONFLICT(cloud_record_name) DO UPDATE SET
                 id = excluded.id,
                 request_id = excluded.request_id,
@@ -1832,6 +2212,7 @@ private struct SharedStoreDatabase {
                 deleted_at = excluded.deleted_at,
                 cloud_record_name = excluded.cloud_record_name,
                 cloud_change_tag = excluded.cloud_change_tag,
+                cloud_system_fields = excluded.cloud_system_fields,
                 last_synced_at = excluded.last_synced_at,
                 sync_dirty = 0,
                 payload = excluded.payload
@@ -1848,14 +2229,26 @@ private struct SharedStoreDatabase {
             try bind(record.isDeleted ? record.updatedAt.timeIntervalSince1970 : nil, to: statement, at: 8)
             try bind(record.id, to: statement, at: 9)
             try bind(record.cloudChangeTag, to: statement, at: 10)
-            try bind(Date().timeIntervalSince1970, to: statement, at: 11)
-            try bind(try encoder.encode(result), to: statement, at: 12)
+            try bind(record.cloudSystemFields, to: statement, at: 11)
+            try bind(Date().timeIntervalSince1970, to: statement, at: 12)
+            try bind(try encoder.encode(result), to: statement, at: 13)
         }
+        return true
     }
 
-    private func upsertSyncedMeeting(_ record: SyncTextRecord, db: OpaquePointer) throws {
+    private func upsertSyncedMeeting(_ record: SyncTextRecord, db: OpaquePointer) throws -> Bool {
         let existingSession = try queryRows(
-            "SELECT id, manual_notes, manual_notes_updated_at, updated_at, payload FROM recording_sessions WHERE cloud_record_name = ? LIMIT 1",
+            """
+            SELECT s.id, s.manual_notes, s.manual_notes_updated_at,
+                   MAX(s.updated_at, s.manual_notes_updated_at, COALESCE(MAX(t.updated_at), 0)),
+                   s.payload,
+                   MAX(s.sync_dirty, COALESCE(MAX(t.sync_dirty), 0))
+            FROM recording_sessions s
+            LEFT JOIN transcripts t ON t.session_id = s.id
+            WHERE s.cloud_record_name = ?
+            GROUP BY s.id
+            LIMIT 1
+            """,
             db: db
         ) { statement in
             try bind(record.id, to: statement, at: 1)
@@ -1865,7 +2258,8 @@ private struct SharedStoreDatabase {
                 manualNotes: sqliteColumnString(statement, 1),
                 manualNotesUpdatedAt: sqlite3_column_double(statement, 2),
                 updatedAt: sqlite3_column_double(statement, 3),
-                payload: sqliteColumnData(statement, 4)
+                payload: sqliteColumnData(statement, 4),
+                isDirty: sqlite3_column_int(statement, 5) != 0
             )
         }.first ?? nil
         let existingManualNotesUpdatedAt = existingSession?.manualNotesUpdatedAt ?? 0
@@ -1882,8 +2276,11 @@ private struct SharedStoreDatabase {
             .map { [.recording, .transcriptionQueued, .transcribing].contains($0.phase) }
             ?? false
 
+        let remoteUpdatedAt = record.updatedAt.timeIntervalSince1970
         if let existingSession,
-           existingSessionIsLocallyActive || existingSession.updatedAt > record.updatedAt.timeIntervalSince1970 {
+           existingSessionIsLocallyActive
+            || existingSession.updatedAt > remoteUpdatedAt
+            || (existingSession.updatedAt == remoteUpdatedAt && existingSession.isDirty) {
             if shouldUseIncomingManualNotes, let existingID = existingSession.id {
                 let encodedPayload: Data?
                 if let payload = existingSession.payload,
@@ -1922,7 +2319,7 @@ private struct SharedStoreDatabase {
                     }
                 }
             }
-            return
+            return false
         }
 
         let sessionID = existingSession?.id.flatMap(UUID.init(uuidString:)) ?? UUID(uuidString: record.id) ?? UUID()
@@ -1964,10 +2361,10 @@ private struct SharedStoreDatabase {
             INSERT INTO recording_sessions (
                 id, request_id, kind, title, phase, created_at, started_at, ended_at,
                 audio_file_name, keeps_audio_recording, transcript_id, engine_identifier,
-                manual_notes, manual_notes_updated_at, error_message, updated_at, deleted_at, cloud_record_name, cloud_change_tag,
-                last_synced_at, sync_dirty, payload
+                manual_notes, manual_notes_updated_at, error_message, updated_at, deleted_at,
+                cloud_record_name, cloud_change_tag, cloud_system_fields, last_synced_at, sync_dirty, payload
             )
-            VALUES (?, NULL, ?, ?, ?, ?, ?, ?, NULL, 0, ?, ?, ?, ?, NULL, ?, ?, ?, ?, ?, 0, ?)
+            VALUES (?, NULL, ?, ?, ?, ?, ?, ?, NULL, 0, ?, ?, ?, ?, NULL, ?, ?, ?, ?, ?, ?, 0, ?)
             ON CONFLICT(id) DO UPDATE SET
                 title = excluded.title,
                 phase = excluded.phase,
@@ -1983,6 +2380,7 @@ private struct SharedStoreDatabase {
                 deleted_at = excluded.deleted_at,
                 cloud_record_name = excluded.cloud_record_name,
                 cloud_change_tag = excluded.cloud_change_tag,
+                cloud_system_fields = excluded.cloud_system_fields,
                 last_synced_at = excluded.last_synced_at,
                 sync_dirty = 0,
                 payload = excluded.payload
@@ -2004,8 +2402,9 @@ private struct SharedStoreDatabase {
             try bind(record.isDeleted ? record.updatedAt.timeIntervalSince1970 : nil, to: statement, at: 13)
             try bind(record.id, to: statement, at: 14)
             try bind(record.cloudChangeTag, to: statement, at: 15)
-            try bind(Date().timeIntervalSince1970, to: statement, at: 16)
-            try bind(try encoder.encode(sessionWithManualNotes), to: statement, at: 17)
+            try bind(record.cloudSystemFields, to: statement, at: 16)
+            try bind(Date().timeIntervalSince1970, to: statement, at: 17)
+            try bind(try encoder.encode(sessionWithManualNotes), to: statement, at: 18)
         }
 
         try execute("DELETE FROM transcripts WHERE session_id = ?", db: db) { statement in
@@ -2028,16 +2427,24 @@ private struct SharedStoreDatabase {
             try bind(Date().timeIntervalSince1970, to: statement, at: 5)
             try bind(sessionID.uuidString, to: statement, at: 6)
         }
+        return true
     }
 
-    private func localUpdatedAt(table: String, recordName: String, db: OpaquePointer) throws -> Double? {
+    private func localSyncMetadata(
+        table: String,
+        recordName: String,
+        db: OpaquePointer
+    ) throws -> (updatedAt: Double, isDirty: Bool)? {
         try queryRows(
-            "SELECT updated_at FROM \(table) WHERE cloud_record_name = ? LIMIT 1",
+            "SELECT updated_at, sync_dirty FROM \(table) WHERE cloud_record_name = ? LIMIT 1",
             db: db
         ) { statement in
             try bind(recordName, to: statement, at: 1)
         } read: { statement in
-            sqlite3_column_double(statement, 0)
+            (
+                updatedAt: sqlite3_column_double(statement, 0),
+                isDirty: sqlite3_column_int(statement, 1) != 0
+            )
         }.first ?? nil
     }
 
@@ -2242,6 +2649,16 @@ private struct SharedStoreDatabase {
         }
     }
 
+    private func bind(_ data: Data?, to statement: OpaquePointer, at index: Int32) throws {
+        guard let data else {
+            guard sqlite3_bind_null(statement, index) == SQLITE_OK else {
+                throw SharedStoreDatabaseError.bindFailed("optional blob at index \(index)")
+            }
+            return
+        }
+        try bind(data, to: statement, at: index)
+    }
+
     private func sqlite3ErrorMessage(_ db: OpaquePointer) -> String {
         sqlite3_errmsg(db).map { String(cString: $0) } ?? "unknown SQLite error"
     }
@@ -2321,6 +2738,7 @@ private struct SharedStoreDatabase {
         deleted_at REAL,
         cloud_record_name TEXT,
         cloud_change_tag TEXT,
+        cloud_system_fields BLOB,
         last_synced_at REAL,
         sync_dirty INTEGER NOT NULL DEFAULT 1,
         payload BLOB NOT NULL
@@ -2347,6 +2765,7 @@ private struct SharedStoreDatabase {
         deleted_at REAL,
         cloud_record_name TEXT,
         cloud_change_tag TEXT,
+        cloud_system_fields BLOB,
         last_synced_at REAL,
         sync_dirty INTEGER NOT NULL DEFAULT 1,
         payload BLOB NOT NULL
@@ -2378,6 +2797,12 @@ private struct SharedStoreDatabase {
     );
     CREATE INDEX IF NOT EXISTS idx_transcripts_session_id ON transcripts(session_id);
     CREATE INDEX IF NOT EXISTS idx_transcripts_created_at ON transcripts(created_at DESC);
+
+    CREATE TABLE IF NOT EXISTS cloud_sync_state (
+        key TEXT PRIMARY KEY NOT NULL,
+        value BLOB NOT NULL,
+        updated_at REAL NOT NULL
+    );
 
     CREATE TABLE IF NOT EXISTS custom_words (
         id TEXT PRIMARY KEY NOT NULL,

--- a/Shared/SharedStore.swift
+++ b/Shared/SharedStore.swift
@@ -323,8 +323,18 @@ struct SharedStore: Sendable {
         )
     }
 
-    func resetTextRecordCloudMetadataForAccountChange() throws {
-        try database().resetTextRecordCloudMetadataForAccountChange()
+    /// Claims this local dataset for a privacy-preserving CloudKit account scope.
+    ///
+    /// The first scope wins. A later account can observe only a mismatch; it
+    /// cannot replace the owner and accidentally upload this dataset.
+    func claimCloudSyncAccountScope(_ scope: String, forKey key: String) throws -> Bool {
+        try database().claimCloudSyncAccountScope(scope, forKey: key)
+    }
+
+    /// Requeues text records after their same-account custom zone is recreated.
+    /// Authored content and stable record names are preserved.
+    func resetTextRecordCloudMetadataForZoneRecreation() throws {
+        try database().resetTextRecordCloudMetadataForZoneRecreation()
     }
 
     func cloudSyncStateData(forKey key: String) throws -> Data? {
@@ -550,6 +560,57 @@ private enum SharedStoreDatabaseError: Error, LocalizedError {
 private struct SharedStoreDatabase {
     private static let databaseFileName = "Muesli.sqlite"
     private static let schemaVersion = 5
+
+    private static let syncMeetingLookupColumns = """
+    s.cloud_record_name, s.title, s.created_at, s.started_at, s.ended_at,
+    s.engine_identifier, s.updated_at, s.deleted_at, s.cloud_change_tag,
+    s.payload, t.text, t.speaker_transcript, t.summary_text, t.updated_at,
+    t.deleted_at, s.manual_notes, s.manual_notes_updated_at, s.cloud_system_fields
+    """
+    private static let syncMeetingDetailedColumns = """
+    s.cloud_record_name, s.id, s.title, s.kind, s.phase, s.created_at,
+    s.started_at, s.ended_at, s.engine_identifier, s.error_message,
+    s.updated_at, s.deleted_at, s.cloud_change_tag, s.payload,
+    t.text, t.speaker_transcript, t.summary_text, t.summary_backend,
+    t.summary_model, t.updated_at, t.deleted_at, s.manual_notes,
+    s.manual_notes_updated_at, s.cloud_system_fields
+    """
+
+    private struct SyncMeetingColumnLayout {
+        let recordName: Int32
+        let title: Int32
+        let createdAt: Int32
+        let startedAt: Int32
+        let endedAt: Int32
+        let engineIdentifier: Int32
+        let updatedAt: Int32
+        let deletedAt: Int32
+        let cloudChangeTag: Int32
+        let payload: Int32
+        let text: Int32
+        let speakerTranscript: Int32
+        let summaryText: Int32
+        let transcriptUpdatedAt: Int32
+        let transcriptDeletedAt: Int32
+        let manualNotes: Int32
+        let manualNotesUpdatedAt: Int32
+        let cloudSystemFields: Int32
+    }
+
+    private static let syncMeetingLookupLayout = SyncMeetingColumnLayout(
+        recordName: 0, title: 1, createdAt: 2, startedAt: 3, endedAt: 4,
+        engineIdentifier: 5, updatedAt: 6, deletedAt: 7, cloudChangeTag: 8,
+        payload: 9, text: 10, speakerTranscript: 11, summaryText: 12,
+        transcriptUpdatedAt: 13, transcriptDeletedAt: 14, manualNotes: 15,
+        manualNotesUpdatedAt: 16, cloudSystemFields: 17
+    )
+    private static let syncMeetingDetailedLayout = SyncMeetingColumnLayout(
+        recordName: 0, title: 2, createdAt: 5, startedAt: 6, endedAt: 7,
+        engineIdentifier: 8, updatedAt: 10, deletedAt: 11, cloudChangeTag: 12,
+        payload: 13, text: 14, speakerTranscript: 15, summaryText: 16,
+        transcriptUpdatedAt: 19, transcriptDeletedAt: 20, manualNotes: 21,
+        manualNotesUpdatedAt: 22, cloudSystemFields: 23
+    )
 
     private static let initializationLock = NSLock()
     nonisolated(unsafe) private static var initializedDatabasePaths: Set<String> = []
@@ -1005,10 +1066,7 @@ private struct SharedStoreDatabase {
 
             let meetings = try queryRows(
                 """
-                SELECT s.cloud_record_name, s.title, s.created_at, s.started_at, s.ended_at,
-                       s.engine_identifier, s.updated_at, s.deleted_at, s.cloud_change_tag,
-                       s.payload, t.text, t.speaker_transcript, t.summary_text, t.updated_at,
-                       t.deleted_at, s.manual_notes, s.manual_notes_updated_at, s.cloud_system_fields
+                SELECT \(Self.syncMeetingLookupColumns)
                 FROM recording_sessions s
                 LEFT JOIN transcripts t ON t.session_id = s.id
                 WHERE s.cloud_record_name IN (\(placeholders))
@@ -1016,44 +1074,7 @@ private struct SharedStoreDatabase {
                 """,
                 db: db,
                 bindValues: bindRecordNames,
-                read: { statement in
-                    let started = Self.optionalDate(statement, 3)
-                    let ended = Self.optionalDate(statement, 4)
-                    let text = sqliteColumnString(statement, 10) ?? ""
-                    let summary = sqliteColumnString(statement, 12)
-                    let manualNotesUpdatedAt = sqlite3_column_double(statement, 16)
-                    let updated = max(
-                        sqlite3_column_double(statement, 6),
-                        sqlite3_column_double(statement, 13),
-                        manualNotesUpdatedAt
-                    )
-                    let payload = sqliteColumnData(statement, 9)
-                    let session = payload.flatMap { try? decoder.decode(RecordingSession.self, from: $0) }
-                    let manualNotes = session?.manualNotes ?? sqliteColumnString(statement, 15)
-                    return SyncTextRecord(
-                        id: sqliteColumnString(statement, 0) ?? UUID().uuidString,
-                        kind: .meeting,
-                        title: sqliteColumnString(statement, 1),
-                        text: text,
-                        speakerTranscript: sqliteColumnString(statement, 11),
-                        summaryText: summary,
-                        manualNotes: manualNotes,
-                        source: Self.syncPlatformSource(session?.source),
-                        localSource: Self.syncSource(session?.source, fallback: "meeting"),
-                        engineIdentifier: sqliteColumnString(statement, 5),
-                        createdAt: Date(timeIntervalSince1970: sqlite3_column_double(statement, 2)),
-                        updatedAt: Date(timeIntervalSince1970: updated),
-                        manualNotesUpdatedAt: manualNotesUpdatedAt > 0 ? Date(timeIntervalSince1970: manualNotesUpdatedAt) : nil,
-                        startedAt: started,
-                        endedAt: ended,
-                        durationSeconds: started.map { (ended ?? Date()).timeIntervalSince($0) } ?? 0,
-                        wordCount: Self.wordCount(text + " " + (summary ?? "") + " " + (manualNotes ?? "")),
-                        isDeleted: sqlite3_column_type(statement, 7) != SQLITE_NULL
-                            || sqlite3_column_type(statement, 14) != SQLITE_NULL,
-                        cloudChangeTag: sqliteColumnString(statement, 8),
-                        cloudSystemFields: sqliteColumnData(statement, 17)
-                    )
-                }
+                read: { syncMeetingRecord($0, layout: Self.syncMeetingLookupLayout) }
             )
             for record in meetings { records[record.id] = record }
             return records
@@ -1070,6 +1091,39 @@ private struct SharedStoreDatabase {
             } read: { statement in
                 sqliteColumnData(statement, 0)
             }.first ?? nil
+        }
+    }
+
+    func claimCloudSyncAccountScope(_ scope: String, forKey key: String) throws -> Bool {
+        let scopeData = Data(scope.utf8)
+        return try withDatabase { db in
+            var matches = false
+            try transaction(db: db) {
+                let existing = try queryRows(
+                    "SELECT value FROM cloud_sync_state WHERE key = ? LIMIT 1",
+                    db: db
+                ) { statement in
+                    try bind(key, to: statement, at: 1)
+                } read: { statement in
+                    sqliteColumnData(statement, 0)
+                }.first ?? nil
+
+                if let existing {
+                    matches = existing == scopeData
+                    return
+                }
+
+                try execute(
+                    "INSERT INTO cloud_sync_state (key, value, updated_at) VALUES (?, ?, ?)",
+                    db: db
+                ) { statement in
+                    try bind(key, to: statement, at: 1)
+                    try bind(scopeData, to: statement, at: 2)
+                    try bind(Date().timeIntervalSince1970, to: statement, at: 3)
+                }
+                matches = true
+            }
+            return matches
         }
     }
 
@@ -1174,12 +1228,7 @@ private struct SharedStoreDatabase {
 
             let meetingRows = try queryRows(
                 """
-                SELECT s.cloud_record_name, s.id, s.title, s.kind, s.phase, s.created_at,
-                       s.started_at, s.ended_at, s.engine_identifier, s.error_message,
-                       s.updated_at, s.deleted_at, s.cloud_change_tag, s.payload,
-                       t.text, t.speaker_transcript, t.summary_text, t.summary_backend,
-                       t.summary_model, t.updated_at, t.deleted_at, s.manual_notes,
-                       s.manual_notes_updated_at, s.cloud_system_fields
+                SELECT \(Self.syncMeetingDetailedColumns)
                 FROM recording_sessions s
                 LEFT JOIN transcripts t ON t.session_id = s.id
                 WHERE (s.sync_dirty = 1 OR t.sync_dirty = 1)
@@ -1193,39 +1242,7 @@ private struct SharedStoreDatabase {
             ) { statement in
                 try bind(RecordingSessionKind.meeting.rawValue, to: statement, at: 1)
                 try bind(remaining, to: statement, at: 2)
-            } read: { statement in
-                let started = Self.optionalDate(statement, 6)
-                let ended = Self.optionalDate(statement, 7)
-                let text = sqliteColumnString(statement, 14) ?? ""
-                let summary = sqliteColumnString(statement, 16)
-                let manualNotesUpdatedAt = sqlite3_column_double(statement, 22)
-                let updated = max(sqlite3_column_double(statement, 10), sqlite3_column_double(statement, 19), manualNotesUpdatedAt)
-                let payload = sqliteColumnData(statement, 13)
-                let session = payload.flatMap { try? decoder.decode(RecordingSession.self, from: $0) }
-                let manualNotes = session?.manualNotes ?? sqliteColumnString(statement, 21)
-                return SyncTextRecord(
-                    id: sqliteColumnString(statement, 0) ?? UUID().uuidString,
-                    kind: .meeting,
-                    title: sqliteColumnString(statement, 2),
-                    text: text,
-                    speakerTranscript: sqliteColumnString(statement, 15),
-                    summaryText: summary,
-                    manualNotes: manualNotes,
-                    source: Self.syncPlatformSource(session?.source),
-                    localSource: Self.syncSource(session?.source, fallback: "meeting"),
-                    engineIdentifier: sqliteColumnString(statement, 8),
-                    createdAt: Date(timeIntervalSince1970: sqlite3_column_double(statement, 5)),
-                    updatedAt: Date(timeIntervalSince1970: updated),
-                    manualNotesUpdatedAt: manualNotesUpdatedAt > 0 ? Date(timeIntervalSince1970: manualNotesUpdatedAt) : nil,
-                    startedAt: started,
-                    endedAt: ended,
-                    durationSeconds: started.map { (ended ?? Date()).timeIntervalSince($0) } ?? 0,
-                    wordCount: Self.wordCount(text + " " + (summary ?? "") + " " + (manualNotes ?? "")),
-                    isDeleted: sqlite3_column_type(statement, 11) != SQLITE_NULL || sqlite3_column_type(statement, 20) != SQLITE_NULL,
-                    cloudChangeTag: sqliteColumnString(statement, 12),
-                    cloudSystemFields: sqliteColumnData(statement, 23)
-                )
-            }
+            } read: { syncMeetingRecord($0, layout: Self.syncMeetingDetailedLayout) }
             records.append(contentsOf: meetingRows)
             return records
         }
@@ -1258,12 +1275,7 @@ private struct SharedStoreDatabase {
 
             let meetingRows = try queryRows(
                 """
-                SELECT s.cloud_record_name, s.id, s.title, s.kind, s.phase, s.created_at,
-                       s.started_at, s.ended_at, s.engine_identifier, s.error_message,
-                       s.updated_at, s.deleted_at, s.cloud_change_tag, s.payload,
-                       t.text, t.speaker_transcript, t.summary_text, t.summary_backend,
-                       t.summary_model, t.updated_at, t.deleted_at, s.manual_notes,
-                       s.manual_notes_updated_at, s.cloud_system_fields
+                SELECT \(Self.syncMeetingDetailedColumns)
                 FROM recording_sessions s
                 LEFT JOIN transcripts t ON t.session_id = s.id
                 WHERE s.cloud_record_name IS NOT NULL
@@ -1275,39 +1287,7 @@ private struct SharedStoreDatabase {
             ) { statement in
                 try bind(RecordingSessionKind.meeting.rawValue, to: statement, at: 1)
                 try bind(remaining, to: statement, at: 2)
-            } read: { statement in
-                let started = Self.optionalDate(statement, 6)
-                let ended = Self.optionalDate(statement, 7)
-                let text = sqliteColumnString(statement, 14) ?? ""
-                let summary = sqliteColumnString(statement, 16)
-                let manualNotesUpdatedAt = sqlite3_column_double(statement, 22)
-                let updated = max(sqlite3_column_double(statement, 10), sqlite3_column_double(statement, 19), manualNotesUpdatedAt)
-                let payload = sqliteColumnData(statement, 13)
-                let session = payload.flatMap { try? decoder.decode(RecordingSession.self, from: $0) }
-                let manualNotes = session?.manualNotes ?? sqliteColumnString(statement, 21)
-                return SyncTextRecord(
-                    id: sqliteColumnString(statement, 0) ?? UUID().uuidString,
-                    kind: .meeting,
-                    title: sqliteColumnString(statement, 2),
-                    text: text,
-                    speakerTranscript: sqliteColumnString(statement, 15),
-                    summaryText: summary,
-                    manualNotes: manualNotes,
-                    source: Self.syncPlatformSource(session?.source),
-                    localSource: Self.syncSource(session?.source, fallback: "meeting"),
-                    engineIdentifier: sqliteColumnString(statement, 8),
-                    createdAt: Date(timeIntervalSince1970: sqlite3_column_double(statement, 5)),
-                    updatedAt: Date(timeIntervalSince1970: updated),
-                    manualNotesUpdatedAt: manualNotesUpdatedAt > 0 ? Date(timeIntervalSince1970: manualNotesUpdatedAt) : nil,
-                    startedAt: started,
-                    endedAt: ended,
-                    durationSeconds: started.map { (ended ?? Date()).timeIntervalSince($0) } ?? 0,
-                    wordCount: Self.wordCount(text + " " + (summary ?? "") + " " + (manualNotes ?? "")),
-                    isDeleted: sqlite3_column_type(statement, 11) != SQLITE_NULL || sqlite3_column_type(statement, 20) != SQLITE_NULL,
-                    cloudChangeTag: sqliteColumnString(statement, 12),
-                    cloudSystemFields: sqliteColumnData(statement, 23)
-                )
-            }
+            } read: { syncMeetingRecord($0, layout: Self.syncMeetingDetailedLayout) }
             records.append(contentsOf: meetingRows)
             return records
         }
@@ -1451,7 +1431,7 @@ private struct SharedStoreDatabase {
         }
     }
 
-    func resetTextRecordCloudMetadataForAccountChange() throws {
+    func resetTextRecordCloudMetadataForZoneRecreation() throws {
         try withDatabase { db in
             try transaction(db: db) {
                 try exec(
@@ -2707,6 +2687,53 @@ private struct SharedStoreDatabase {
             isDeleted: sqlite3_column_type(statement, 5) != SQLITE_NULL,
             cloudChangeTag: sqliteColumnString(statement, 6),
             cloudSystemFields: sqliteColumnData(statement, 7)
+        )
+    }
+
+    private func syncMeetingRecord(
+        _ statement: OpaquePointer,
+        layout: SyncMeetingColumnLayout
+    ) -> SyncTextRecord {
+        let startedAt = Self.optionalDate(statement, layout.startedAt)
+        let endedAt = Self.optionalDate(statement, layout.endedAt)
+        let text = sqliteColumnString(statement, layout.text) ?? ""
+        let summary = sqliteColumnString(statement, layout.summaryText)
+        let manualNotesTimestamp = sqlite3_column_double(statement, layout.manualNotesUpdatedAt)
+        let updatedTimestamp = max(
+            sqlite3_column_double(statement, layout.updatedAt),
+            sqlite3_column_double(statement, layout.transcriptUpdatedAt),
+            manualNotesTimestamp
+        )
+        let payload = sqliteColumnData(statement, layout.payload)
+        let session = payload.flatMap { try? decoder.decode(RecordingSession.self, from: $0) }
+        let manualNotes = session?.manualNotes ?? sqliteColumnString(statement, layout.manualNotes)
+
+        return SyncTextRecord(
+            id: sqliteColumnString(statement, layout.recordName) ?? UUID().uuidString,
+            kind: .meeting,
+            title: sqliteColumnString(statement, layout.title),
+            text: text,
+            speakerTranscript: sqliteColumnString(statement, layout.speakerTranscript),
+            summaryText: summary,
+            manualNotes: manualNotes,
+            source: Self.syncPlatformSource(session?.source),
+            localSource: Self.syncSource(session?.source, fallback: "meeting"),
+            engineIdentifier: sqliteColumnString(statement, layout.engineIdentifier),
+            createdAt: Date(timeIntervalSince1970: sqlite3_column_double(statement, layout.createdAt)),
+            updatedAt: Date(timeIntervalSince1970: updatedTimestamp),
+            manualNotesUpdatedAt: manualNotesTimestamp > 0
+                ? Date(timeIntervalSince1970: manualNotesTimestamp)
+                : nil,
+            startedAt: startedAt,
+            endedAt: endedAt,
+            durationSeconds: startedAt.map { (endedAt ?? Date()).timeIntervalSince($0) } ?? 0,
+            wordCount: Self.wordCount(
+                text + " " + (summary ?? "") + " " + (manualNotes ?? "")
+            ),
+            isDeleted: sqlite3_column_type(statement, layout.deletedAt) != SQLITE_NULL
+                || sqlite3_column_type(statement, layout.transcriptDeletedAt) != SQLITE_NULL,
+            cloudChangeTag: sqliteColumnString(statement, layout.cloudChangeTag),
+            cloudSystemFields: sqliteColumnData(statement, layout.cloudSystemFields)
         )
     }
 

--- a/Shared/SharedStore.swift
+++ b/Shared/SharedStore.swift
@@ -12,6 +12,12 @@ enum SharedStoreError: Error, LocalizedError {
     }
 }
 
+struct SharedStoreHistorySnapshot: Sendable, Equatable {
+    let history: [DictationResult]
+    let sessions: [RecordingSession]
+    let transcripts: [Transcript]
+}
+
 struct SharedStore: Sendable {
     private let appGroupIdentifier: String
     private let overrideContainerURL: URL?
@@ -90,6 +96,13 @@ struct SharedStore: Sendable {
 
     func resultsHistory() throws -> [DictationResult] {
         try database().resultsHistory()
+    }
+
+    /// Reads every persisted input to the voice-note presentation from one
+    /// SQLite snapshot so the UI never observes a result page paired with an
+    /// older session or transcript inventory.
+    func historySnapshot() throws -> SharedStoreHistorySnapshot {
+        try database().historySnapshot()
     }
 
     func deleteResult(_ result: DictationResult) throws {
@@ -680,11 +693,27 @@ private struct SharedStoreDatabase {
 
     func resultsHistory() throws -> [DictationResult] {
         try withDatabase { db in
-            try queryBlobs(
-                "SELECT payload FROM result_history WHERE deleted_at IS NULL ORDER BY created_at DESC",
-                db: db
-            ) { _ in }.map { try decoder.decode(DictationResult.self, from: $0) }
+            try resultsHistory(db: db)
         }
+    }
+
+    func historySnapshot() throws -> SharedStoreHistorySnapshot {
+        try withDatabase { db in
+            try readTransaction(db: db) {
+                SharedStoreHistorySnapshot(
+                    history: try resultsHistory(db: db),
+                    sessions: try recordingSessions(db: db),
+                    transcripts: try transcripts(db: db)
+                )
+            }
+        }
+    }
+
+    private func resultsHistory(db: OpaquePointer) throws -> [DictationResult] {
+        try queryBlobs(
+            "SELECT payload FROM result_history WHERE deleted_at IS NULL ORDER BY created_at DESC",
+            db: db
+        ) { _ in }.map { try decoder.decode(DictationResult.self, from: $0) }
     }
 
     func deleteResult(id: UUID, requestID: UUID) throws {
@@ -813,12 +842,16 @@ private struct SharedStoreDatabase {
 
     func recordingSessions() throws -> [RecordingSession] {
         try withDatabase { db in
-            try queryRows(
-                "SELECT payload, cloud_record_name FROM recording_sessions WHERE deleted_at IS NULL ORDER BY created_at DESC",
-                db: db
-            ) { _ in } read: { statement in
-                try decodeRecordingSession(statement)
-            }
+            try recordingSessions(db: db)
+        }
+    }
+
+    private func recordingSessions(db: OpaquePointer) throws -> [RecordingSession] {
+        try queryRows(
+            "SELECT payload, cloud_record_name FROM recording_sessions WHERE deleted_at IS NULL ORDER BY created_at DESC",
+            db: db
+        ) { _ in } read: { statement in
+            try decodeRecordingSession(statement)
         }
     }
 
@@ -899,12 +932,16 @@ private struct SharedStoreDatabase {
 
     func transcripts() throws -> [Transcript] {
         try withDatabase { db in
-            try queryBlobs(
-                "SELECT payload FROM transcripts WHERE deleted_at IS NULL ORDER BY created_at DESC",
-                db: db
-            ) { _ in }
-                .map { try decoder.decode(Transcript.self, from: $0) }
+            try transcripts(db: db)
         }
+    }
+
+    private func transcripts(db: OpaquePointer) throws -> [Transcript] {
+        try queryBlobs(
+            "SELECT payload FROM transcripts WHERE deleted_at IS NULL ORDER BY created_at DESC",
+            db: db
+        ) { _ in }
+            .map { try decoder.decode(Transcript.self, from: $0) }
     }
 
     func transcript(for sessionID: UUID) throws -> Transcript? {
@@ -2464,6 +2501,18 @@ private struct SharedStoreDatabase {
         do {
             try body()
             try exec("COMMIT", db: db)
+        } catch {
+            try? exec("ROLLBACK", db: db)
+            throw error
+        }
+    }
+
+    private func readTransaction<T>(db: OpaquePointer, _ body: () throws -> T) throws -> T {
+        try exec("BEGIN DEFERRED TRANSACTION", db: db)
+        do {
+            let value = try body()
+            try exec("COMMIT", db: db)
+            return value
         } catch {
             try? exec("ROLLBACK", db: db)
             throw error

--- a/Shared/SharedStore.swift
+++ b/Shared/SharedStore.swift
@@ -335,6 +335,11 @@ struct SharedStore: Sendable {
         try database().saveCloudSyncStateData(data, forKey: key)
     }
 
+    @discardableResult
+    func requeueDictationsWithRecoverableTimingIfNeeded(repairKey: String) throws -> Int {
+        try database().requeueDictationsWithRecoverableTimingIfNeeded(repairKey: repairKey)
+    }
+
     func clearCloudSyncStateData(forKey key: String) throws {
         try database().clearCloudSyncStateData(forKey: key)
     }
@@ -985,39 +990,16 @@ private struct SharedStoreDatabase {
 
             let dictations = try queryRows(
                 """
-                SELECT cloud_record_name, text, engine_identifier, created_at, updated_at,
-                       deleted_at, cloud_change_tag, cloud_system_fields, payload
-                FROM result_history
-                WHERE cloud_record_name IN (\(placeholders))
+                SELECT r.cloud_record_name, r.text, r.engine_identifier, r.created_at, r.updated_at,
+                       r.deleted_at, r.cloud_change_tag, r.cloud_system_fields, r.payload,
+                       s.started_at, s.ended_at
+                FROM result_history r
+                LEFT JOIN recording_sessions s ON s.id = r.session_id
+                WHERE r.cloud_record_name IN (\(placeholders))
                 """,
                 db: db,
                 bindValues: bindRecordNames,
-                read: { statement in
-                    let text = sqliteColumnString(statement, 1) ?? ""
-                    let payload = sqliteColumnData(statement, 8)
-                    let result = payload.flatMap { try? decoder.decode(DictationResult.self, from: $0) }
-                    return SyncTextRecord(
-                        id: sqliteColumnString(statement, 0) ?? UUID().uuidString,
-                        kind: .dictation,
-                        title: nil,
-                        text: text,
-                        speakerTranscript: nil,
-                        summaryText: nil,
-                        manualNotes: nil,
-                        source: Self.syncPlatformSource(result?.source),
-                        localSource: Self.syncSource(result?.source),
-                        engineIdentifier: sqliteColumnString(statement, 2),
-                        createdAt: Date(timeIntervalSince1970: sqlite3_column_double(statement, 3)),
-                        updatedAt: Date(timeIntervalSince1970: sqlite3_column_double(statement, 4)),
-                        startedAt: nil,
-                        endedAt: nil,
-                        durationSeconds: 0,
-                        wordCount: Self.wordCount(text),
-                        isDeleted: sqlite3_column_type(statement, 5) != SQLITE_NULL,
-                        cloudChangeTag: sqliteColumnString(statement, 6),
-                        cloudSystemFields: sqliteColumnData(statement, 7)
-                    )
-                }
+                read: syncDictationRecord
             )
             for record in dictations { records[record.id] = record }
 
@@ -1118,45 +1100,72 @@ private struct SharedStoreDatabase {
         }
     }
 
+    @discardableResult
+    func requeueDictationsWithRecoverableTimingIfNeeded(repairKey: String) throws -> Int {
+        try withDatabase { db in
+            var requeued = 0
+            try transaction(db: db) {
+                let alreadyRepaired = try queryRows(
+                    "SELECT 1 FROM cloud_sync_state WHERE key = ? LIMIT 1",
+                    db: db
+                ) { statement in
+                    try bind(repairKey, to: statement, at: 1)
+                } read: { _ in true }.first ?? false
+                guard !alreadyRepaired else { return }
+
+                try execute(
+                    """
+                    UPDATE result_history
+                    SET sync_dirty = 1
+                    WHERE cloud_record_name IS NOT NULL
+                      AND deleted_at IS NULL
+                      AND session_id IN (
+                          SELECT id
+                          FROM recording_sessions
+                          WHERE started_at IS NOT NULL
+                            AND ended_at IS NOT NULL
+                            AND ended_at > started_at
+                      )
+                    """,
+                    db: db
+                ) { _ in }
+                requeued = Int(sqlite3_changes(db))
+
+                try execute(
+                    """
+                    INSERT INTO cloud_sync_state (key, value, updated_at)
+                    VALUES (?, ?, ?)
+                    """,
+                    db: db
+                ) { statement in
+                    try bind(repairKey, to: statement, at: 1)
+                    try bind(Data([1]), to: statement, at: 2)
+                    try bind(Date().timeIntervalSince1970, to: statement, at: 3)
+                }
+            }
+            return requeued
+        }
+    }
+
     func textRecordsNeedingSync(limit: Int = 200) throws -> [SyncTextRecord] {
         try withDatabase { db in
             var records: [SyncTextRecord] = []
             let dictationRows = try queryRows(
                 """
-                SELECT cloud_record_name, text, engine_identifier, created_at, updated_at,
-                       deleted_at, session_id, cloud_change_tag, cloud_system_fields, payload
-                FROM result_history
-                WHERE sync_dirty = 1 AND cloud_record_name IS NOT NULL
-                ORDER BY updated_at DESC
+                SELECT r.cloud_record_name, r.text, r.engine_identifier, r.created_at, r.updated_at,
+                       r.deleted_at, r.cloud_change_tag, r.cloud_system_fields, r.payload,
+                       s.started_at, s.ended_at
+                FROM result_history r
+                LEFT JOIN recording_sessions s ON s.id = r.session_id
+                WHERE r.sync_dirty = 1 AND r.cloud_record_name IS NOT NULL
+                ORDER BY r.updated_at DESC
                 LIMIT ?
                 """,
                 db: db
             ) { statement in
                 try bind(limit, to: statement, at: 1)
             } read: { statement in
-                let payload = sqliteColumnData(statement, 9)
-                let result = payload.flatMap { try? decoder.decode(DictationResult.self, from: $0) }
-                return SyncTextRecord(
-                    id: sqliteColumnString(statement, 0) ?? UUID().uuidString,
-                    kind: .dictation,
-                    title: nil,
-                    text: sqliteColumnString(statement, 1) ?? "",
-                    speakerTranscript: nil,
-                    summaryText: nil,
-                    manualNotes: nil,
-                    source: Self.syncPlatformSource(result?.source),
-                    localSource: Self.syncSource(result?.source),
-                    engineIdentifier: sqliteColumnString(statement, 2),
-                    createdAt: Date(timeIntervalSince1970: sqlite3_column_double(statement, 3)),
-                    updatedAt: Date(timeIntervalSince1970: sqlite3_column_double(statement, 4)),
-                    startedAt: nil,
-                    endedAt: nil,
-                    durationSeconds: 0,
-                    wordCount: Self.wordCount(sqliteColumnString(statement, 1) ?? ""),
-                    isDeleted: sqlite3_column_type(statement, 5) != SQLITE_NULL,
-                    cloudChangeTag: sqliteColumnString(statement, 7),
-                    cloudSystemFields: sqliteColumnData(statement, 8)
-                )
+                syncDictationRecord(statement)
             }
             records.append(contentsOf: dictationRows)
 
@@ -1227,40 +1236,20 @@ private struct SharedStoreDatabase {
             var records: [SyncTextRecord] = []
             let dictationRows = try queryRows(
                 """
-                SELECT cloud_record_name, text, engine_identifier, created_at, updated_at,
-                       deleted_at, session_id, cloud_change_tag, cloud_system_fields, payload
-                FROM result_history
-                WHERE cloud_record_name IS NOT NULL
-                ORDER BY updated_at DESC
+                SELECT r.cloud_record_name, r.text, r.engine_identifier, r.created_at, r.updated_at,
+                       r.deleted_at, r.cloud_change_tag, r.cloud_system_fields, r.payload,
+                       s.started_at, s.ended_at
+                FROM result_history r
+                LEFT JOIN recording_sessions s ON s.id = r.session_id
+                WHERE r.cloud_record_name IS NOT NULL
+                ORDER BY r.updated_at DESC
                 LIMIT ?
                 """,
                 db: db
             ) { statement in
                 try bind(limit, to: statement, at: 1)
             } read: { statement in
-                let payload = sqliteColumnData(statement, 9)
-                let result = payload.flatMap { try? decoder.decode(DictationResult.self, from: $0) }
-                return SyncTextRecord(
-                    id: sqliteColumnString(statement, 0) ?? UUID().uuidString,
-                    kind: .dictation,
-                    title: nil,
-                    text: sqliteColumnString(statement, 1) ?? "",
-                    speakerTranscript: nil,
-                    summaryText: nil,
-                    manualNotes: nil,
-                    source: Self.syncPlatformSource(result?.source),
-                    localSource: Self.syncSource(result?.source),
-                    engineIdentifier: sqliteColumnString(statement, 2),
-                    createdAt: Date(timeIntervalSince1970: sqlite3_column_double(statement, 3)),
-                    updatedAt: Date(timeIntervalSince1970: sqlite3_column_double(statement, 4)),
-                    startedAt: nil,
-                    endedAt: nil,
-                    durationSeconds: 0,
-                    wordCount: Self.wordCount(sqliteColumnString(statement, 1) ?? ""),
-                    isDeleted: sqlite3_column_type(statement, 5) != SQLITE_NULL,
-                    cloudChangeTag: sqliteColumnString(statement, 7),
-                    cloudSystemFields: sqliteColumnData(statement, 8)
-                )
+                syncDictationRecord(statement)
             }
             records.append(contentsOf: dictationRows)
 
@@ -2684,6 +2673,41 @@ private struct SharedStoreDatabase {
         let value = sqlite3_column_double(statement, index)
         guard value > 0 else { return nil }
         return Date(timeIntervalSince1970: value)
+    }
+
+    private func syncDictationRecord(_ statement: OpaquePointer) -> SyncTextRecord {
+        let text = sqliteColumnString(statement, 1) ?? ""
+        let payload = sqliteColumnData(statement, 8)
+        let result = payload.flatMap { try? decoder.decode(DictationResult.self, from: $0) }
+        let startedAt = Self.optionalDate(statement, 9)
+        let endedAt = Self.optionalDate(statement, 10)
+        let durationSeconds: TimeInterval
+        if let startedAt, let endedAt {
+            durationSeconds = max(endedAt.timeIntervalSince(startedAt), 0)
+        } else {
+            durationSeconds = 0
+        }
+        return SyncTextRecord(
+            id: sqliteColumnString(statement, 0) ?? UUID().uuidString,
+            kind: .dictation,
+            title: nil,
+            text: text,
+            speakerTranscript: nil,
+            summaryText: nil,
+            manualNotes: nil,
+            source: Self.syncPlatformSource(result?.source),
+            localSource: Self.syncSource(result?.source),
+            engineIdentifier: sqliteColumnString(statement, 2),
+            createdAt: Date(timeIntervalSince1970: sqlite3_column_double(statement, 3)),
+            updatedAt: Date(timeIntervalSince1970: sqlite3_column_double(statement, 4)),
+            startedAt: startedAt,
+            endedAt: endedAt,
+            durationSeconds: durationSeconds,
+            wordCount: Self.wordCount(text),
+            isDeleted: sqlite3_column_type(statement, 5) != SQLITE_NULL,
+            cloudChangeTag: sqliteColumnString(statement, 6),
+            cloudSystemFields: sqliteColumnData(statement, 7)
+        )
     }
 
     private static func wordCount(_ text: String) -> Int {

--- a/Tests/MuesliTests/MuesliCKSyncEngineTests.swift
+++ b/Tests/MuesliTests/MuesliCKSyncEngineTests.swift
@@ -131,6 +131,135 @@ final class MuesliCKSyncEngineTests: XCTestCase {
         _ = try await gate.prepare { false }
     }
 
+    func testZoneMissingClassifierRecognizesDirectAndNestedCloudKitErrors() {
+        for code in [CKError.Code.unknownItem, .zoneNotFound, .userDeletedZone] {
+            let direct = CKError(code)
+            XCTAssertTrue(ICloudTextSyncEngine.isSyncZoneMissing(direct), "direct \(code)")
+            XCTAssertTrue(MuesliCKSyncEngine.invalidatesPreparation(direct), "direct \(code)")
+
+            let nested = Self.partialFailure(containing: Self.partialFailure(containing: direct))
+            XCTAssertTrue(ICloudTextSyncEngine.isSyncZoneMissing(nested), "nested \(code)")
+            XCTAssertTrue(MuesliCKSyncEngine.invalidatesPreparation(nested), "nested \(code)")
+        }
+    }
+
+    func testAccountContextClassifierRecognizesDirectAndNestedPartialFailures() {
+        for code in [CKError.Code.notAuthenticated, .permissionFailure] {
+            let direct = CKError(code)
+            XCTAssertFalse(ICloudTextSyncEngine.isSyncZoneMissing(direct), "direct \(code)")
+            XCTAssertTrue(MuesliCKSyncEngine.invalidatesPreparation(direct), "direct \(code)")
+
+            let nested = Self.partialFailure(containing: Self.partialFailure(containing: direct))
+            XCTAssertFalse(ICloudTextSyncEngine.isSyncZoneMissing(nested), "nested \(code)")
+            XCTAssertTrue(MuesliCKSyncEngine.invalidatesPreparation(nested), "nested \(code)")
+        }
+    }
+
+    func testRecoveryRetryInvalidatesAgainWhenSecondAttemptLosesAccountContext() async {
+        var attempts = 0
+        var invalidationCodes: [CKError.Code] = []
+
+        do {
+            _ = try await MuesliCKSyncRecoveryRunner.run(
+                operation: {
+                    attempts += 1
+                    if attempts == 1 { throw CKError(.zoneNotFound) }
+                    throw CKError(.notAuthenticated)
+                },
+                isZoneMissing: ICloudTextSyncEngine.isSyncZoneMissing,
+                invalidatesPreparation: MuesliCKSyncEngine.invalidatesPreparation,
+                invalidate: { error in
+                    invalidationCodes.append((error as? CKError)?.code ?? .internalError)
+                }
+            ) as ICloudTextSyncResult
+            XCTFail("The bounded retry must rethrow its second failure")
+        } catch let error as CKError {
+            XCTAssertEqual(error.code, .notAuthenticated)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+
+        XCTAssertEqual(attempts, 2)
+        XCTAssertEqual(invalidationCodes, [.zoneNotFound, .notAuthenticated])
+    }
+
+    func testRecoveryRetryInvalidatesAgainWhenSecondAttemptAlsoLosesZone() async {
+        var attempts = 0
+        var invalidations = 0
+
+        do {
+            _ = try await MuesliCKSyncRecoveryRunner.run(
+                operation: {
+                    attempts += 1
+                    throw CKError(attempts == 1 ? .userDeletedZone : .zoneNotFound)
+                },
+                isZoneMissing: ICloudTextSyncEngine.isSyncZoneMissing,
+                invalidatesPreparation: MuesliCKSyncEngine.invalidatesPreparation,
+                invalidate: { _ in invalidations += 1 }
+            ) as ICloudTextSyncResult
+            XCTFail("The bounded retry must stop after two attempts")
+        } catch let error as CKError {
+            XCTAssertEqual(error.code, .zoneNotFound)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+
+        XCTAssertEqual(attempts, 2)
+        XCTAssertEqual(invalidations, 2)
+    }
+
+    func testFailedRuntimeDrainDropsMergedIntentWithItsFailedWaiters() async throws {
+        let executor = TestRuntimeExecutor()
+        let runtime = MuesliCKSyncRuntime(execute: { intent in
+            try await executor.execute(intent)
+        })
+
+        let first = Task { try await runtime.sendLocalChanges() }
+        try await executor.waitForCallCount(1)
+        let merged = Task { try await runtime.fetchRemoteChanges() }
+        await executor.failActiveOperation()
+
+        await assertFailure(first)
+        await assertFailure(merged)
+        let pendingAfterFailure = await runtime.pendingIntentForTesting()
+        XCTAssertTrue(pendingAfterFailure.isEmpty)
+
+        let next = Task { try await runtime.sendLocalChanges() }
+        try await executor.waitForCallCount(2)
+        await executor.succeedActiveOperation()
+        _ = try await next.value
+
+        let executedIntents = await executor.executedIntents()
+        XCTAssertEqual(executedIntents, [.send, .send])
+    }
+
+    func testRuntimeCancellationReleasesBackgroundWaiterBeforeEngineCleanupFinishes() async throws {
+        let executor = TestRuntimeExecutor()
+        let runtime = MuesliCKSyncRuntime(
+            execute: { intent in try await executor.execute(intent) },
+            cancel: { await executor.waitForCancellationRelease() }
+        )
+        let request = Task { try await runtime.fetchRemoteChanges() }
+        try await executor.waitForCallCount(1)
+
+        let cancellation = Task { await runtime.cancel() }
+        do {
+            _ = try await request.value
+            XCTFail("Cancellation must release the background request")
+        } catch is CancellationError {
+            // Expected before the injected engine cleanup is released.
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+
+        let finishedBeforeRelease = await executor.cancellationCleanupFinished()
+        XCTAssertFalse(finishedBeforeRelease)
+        await executor.releaseCancellationCleanup()
+        await cancellation.value
+        let finishedAfterRelease = await executor.cancellationCleanupFinished()
+        XCTAssertTrue(finishedAfterRelease)
+    }
+
     func testBackgroundFetchReportsNewDataOnlyForAppliedRemoteRecords() async {
         let newData = await MuesliCKSyncBackgroundFetch.run {
             ICloudTextSyncResult(uploaded: 0, downloaded: 1)
@@ -558,6 +687,32 @@ final class MuesliCKSyncEngineTests: XCTestCase {
         ))
     }
 
+    private static func partialFailure(containing error: Error) -> CKError {
+        CKError(
+            .partialFailure,
+            userInfo: [
+                CKPartialErrorsByItemIDKey: [
+                    CKRecord.ID(recordName: UUID().uuidString): error,
+                ],
+            ]
+        )
+    }
+
+    private func assertFailure(
+        _ task: Task<ICloudTextSyncResult, Error>,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async {
+        do {
+            _ = try await task.value
+            XCTFail("Expected runtime request to fail", file: file, line: line)
+        } catch TestFailure.expected {
+            // Expected.
+        } catch {
+            XCTFail("Unexpected error: \(error)", file: file, line: line)
+        }
+    }
+
     private static func temporaryDirectory() throws -> URL {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent("muesli-cksyncengine-\(UUID().uuidString)", isDirectory: true)
@@ -597,6 +752,60 @@ private actor TestAsyncCounter {
 
     func increment() {
         value += 1
+    }
+}
+
+private actor TestRuntimeExecutor {
+    private var intents: [MuesliCKSyncIntent] = []
+    private var operationContinuation: CheckedContinuation<ICloudTextSyncResult, Error>?
+    private var cancellationContinuation: CheckedContinuation<Void, Never>?
+    private var cancellationFinished = false
+
+    func execute(_ intent: MuesliCKSyncIntent) async throws -> ICloudTextSyncResult {
+        intents.append(intent)
+        return try await withCheckedThrowingContinuation { continuation in
+            operationContinuation = continuation
+        }
+    }
+
+    func waitForCallCount(_ expected: Int) async throws {
+        for _ in 0..<200 {
+            if intents.count >= expected { return }
+            try await Task.sleep(for: .milliseconds(5))
+        }
+        throw TestFailure.expected
+    }
+
+    func failActiveOperation() {
+        operationContinuation?.resume(throwing: TestFailure.expected)
+        operationContinuation = nil
+    }
+
+    func succeedActiveOperation() {
+        operationContinuation?.resume(returning: ICloudTextSyncResult(uploaded: 1, downloaded: 0))
+        operationContinuation = nil
+    }
+
+    func executedIntents() -> [MuesliCKSyncIntent] {
+        intents
+    }
+
+    func waitForCancellationRelease() async {
+        await withCheckedContinuation { continuation in
+            cancellationContinuation = continuation
+        }
+        cancellationFinished = true
+    }
+
+    func releaseCancellationCleanup() {
+        operationContinuation?.resume(throwing: CancellationError())
+        operationContinuation = nil
+        cancellationContinuation?.resume()
+        cancellationContinuation = nil
+    }
+
+    func cancellationCleanupFinished() -> Bool {
+        cancellationFinished
     }
 }
 

--- a/Tests/MuesliTests/MuesliCKSyncEngineTests.swift
+++ b/Tests/MuesliTests/MuesliCKSyncEngineTests.swift
@@ -234,7 +234,18 @@ final class MuesliCKSyncEngineTests: XCTestCase {
         XCTAssertNotNil(stored.cloudSystemFields)
     }
 
-    func testAccountChangeClearsOldStateAndRequeuesSyncedLocalText() async throws {
+    func testAccountScopeHashIsStableDistinctAndDoesNotExposeRecordName() {
+        let first = CKRecord.ID(recordName: "private-user-a")
+        let second = CKRecord.ID(recordName: "private-user-b")
+
+        let firstScope = MuesliCKSyncEngine.accountScope(for: first)
+
+        XCTAssertEqual(firstScope, MuesliCKSyncEngine.accountScope(for: first))
+        XCTAssertNotEqual(firstScope, MuesliCKSyncEngine.accountScope(for: second))
+        XCTAssertFalse(firstScope.contains(first.recordName))
+    }
+
+    func testAccountSwitchClearsPendingStateWithoutRequeueingSyncedLocalText() async throws {
         let directory = try Self.temporaryDirectory()
         defer { try? FileManager.default.removeItem(at: directory) }
         let store = Muesli.SharedStore(containerURL: directory)
@@ -258,18 +269,64 @@ final class MuesliCKSyncEngineTests: XCTestCase {
         ))
         XCTAssertFalse(try store.hasTextRecordsNeedingSync())
         try store.saveCloudSyncStateData(Data([1, 2, 3]), forKey: MuesliCKSyncEngine.stateKey)
+        let owner = CKRecord.ID(recordName: "owner-account")
+        XCTAssertTrue(try store.claimCloudSyncAccountScope(
+            MuesliCKSyncEngine.accountScope(for: owner),
+            forKey: MuesliCKSyncEngine.accountScopeKey
+        ))
+
+        let pending = CKSyncEngine.PendingRecordZoneChange.saveRecord(saved.recordID)
+        let state = TestPendingState([pending])
+        let engine = MuesliCKSyncEngine(store: store)
+        let authorized = try await engine.handleAccountChange(
+            currentUser: CKRecord.ID(recordName: "different-account"),
+            state: state
+        )
+
+        XCTAssertFalse(authorized)
+        XCTAssertNil(try store.cloudSyncStateData(forKey: MuesliCKSyncEngine.stateKey))
+        XCTAssertTrue(state.pendingRecordZoneChanges.isEmpty)
+        XCTAssertFalse(try store.hasTextRecordsNeedingSync())
+        let registeredWhileBlocked = try await engine.registerNextDirtyBatch(state: state)
+        XCTAssertEqual(registeredWhileBlocked, 0)
+
+        let preserved = try XCTUnwrap(
+            try store.textRecordsForSync(recordNames: [local.id])[local.id]
+        )
+        XCTAssertEqual(preserved.text, "local text survives account change")
+        XCTAssertEqual(preserved.cloudChangeTag, "old-account-tag")
+        XCTAssertNotNil(preserved.cloudSystemFields)
+    }
+
+    func testSameAccountSignInRebuildsPendingSavesForDirtyRows() async throws {
+        let directory = try Self.temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = Muesli.SharedStore(containerURL: directory)
+        try store.saveResult(Muesli.DictationResult(
+            requestID: UUID(),
+            text: "same-account dirty row",
+            engineIdentifier: "test"
+        ))
+        let dirty = try XCTUnwrap(try store.textRecordsNeedingSync().first)
+        let owner = CKRecord.ID(recordName: "owner-account")
+        XCTAssertTrue(try store.claimCloudSyncAccountScope(
+            MuesliCKSyncEngine.accountScope(for: owner),
+            forKey: MuesliCKSyncEngine.accountScopeKey
+        ))
 
         let state = TestPendingState()
         let engine = MuesliCKSyncEngine(store: store)
-        try await engine.handleAccountChange(requiresMetadataReset: true, state: state)
+        let authorized = try await engine.handleAccountChange(
+            currentUser: owner,
+            state: state
+        )
 
-        XCTAssertNil(try store.cloudSyncStateData(forKey: MuesliCKSyncEngine.stateKey))
-        XCTAssertTrue(try store.hasTextRecordsNeedingSync())
+        XCTAssertTrue(authorized)
         let pending = try XCTUnwrap(state.pendingRecordZoneChanges.first)
         guard case .saveRecord(let pendingRecordID) = pending else {
-            return XCTFail("Expected account change to queue a record save")
+            return XCTFail("Expected the dirty row to be restored to the pending outbox")
         }
-        XCTAssertEqual(pendingRecordID.recordName, local.id)
+        XCTAssertEqual(pendingRecordID.recordName, dirty.id)
         XCTAssertEqual(pendingRecordID.zoneID, ICloudTextSyncEngine.Schema.syncZoneID)
     }
 

--- a/Tests/MuesliTests/MuesliCKSyncEngineTests.swift
+++ b/Tests/MuesliTests/MuesliCKSyncEngineTests.swift
@@ -10,14 +10,13 @@ final class MuesliCKSyncEngineTests: XCTestCase {
         XCTAssertEqual(MuesliCKSyncProgress.uploading(42).diagnosticValue, "uploading")
     }
 
-    func testCycleFetchesBeforeSendingEveryAvailableDirtyPage() async throws {
+    func testLocalCycleSendsEveryAvailableDirtyPageWithoutFetching() async throws {
         var events: [String] = []
         var registeredPages = [2, 1, 0]
         var uploaded = 0
 
-        try await MuesliCKSyncCycle.run(
+        try await MuesliCKSyncCycle.sendLocalChanges(
             maximumUploadBatches: 10,
-            fetch: { events.append("fetch") },
             registerNextBatch: {
                 events.append("register")
                 return registeredPages.removeFirst()
@@ -31,7 +30,7 @@ final class MuesliCKSyncEngineTests: XCTestCase {
 
         XCTAssertEqual(
             events,
-            ["fetch", "register", "send", "register", "send", "register"]
+            ["register", "send", "register", "send", "register"]
         )
         XCTAssertEqual(uploaded, 2)
     }
@@ -39,9 +38,8 @@ final class MuesliCKSyncEngineTests: XCTestCase {
     func testCycleStopsWhenSendMakesNoProgress() async throws {
         var registrations = 0
 
-        try await MuesliCKSyncCycle.run(
+        try await MuesliCKSyncCycle.sendLocalChanges(
             maximumUploadBatches: 10,
-            fetch: {},
             registerNextBatch: {
                 registrations += 1
                 return 1
@@ -51,6 +49,117 @@ final class MuesliCKSyncEngineTests: XCTestCase {
         )
 
         XCTAssertEqual(registrations, 1)
+    }
+
+    func testOperationPlansKeepLocalAndIncomingPathsDirectional() {
+        XCTAssertEqual(MuesliCKSyncPlan.operations(for: .send), [.send])
+        XCTAssertEqual(MuesliCKSyncPlan.operations(for: .fetch), [.fetch])
+        XCTAssertEqual(MuesliCKSyncPlan.operations(for: .manual), [.send, .fetch])
+    }
+
+    func testLaunchPolicyPreparesPersistentEngineWheneverSyncIsEnabled() {
+        XCTAssertTrue(MuesliCKSyncLaunchPolicy.shouldPrepare(syncEnabled: true))
+        XCTAssertFalse(MuesliCKSyncLaunchPolicy.shouldPrepare(syncEnabled: false))
+    }
+
+    func testConcurrentTriggerIntentUnionsInsteadOfOverwritingDirections() {
+        var intents = MuesliCKSyncIntentAccumulator()
+        intents.insert(.fetch)
+        intents.insert(.send)
+
+        XCTAssertEqual(intents.take(), .manual)
+        XCTAssertTrue(intents.pending.isEmpty)
+    }
+
+    func testPreparationGateRunsPreflightOnceUntilInvalidated() async throws {
+        let gate = MuesliCKSyncPreparationGate()
+        let counter = TestAsyncCounter()
+
+        async let first = gate.prepare {
+            await counter.increment()
+            try await Task.sleep(for: .milliseconds(20))
+            return false
+        }
+        async let second = gate.prepare {
+            await counter.increment()
+            return false
+        }
+        _ = try await (first, second)
+
+        _ = try await gate.prepare {
+            await counter.increment()
+            return false
+        }
+        let countBeforeInvalidation = await counter.value
+        XCTAssertEqual(countBeforeInvalidation, 1)
+
+        await gate.invalidate()
+        _ = try await gate.prepare {
+            await counter.increment()
+            return false
+        }
+        let countAfterInvalidation = await counter.value
+        XCTAssertEqual(countAfterInvalidation, 2)
+    }
+
+    func testPreparationInvalidationCannotPublishRetiredCompletion() async throws {
+        let gate = MuesliCKSyncPreparationGate()
+        let started = XCTestExpectation(description: "preparation started")
+
+        let preparation = Task {
+            try await gate.prepare {
+                started.fulfill()
+                do {
+                    try await Task.sleep(for: .seconds(1))
+                } catch {
+                    // Simulate an underlying CloudKit bridge that completes even
+                    // after task cancellation; the gate generation must reject it.
+                }
+                return false
+            }
+        }
+        await fulfillment(of: [started], timeout: 1)
+        await gate.invalidate()
+
+        do {
+            _ = try await preparation.value
+            XCTFail("Retired preparation must not become ready")
+        } catch is CancellationError {
+            // Expected.
+        }
+
+        _ = try await gate.prepare { false }
+    }
+
+    func testBackgroundFetchReportsNewDataOnlyForAppliedRemoteRecords() async {
+        let newData = await MuesliCKSyncBackgroundFetch.run {
+            ICloudTextSyncResult(uploaded: 0, downloaded: 1)
+        }
+        let noData = await MuesliCKSyncBackgroundFetch.run {
+            ICloudTextSyncResult(uploaded: 0, downloaded: 0)
+        }
+        let failed = await MuesliCKSyncBackgroundFetch.run {
+            throw TestFailure.expected
+        }
+
+        XCTAssertEqual(newData, .newData)
+        XCTAssertEqual(noData, .noData)
+        XCTAssertEqual(failed, .failed)
+    }
+
+    func testBackgroundNotificationRoutesOnlyCloudKitPushesWhileSyncIsEnabled() {
+        XCTAssertTrue(MuesliCKSyncBackgroundFetch.shouldFetch(
+            isCloudKitNotification: true,
+            syncEnabled: true
+        ))
+        XCTAssertFalse(MuesliCKSyncBackgroundFetch.shouldFetch(
+            isCloudKitNotification: false,
+            syncEnabled: true
+        ))
+        XCTAssertFalse(MuesliCKSyncBackgroundFetch.shouldFetch(
+            isCloudKitNotification: true,
+            syncEnabled: false
+        ))
     }
 
     func testRecordBatchLoadsCurrentRowsAndDropsOnlyMissingRows() async {
@@ -481,6 +590,14 @@ final class MuesliCKSyncEngineTests: XCTestCase {
 
 private enum TestFailure: Error {
     case expected
+}
+
+private actor TestAsyncCounter {
+    private(set) var value = 0
+
+    func increment() {
+        value += 1
+    }
 }
 
 private final class TestPendingState: MuesliCKSyncPendingState, @unchecked Sendable {

--- a/Tests/MuesliTests/MuesliCKSyncEngineTests.swift
+++ b/Tests/MuesliTests/MuesliCKSyncEngineTests.swift
@@ -3,6 +3,13 @@ import XCTest
 @testable import Muesli
 
 final class MuesliCKSyncEngineTests: XCTestCase {
+    func testProgressDiagnosticsExposeOnlyFixedPhaseNames() {
+        XCTAssertEqual(MuesliCKSyncProgress.preparing.diagnosticValue, "preparing")
+        XCTAssertEqual(MuesliCKSyncProgress.fetching.diagnosticValue, "fetching")
+        XCTAssertEqual(MuesliCKSyncProgress.downloading(42).diagnosticValue, "downloading")
+        XCTAssertEqual(MuesliCKSyncProgress.uploading(42).diagnosticValue, "uploading")
+    }
+
     func testCycleFetchesBeforeSendingEveryAvailableDirtyPage() async throws {
         var events: [String] = []
         var registeredPages = [2, 1, 0]

--- a/Tests/MuesliTests/MuesliCKSyncEngineTests.swift
+++ b/Tests/MuesliTests/MuesliCKSyncEngineTests.swift
@@ -124,6 +124,23 @@ final class MuesliCKSyncEngineTests: XCTestCase {
         XCTAssertEqual(rehydrated["text"] as? String, "second")
     }
 
+    func testDictationTimingSurvivesCloudRecordRoundTrip() throws {
+        let startedAt = Date(timeIntervalSince1970: 100)
+        let endedAt = Date(timeIntervalSince1970: 142)
+        var local = Self.record(id: "timed", text: "timed voice note")
+        local.startedAt = startedAt
+        local.endedAt = endedAt
+        local.durationSeconds = 42
+
+        let cloud = ICloudTextSyncEngine.syncZoneCloudRecord(from: local)
+        let decoded = try XCTUnwrap(ICloudTextSyncEngine.syncTextRecord(from: cloud))
+
+        XCTAssertEqual((cloud["durationSeconds"] as? NSNumber)?.doubleValue, 42)
+        XCTAssertEqual(decoded.startedAt, startedAt)
+        XCTAssertEqual(decoded.endedAt, endedAt)
+        XCTAssertEqual(decoded.durationSeconds, 42, accuracy: 0.001)
+    }
+
     func testNewerFetchedServerRecordReplacesLocalDirtyRowAndPendingSave() async throws {
         let directory = try Self.temporaryDirectory()
         defer { try? FileManager.default.removeItem(at: directory) }

--- a/Tests/MuesliTests/MuesliCKSyncEngineTests.swift
+++ b/Tests/MuesliTests/MuesliCKSyncEngineTests.swift
@@ -525,6 +525,57 @@ final class MuesliCKSyncEngineTests: XCTestCase {
         XCTAssertFalse(ICloudTextSyncEngine.isMissingProvenanceRecord(beyondBound))
     }
 
+    func testProvenanceMatchesOnlyCompleteExpectedTextRecordResponses() throws {
+        let zoneID = ICloudTextSyncEngine.Schema.syncZoneID
+        let firstID = CKRecord.ID(recordName: "first", zoneID: zoneID)
+        let secondID = CKRecord.ID(recordName: "second", zoneID: zoneID)
+        let first = CKRecord(
+            recordType: ICloudTextSyncEngine.Schema.textRecordType,
+            recordID: firstID
+        )
+        let second = CKRecord(
+            recordType: ICloudTextSyncEngine.Schema.textRecordType,
+            recordID: secondID
+        )
+
+        XCTAssertEqual(
+            try ICloudTextSyncEngine.matchingProvenanceRecordNames(
+                expectedRecordIDs: [firstID, secondID],
+                results: [firstID: .success(first), secondID: .success(second)]
+            ),
+            Set(["first", "second"])
+        )
+        XCTAssertEqual(
+            try ICloudTextSyncEngine.matchingProvenanceRecordNames(
+                expectedRecordIDs: [firstID, secondID],
+                results: [firstID: .success(first)]
+            ),
+            Set(["first"]),
+            "An incomplete CloudKit response must remain only a partial proof"
+        )
+
+        let wrongType = CKRecord(recordType: "BridgeDevice", recordID: secondID)
+        XCTAssertEqual(
+            try ICloudTextSyncEngine.matchingProvenanceRecordNames(
+                expectedRecordIDs: [firstID, secondID],
+                results: [firstID: .success(first), secondID: .success(wrongType)]
+            ),
+            Set(["first"]),
+            "A record with the right ID but wrong type is not text provenance"
+        )
+        XCTAssertEqual(
+            try ICloudTextSyncEngine.matchingProvenanceRecordNames(
+                expectedRecordIDs: [firstID, secondID],
+                results: [
+                    firstID: .success(first),
+                    secondID: .failure(CKError(.unknownItem))
+                ]
+            ),
+            Set(["first"]),
+            "A missing record is a safe mismatch, not proof for the library"
+        )
+    }
+
     func testRecordBatchLoadsCurrentRowsAndDropsOnlyMissingRows() async {
         let engine = MuesliCKSyncEngine()
         let presentID = CKRecord.ID(
@@ -864,7 +915,7 @@ final class MuesliCKSyncEngineTests: XCTestCase {
             store: store,
             legacyAccountRecordVerifier: { recordNames in
                 XCTAssertEqual(recordNames, Set([local.id]))
-                return false
+                return []
             }
         )
         let authorized = try await engine.handleAccountChange(
@@ -892,25 +943,34 @@ final class MuesliCKSyncEngineTests: XCTestCase {
         let store = Muesli.SharedStore(containerURL: directory)
         try store.saveResult(Muesli.DictationResult(
             requestID: UUID(),
-            text: "legacy synced text",
+            text: "first legacy synced text",
             engineIdentifier: "test"
         ))
-        let local = try XCTUnwrap(try store.textRecordsNeedingSync().first)
-        XCTAssertTrue(try store.markTextRecordSynced(
-            kind: local.kind,
-            recordName: local.id,
-            changeTag: "legacy-account-tag",
-            systemFields: Data([1]),
-            recordUpdatedAt: local.updatedAt
+        try store.saveResult(Muesli.DictationResult(
+            requestID: UUID(),
+            text: "second legacy synced text",
+            engineIdentifier: "test"
         ))
+        let locals = try store.textRecordsNeedingSync()
+        XCTAssertEqual(locals.count, 2)
+        for local in locals {
+            XCTAssertTrue(try store.markTextRecordSynced(
+                kind: local.kind,
+                recordName: local.id,
+                changeTag: "legacy-account-tag",
+                systemFields: Data([1]),
+                recordUpdatedAt: local.updatedAt
+            ))
+        }
+        let requiredNames = Set(locals.map(\.id))
 
         let currentUser = CKRecord.ID(recordName: "verified-account")
         let state = TestPendingState()
         let engine = MuesliCKSyncEngine(
             store: store,
             legacyAccountRecordVerifier: { recordNames in
-                XCTAssertEqual(recordNames, Set([local.id]))
-                return true
+                XCTAssertEqual(recordNames, requiredNames)
+                return recordNames
             }
         )
         let authorized = try await engine.handleAccountChange(
@@ -924,6 +984,120 @@ final class MuesliCKSyncEngineTests: XCTestCase {
             Data(MuesliCKSyncEngine.accountScope(for: currentUser).utf8)
         )
         XCTAssertTrue(state.pendingRecordZoneChanges.isEmpty)
+    }
+
+    func testUnscopedLegacyLibraryRejectsPartialRecordOverlap() async throws {
+        let directory = try Self.temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = Muesli.SharedStore(containerURL: directory)
+        try store.saveResult(Muesli.DictationResult(
+            requestID: UUID(),
+            text: "first legacy note",
+            engineIdentifier: "test"
+        ))
+        try store.saveResult(Muesli.DictationResult(
+            requestID: UUID(),
+            text: "second legacy note",
+            engineIdentifier: "test"
+        ))
+        let records = try store.textRecordsNeedingSync()
+        XCTAssertEqual(records.count, 2)
+        for record in records {
+            XCTAssertTrue(try store.markTextRecordSynced(
+                kind: record.kind,
+                recordName: record.id,
+                changeTag: "legacy-account-tag",
+                systemFields: Data([1]),
+                recordUpdatedAt: record.updatedAt
+            ))
+        }
+        let requiredNames = Set(records.map(\.id))
+        let oneMatchingName = try XCTUnwrap(requiredNames.first)
+        let state = TestPendingState()
+        let engine = MuesliCKSyncEngine(
+            store: store,
+            legacyAccountRecordVerifier: { recordNames in
+                XCTAssertEqual(recordNames, requiredNames)
+                return Set([oneMatchingName])
+            }
+        )
+
+        let authorized = try await engine.handleAccountChange(
+            currentUser: CKRecord.ID(recordName: "partially-overlapping-account"),
+            state: state
+        )
+
+        XCTAssertFalse(authorized)
+        XCTAssertNil(try store.cloudSyncStateData(forKey: MuesliCKSyncEngine.accountScopeKey))
+        XCTAssertTrue(state.pendingRecordZoneChanges.isEmpty)
+        XCTAssertFalse(try store.hasTextRecordsNeedingSync())
+    }
+
+    func testUnscopedLegacyLibraryRejectsMismatchedProofSet() async throws {
+        let directory = try Self.temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = Muesli.SharedStore(containerURL: directory)
+        try store.saveResult(Muesli.DictationResult(
+            requestID: UUID(),
+            text: "legacy note",
+            engineIdentifier: "test"
+        ))
+        let local = try XCTUnwrap(try store.textRecordsNeedingSync().first)
+        XCTAssertTrue(try store.markTextRecordSynced(
+            kind: local.kind,
+            recordName: local.id,
+            changeTag: "legacy-account-tag",
+            systemFields: Data([1]),
+            recordUpdatedAt: local.updatedAt
+        ))
+        let state = TestPendingState()
+        let engine = MuesliCKSyncEngine(
+            store: store,
+            legacyAccountRecordVerifier: { recordNames in
+                recordNames.union(["unrequested-record"])
+            }
+        )
+
+        let authorized = try await engine.handleAccountChange(
+            currentUser: CKRecord.ID(recordName: "mismatched-account"),
+            state: state
+        )
+
+        XCTAssertFalse(authorized)
+        XCTAssertNil(try store.cloudSyncStateData(forKey: MuesliCKSyncEngine.accountScopeKey))
+        XCTAssertTrue(state.pendingRecordZoneChanges.isEmpty)
+    }
+
+    func testFreshLocalOnlyLibraryClaimsAccountWithoutLegacyProof() async throws {
+        let directory = try Self.temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = Muesli.SharedStore(containerURL: directory)
+        try store.saveResult(Muesli.DictationResult(
+            requestID: UUID(),
+            text: "fresh local note",
+            engineIdentifier: "test"
+        ))
+        let currentUser = CKRecord.ID(recordName: "fresh-local-account")
+        let state = TestPendingState()
+        let engine = MuesliCKSyncEngine(
+            store: store,
+            legacyAccountRecordVerifier: { _ in
+                XCTFail("Fresh local-only rows must not require legacy provenance")
+                return []
+            }
+        )
+
+        let authorized = try await engine.handleAccountChange(
+            currentUser: currentUser,
+            state: state
+        )
+
+        XCTAssertTrue(authorized)
+        XCTAssertEqual(
+            try store.cloudSyncStateData(forKey: MuesliCKSyncEngine.accountScopeKey),
+            Data(MuesliCKSyncEngine.accountScope(for: currentUser).utf8)
+        )
+        XCTAssertEqual(state.pendingRecordZoneChanges.count, 1)
     }
 
     private static func cloudRecord(

--- a/Tests/MuesliTests/MuesliCKSyncEngineTests.swift
+++ b/Tests/MuesliTests/MuesliCKSyncEngineTests.swift
@@ -330,6 +330,98 @@ final class MuesliCKSyncEngineTests: XCTestCase {
         XCTAssertEqual(pendingRecordID.zoneID, ICloudTextSyncEngine.Schema.syncZoneID)
     }
 
+    func testUnscopedLegacyLibraryDoesNotClaimUnverifiedAccount() async throws {
+        let directory = try Self.temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = Muesli.SharedStore(containerURL: directory)
+        try store.saveResult(Muesli.DictationResult(
+            requestID: UUID(),
+            text: "legacy authored text stays local",
+            engineIdentifier: "test"
+        ))
+        let local = try XCTUnwrap(try store.textRecordsNeedingSync().first)
+        let saved = Self.cloudRecord(
+            basedOn: local,
+            text: local.text,
+            updatedAt: local.updatedAt
+        )
+        XCTAssertTrue(try store.markTextRecordSynced(
+            kind: local.kind,
+            recordName: local.id,
+            changeTag: "legacy-account-tag",
+            systemFields: ICloudTextSyncEngine.encodedSystemFields(for: saved),
+            recordUpdatedAt: local.updatedAt
+        ))
+        try store.saveCloudSyncStateData(Data([7, 8, 9]), forKey: MuesliCKSyncEngine.stateKey)
+
+        let pending = CKSyncEngine.PendingRecordZoneChange.saveRecord(saved.recordID)
+        let state = TestPendingState([pending])
+        let engine = MuesliCKSyncEngine(
+            store: store,
+            legacyAccountRecordVerifier: { recordNames in
+                XCTAssertEqual(recordNames, Set([local.id]))
+                return false
+            }
+        )
+        let authorized = try await engine.handleAccountChange(
+            currentUser: CKRecord.ID(recordName: "unverified-account"),
+            state: state
+        )
+
+        XCTAssertFalse(authorized)
+        XCTAssertNil(try store.cloudSyncStateData(forKey: MuesliCKSyncEngine.accountScopeKey))
+        XCTAssertNil(try store.cloudSyncStateData(forKey: MuesliCKSyncEngine.stateKey))
+        XCTAssertTrue(state.pendingRecordZoneChanges.isEmpty)
+        XCTAssertFalse(try store.hasTextRecordsNeedingSync())
+
+        let preserved = try XCTUnwrap(
+            try store.textRecordsForSync(recordNames: [local.id])[local.id]
+        )
+        XCTAssertEqual(preserved.text, "legacy authored text stays local")
+        XCTAssertEqual(preserved.cloudChangeTag, "legacy-account-tag")
+        XCTAssertNotNil(preserved.cloudSystemFields)
+    }
+
+    func testUnscopedLegacyLibraryClaimsVerifiedAccount() async throws {
+        let directory = try Self.temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = Muesli.SharedStore(containerURL: directory)
+        try store.saveResult(Muesli.DictationResult(
+            requestID: UUID(),
+            text: "legacy synced text",
+            engineIdentifier: "test"
+        ))
+        let local = try XCTUnwrap(try store.textRecordsNeedingSync().first)
+        XCTAssertTrue(try store.markTextRecordSynced(
+            kind: local.kind,
+            recordName: local.id,
+            changeTag: "legacy-account-tag",
+            systemFields: Data([1]),
+            recordUpdatedAt: local.updatedAt
+        ))
+
+        let currentUser = CKRecord.ID(recordName: "verified-account")
+        let state = TestPendingState()
+        let engine = MuesliCKSyncEngine(
+            store: store,
+            legacyAccountRecordVerifier: { recordNames in
+                XCTAssertEqual(recordNames, Set([local.id]))
+                return true
+            }
+        )
+        let authorized = try await engine.handleAccountChange(
+            currentUser: currentUser,
+            state: state
+        )
+
+        XCTAssertTrue(authorized)
+        XCTAssertEqual(
+            try store.cloudSyncStateData(forKey: MuesliCKSyncEngine.accountScopeKey),
+            Data(MuesliCKSyncEngine.accountScope(for: currentUser).utf8)
+        )
+        XCTAssertTrue(state.pendingRecordZoneChanges.isEmpty)
+    }
+
     private static func cloudRecord(
         basedOn record: Muesli.SyncTextRecord,
         text: String,

--- a/Tests/MuesliTests/MuesliCKSyncEngineTests.swift
+++ b/Tests/MuesliTests/MuesliCKSyncEngineTests.swift
@@ -57,9 +57,29 @@ final class MuesliCKSyncEngineTests: XCTestCase {
         XCTAssertEqual(MuesliCKSyncPlan.operations(for: .manual), [.send, .fetch])
     }
 
-    func testLaunchPolicyPreparesPersistentEngineWheneverSyncIsEnabled() {
-        XCTAssertTrue(MuesliCKSyncLaunchPolicy.shouldPrepare(syncEnabled: true))
-        XCTAssertFalse(MuesliCKSyncLaunchPolicy.shouldPrepare(syncEnabled: false))
+    func testLaunchPolicyReplaysOutgoingBeforeFetchingWheneverSyncIsEnabled() {
+        XCTAssertEqual(MuesliCKSyncLaunchPolicy.initialIntent(syncEnabled: true), .manual)
+        XCTAssertNil(MuesliCKSyncLaunchPolicy.initialIntent(syncEnabled: false))
+    }
+
+    func testAutomaticZoneLossEventsOnlyClassifyTheMuesliSyncZone() {
+        let target = ICloudTextSyncEngine.Schema.syncZoneID
+        let unrelated = CKRecordZone.ID(zoneName: "unrelated")
+
+        XCTAssertTrue(MuesliCKSyncAutomaticEventPolicy.lostSyncZone(in: [target]))
+        XCTAssertFalse(MuesliCKSyncAutomaticEventPolicy.lostSyncZone(in: [unrelated]))
+        XCTAssertTrue(MuesliCKSyncAutomaticEventPolicy.lostSyncZone(
+            zoneID: target,
+            error: CKError(.userDeletedZone)
+        ))
+        XCTAssertFalse(MuesliCKSyncAutomaticEventPolicy.lostSyncZone(
+            zoneID: target,
+            error: CKError(.networkUnavailable)
+        ))
+        XCTAssertFalse(MuesliCKSyncAutomaticEventPolicy.lostSyncZone(
+            zoneID: unrelated,
+            error: CKError(.zoneNotFound)
+        ))
     }
 
     func testConcurrentTriggerIntentUnionsInsteadOfOverwritingDirections() {
@@ -208,7 +228,45 @@ final class MuesliCKSyncEngineTests: XCTestCase {
         XCTAssertEqual(invalidations, 2)
     }
 
-    func testFailedRuntimeDrainDropsMergedIntentWithItsFailedWaiters() async throws {
+    func testFetchZoneRecoveryFlushesEveryRebuiltOutboxPageBeforeFetching() async throws {
+        var events: [String] = []
+        var pages = [2, 1, 0]
+        var uploaded = 0
+
+        let result: ICloudTextSyncResult = try await MuesliCKSyncRecoveryRunner.run(
+            operation: {
+                events.append("fetch-failed")
+                throw CKError(.zoneNotFound)
+            },
+            recoveryOperation: {
+                try await MuesliCKSyncCycle.sendLocalChanges(
+                    maximumUploadBatches: 10,
+                    registerNextBatch: {
+                        events.append("register")
+                        return pages.removeFirst()
+                    },
+                    uploadedCount: { uploaded },
+                    send: {
+                        events.append("send")
+                        uploaded += 1
+                    }
+                )
+                events.append("fetch")
+                return ICloudTextSyncResult(uploaded: uploaded, downloaded: 0)
+            },
+            isZoneMissing: ICloudTextSyncEngine.isSyncZoneMissing,
+            invalidatesPreparation: MuesliCKSyncEngine.invalidatesPreparation,
+            invalidate: { _ in events.append("invalidate") }
+        )
+
+        XCTAssertEqual(result.uploaded, 2)
+        XCTAssertEqual(
+            events,
+            ["fetch-failed", "invalidate", "register", "send", "register", "send", "register", "fetch"]
+        )
+    }
+
+    func testFailedActiveRuntimeBatchPreservesLaterIncomingRequest() async throws {
         let executor = TestRuntimeExecutor()
         let runtime = MuesliCKSyncRuntime(execute: { intent in
             try await executor.execute(intent)
@@ -220,17 +278,14 @@ final class MuesliCKSyncEngineTests: XCTestCase {
         await executor.failActiveOperation()
 
         await assertFailure(first)
-        await assertFailure(merged)
-        let pendingAfterFailure = await runtime.pendingIntentForTesting()
-        XCTAssertTrue(pendingAfterFailure.isEmpty)
-
-        let next = Task { try await runtime.sendLocalChanges() }
         try await executor.waitForCallCount(2)
         await executor.succeedActiveOperation()
-        _ = try await next.value
+        _ = try await merged.value
 
         let executedIntents = await executor.executedIntents()
-        XCTAssertEqual(executedIntents, [.send, .send])
+        XCTAssertEqual(executedIntents, [.send, .fetch])
+        let pendingIntent = await runtime.pendingIntentForTesting()
+        XCTAssertTrue(pendingIntent.isEmpty)
     }
 
     func testRuntimeCancellationReleasesBackgroundWaiterBeforeEngineCleanupFinishes() async throws {
@@ -258,6 +313,108 @@ final class MuesliCKSyncEngineTests: XCTestCase {
         await cancellation.value
         let finishedAfterRelease = await executor.cancellationCleanupFinished()
         XCTAssertTrue(finishedAfterRelease)
+    }
+
+    func testRequestEnqueuedDuringCancellationWaitsForCleanupThenStartsOnce() async throws {
+        let executor = TestRuntimeExecutor()
+        let runtime = MuesliCKSyncRuntime(
+            execute: { intent in try await executor.execute(intent) },
+            cancel: { await executor.waitForCancellationRelease() }
+        )
+        let retired = Task { try await runtime.fetchRemoteChanges() }
+        try await executor.waitForCallCount(1)
+
+        let cancellation = Task { await runtime.cancel() }
+        try await executor.waitForCancellationCleanupStart()
+        let replacement = Task { try await runtime.sendLocalChanges() }
+        try await Task.sleep(for: .milliseconds(30))
+        let intentsBeforeCleanup = await executor.executedIntents()
+        XCTAssertEqual(intentsBeforeCleanup, [.fetch])
+
+        await executor.releaseCancellationCleanup()
+        await cancellation.value
+        try await executor.waitForCallCount(2)
+        let intentsAfterCleanup = await executor.executedIntents()
+        XCTAssertEqual(intentsAfterCleanup, [.fetch, .send])
+        await executor.succeedActiveOperation()
+        _ = try await replacement.value
+
+        do {
+            _ = try await retired.value
+            XCTFail("The retired generation must be cancelled")
+        } catch is CancellationError {
+            // Expected.
+        }
+    }
+
+    func testDeadlineRemovesBlockedBackgroundWaiterButLeavesDurableFetchRunning() async throws {
+        let executor = TestRuntimeExecutor()
+        let runtime = MuesliCKSyncRuntime(execute: { intent in
+            try await executor.execute(intent)
+        })
+        let request = Task {
+            try await runtime.fetchRemoteChanges(deadline: .milliseconds(25))
+        }
+        try await executor.waitForCallCount(1)
+
+        do {
+            _ = try await request.value
+            XCTFail("The bounded APNs waiter must expire")
+        } catch MuesliCKSyncRuntimeError.deadlineExceeded {
+            // Expected.
+        }
+        let waiterCount = await runtime.waiterCountForTesting()
+        let executedIntents = await executor.executedIntents()
+        XCTAssertEqual(waiterCount, 0)
+        XCTAssertEqual(executedIntents, [.fetch])
+
+        // Expiry releases only the OS completion waiter. The shared durable
+        // operation remains owned by the runtime/CKSyncEngine and may finish.
+        await executor.succeedActiveOperation()
+    }
+
+    func testBridgeRefreshUnionsForceAndRunsOneFollowUpGeneration() async throws {
+        let bridge = TestBridgeRefreshExecutor()
+        let runtime = MuesliCKSyncRuntime(
+            execute: { _ in ICloudTextSyncResult(uploaded: 0, downloaded: 0) },
+            refreshBridge: { force, shouldCommit in
+                await bridge.execute(force: force, shouldCommit: shouldCommit)
+            }
+        )
+
+        let first = Task { await runtime.refreshBridgeDevice(forceRefresh: false) }
+        try await bridge.waitForCallCount(1)
+        let forced = Task { await runtime.refreshBridgeDevice(forceRefresh: true) }
+        await bridge.releaseActive()
+        try await bridge.waitForCallCount(2)
+        await bridge.releaseActive()
+        await first.value
+        await forced.value
+
+        let forceValues = await bridge.forceValues()
+        let commitAuthorities = await bridge.commitAuthorities()
+        XCTAssertEqual(forceValues, [false, true])
+        XCTAssertEqual(commitAuthorities, [true, true])
+    }
+
+    func testCancelledBridgeRefreshCannotPublishStaleIdentity() async throws {
+        let bridge = TestBridgeRefreshExecutor()
+        let runtime = MuesliCKSyncRuntime(
+            execute: { _ in ICloudTextSyncResult(uploaded: 0, downloaded: 0) },
+            refreshBridge: { force, shouldCommit in
+                await bridge.execute(force: force, shouldCommit: shouldCommit)
+            }
+        )
+
+        let refresh = Task { await runtime.refreshBridgeDevice(forceRefresh: true) }
+        try await bridge.waitForCallCount(1)
+        await runtime.cancel()
+        await refresh.value
+        await bridge.releaseActive()
+        try await bridge.waitForCommitCount(1)
+
+        let commitAuthorities = await bridge.commitAuthorities()
+        XCTAssertEqual(commitAuthorities, [false])
     }
 
     func testBackgroundFetchReportsNewDataOnlyForAppliedRemoteRecords() async {
@@ -289,6 +446,14 @@ final class MuesliCKSyncEngineTests: XCTestCase {
             isCloudKitNotification: true,
             syncEnabled: false
         ))
+    }
+
+    func testProvenanceMissingClassifierBoundsNestedErrorGraphs() {
+        let withinBound = Self.nestedPartialFailure(depth: 6, leaf: CKError(.unknownItem))
+        let beyondBound = Self.nestedPartialFailure(depth: 9, leaf: CKError(.unknownItem))
+
+        XCTAssertTrue(ICloudTextSyncEngine.isMissingProvenanceRecord(withinBound))
+        XCTAssertFalse(ICloudTextSyncEngine.isMissingProvenanceRecord(beyondBound))
     }
 
     func testRecordBatchLoadsCurrentRowsAndDropsOnlyMissingRows() async {
@@ -568,6 +733,38 @@ final class MuesliCKSyncEngineTests: XCTestCase {
         XCTAssertEqual(pendingRecordID.zoneID, ICloudTextSyncEngine.Schema.syncZoneID)
     }
 
+    func testStartupCanRebuildOrdinaryPersistedDirtyOutboxFromEmptyEngineState() async throws {
+        let directory = try Self.temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = Muesli.SharedStore(containerURL: directory)
+        try store.saveResult(Muesli.DictationResult(
+            requestID: UUID(),
+            text: "persisted before process launch",
+            engineIdentifier: "test"
+        ))
+        let dirty = try XCTUnwrap(try store.textRecordsNeedingSync().first)
+        let owner = CKRecord.ID(recordName: "startup-owner")
+        XCTAssertTrue(try store.claimCloudSyncAccountScope(
+            MuesliCKSyncEngine.accountScope(for: owner),
+            forKey: MuesliCKSyncEngine.accountScopeKey
+        ))
+        let state = TestPendingState()
+        let engine = MuesliCKSyncEngine(store: store)
+        let authorized = try await engine.handleAccountChange(currentUser: owner, state: state)
+        XCTAssertTrue(authorized)
+
+        // Simulate an empty restored CKSyncEngine serialization while SQLite's
+        // durable sync_dirty row survived the prior process.
+        state.remove(pendingRecordZoneChanges: state.pendingRecordZoneChanges)
+        XCTAssertTrue(state.pendingRecordZoneChanges.isEmpty)
+        let registered = try await engine.registerNextDirtyBatch(state: state)
+        XCTAssertEqual(registered, 1)
+        guard case .saveRecord(let recordID) = try XCTUnwrap(state.pendingRecordZoneChanges.first) else {
+            return XCTFail("Expected startup convergence to rebuild the save")
+        }
+        XCTAssertEqual(recordID.recordName, dirty.id)
+    }
+
     func testUnscopedLegacyLibraryDoesNotClaimUnverifiedAccount() async throws {
         let directory = try Self.temporaryDirectory()
         defer { try? FileManager.default.removeItem(at: directory) }
@@ -698,6 +895,10 @@ final class MuesliCKSyncEngineTests: XCTestCase {
         )
     }
 
+    private static func nestedPartialFailure(depth: Int, leaf: Error) -> Error {
+        (0..<depth).reduce(leaf) { current, _ in partialFailure(containing: current) }
+    }
+
     private func assertFailure(
         _ task: Task<ICloudTextSyncResult, Error>,
         file: StaticString = #filePath,
@@ -757,14 +958,15 @@ private actor TestAsyncCounter {
 
 private actor TestRuntimeExecutor {
     private var intents: [MuesliCKSyncIntent] = []
-    private var operationContinuation: CheckedContinuation<ICloudTextSyncResult, Error>?
+    private var operationContinuations: [CheckedContinuation<ICloudTextSyncResult, Error>] = []
     private var cancellationContinuation: CheckedContinuation<Void, Never>?
+    private var cancellationStarted = false
     private var cancellationFinished = false
 
     func execute(_ intent: MuesliCKSyncIntent) async throws -> ICloudTextSyncResult {
         intents.append(intent)
         return try await withCheckedThrowingContinuation { continuation in
-            operationContinuation = continuation
+            operationContinuations.append(continuation)
         }
     }
 
@@ -777,13 +979,15 @@ private actor TestRuntimeExecutor {
     }
 
     func failActiveOperation() {
-        operationContinuation?.resume(throwing: TestFailure.expected)
-        operationContinuation = nil
+        guard !operationContinuations.isEmpty else { return }
+        operationContinuations.removeFirst().resume(throwing: TestFailure.expected)
     }
 
     func succeedActiveOperation() {
-        operationContinuation?.resume(returning: ICloudTextSyncResult(uploaded: 1, downloaded: 0))
-        operationContinuation = nil
+        guard !operationContinuations.isEmpty else { return }
+        operationContinuations.removeFirst().resume(
+            returning: ICloudTextSyncResult(uploaded: 1, downloaded: 0)
+        )
     }
 
     func executedIntents() -> [MuesliCKSyncIntent] {
@@ -791,6 +995,7 @@ private actor TestRuntimeExecutor {
     }
 
     func waitForCancellationRelease() async {
+        cancellationStarted = true
         await withCheckedContinuation { continuation in
             cancellationContinuation = continuation
         }
@@ -798,15 +1003,65 @@ private actor TestRuntimeExecutor {
     }
 
     func releaseCancellationCleanup() {
-        operationContinuation?.resume(throwing: CancellationError())
-        operationContinuation = nil
+        if !operationContinuations.isEmpty {
+            operationContinuations.removeFirst().resume(throwing: CancellationError())
+        }
         cancellationContinuation?.resume()
         cancellationContinuation = nil
+    }
+
+    func waitForCancellationCleanupStart() async throws {
+        for _ in 0..<200 {
+            if cancellationStarted { return }
+            try await Task.sleep(for: .milliseconds(5))
+        }
+        throw TestFailure.expected
     }
 
     func cancellationCleanupFinished() -> Bool {
         cancellationFinished
     }
+}
+
+private actor TestBridgeRefreshExecutor {
+    private var forces: [Bool] = []
+    private var commitResults: [Bool] = []
+    private var operationContinuations: [CheckedContinuation<Void, Never>] = []
+
+    func execute(
+        force: Bool,
+        shouldCommit: @escaping @Sendable () async -> Bool
+    ) async {
+        forces.append(force)
+        await withCheckedContinuation { continuation in
+            operationContinuations.append(continuation)
+        }
+        commitResults.append(await shouldCommit())
+    }
+
+    func waitForCallCount(_ expected: Int) async throws {
+        for _ in 0..<200 {
+            if forces.count >= expected { return }
+            try await Task.sleep(for: .milliseconds(5))
+        }
+        throw TestFailure.expected
+    }
+
+    func waitForCommitCount(_ expected: Int) async throws {
+        for _ in 0..<200 {
+            if commitResults.count >= expected { return }
+            try await Task.sleep(for: .milliseconds(5))
+        }
+        throw TestFailure.expected
+    }
+
+    func releaseActive() {
+        guard !operationContinuations.isEmpty else { return }
+        operationContinuations.removeFirst().resume()
+    }
+
+    func forceValues() -> [Bool] { forces }
+    func commitAuthorities() -> [Bool] { commitResults }
 }
 
 private final class TestPendingState: MuesliCKSyncPendingState, @unchecked Sendable {

--- a/Tests/MuesliTests/MuesliCKSyncEngineTests.swift
+++ b/Tests/MuesliTests/MuesliCKSyncEngineTests.swift
@@ -1,0 +1,290 @@
+import CloudKit
+import XCTest
+@testable import Muesli
+
+final class MuesliCKSyncEngineTests: XCTestCase {
+    func testCycleFetchesBeforeSendingEveryAvailableDirtyPage() async throws {
+        var events: [String] = []
+        var registeredPages = [2, 1, 0]
+        var uploaded = 0
+
+        try await MuesliCKSyncCycle.run(
+            maximumUploadBatches: 10,
+            fetch: { events.append("fetch") },
+            registerNextBatch: {
+                events.append("register")
+                return registeredPages.removeFirst()
+            },
+            uploadedCount: { uploaded },
+            send: {
+                events.append("send")
+                uploaded += 1
+            }
+        )
+
+        XCTAssertEqual(
+            events,
+            ["fetch", "register", "send", "register", "send", "register"]
+        )
+        XCTAssertEqual(uploaded, 2)
+    }
+
+    func testCycleStopsWhenSendMakesNoProgress() async throws {
+        var registrations = 0
+
+        try await MuesliCKSyncCycle.run(
+            maximumUploadBatches: 10,
+            fetch: {},
+            registerNextBatch: {
+                registrations += 1
+                return 1
+            },
+            uploadedCount: { 0 },
+            send: {}
+        )
+
+        XCTAssertEqual(registrations, 1)
+    }
+
+    func testRecordBatchLoadsCurrentRowsAndDropsOnlyMissingRows() async {
+        let engine = MuesliCKSyncEngine()
+        let presentID = CKRecord.ID(
+            recordName: "present",
+            zoneID: ICloudTextSyncEngine.Schema.syncZoneID
+        )
+        let missingID = CKRecord.ID(
+            recordName: "missing",
+            zoneID: ICloudTextSyncEngine.Schema.syncZoneID
+        )
+        let present = Self.record(id: "present", text: "latest local value")
+
+        let batch = await engine.makeRecordBatch(
+            pendingChanges: [.saveRecord(presentID), .saveRecord(missingID)],
+            loadRecords: { _ in [present.id: present] }
+        )
+
+        XCTAssertEqual(batch.recordsToSave.count, 1)
+        XCTAssertEqual(batch.recordsToSave.first?.recordID, presentID)
+        let uploadedText = batch.recordsToSave.first?["text"] as? String
+        XCTAssertEqual(uploadedText, "latest local value")
+        XCTAssertEqual(batch.staleChanges.count, 1)
+        if case .saveRecord(let staleID) = batch.staleChanges[0] {
+            XCTAssertEqual(staleID, missingID)
+        } else {
+            XCTFail("Expected missing local row to become a stale save")
+        }
+    }
+
+    func testRecordBatchKeepsPendingStateWhenLocalReadFails() async {
+        let engine = MuesliCKSyncEngine()
+        let recordID = CKRecord.ID(
+            recordName: "retry-me",
+            zoneID: ICloudTextSyncEngine.Schema.syncZoneID
+        )
+
+        let batch = await engine.makeRecordBatch(
+            pendingChanges: [.saveRecord(recordID)],
+            loadRecords: { _ in throw TestFailure.expected }
+        )
+
+        XCTAssertTrue(batch.recordsToSave.isEmpty)
+        XCTAssertTrue(batch.staleChanges.isEmpty)
+    }
+
+    func testTombstoneRoundTripDoesNotRequireAuthoredText() {
+        var tombstone = Self.record(id: "deleted", text: "private text")
+        tombstone.isDeleted = true
+        let cloud = ICloudTextSyncEngine.syncZoneCloudRecord(from: tombstone)
+
+        XCTAssertNil(cloud["text"])
+        let decoded = ICloudTextSyncEngine.syncTextRecord(from: cloud)
+        XCTAssertEqual(decoded?.id, "deleted")
+        XCTAssertEqual(decoded?.text, "")
+        XCTAssertEqual(decoded?.isDeleted, true)
+        XCTAssertNotNil(decoded?.cloudSystemFields)
+    }
+
+    func testPersistedSystemFieldsRehydrateCloudRecordIdentity() {
+        let original = ICloudTextSyncEngine.syncZoneCloudRecord(
+            from: Self.record(id: "stable", text: "first")
+        )
+        var updated = Self.record(id: "stable", text: "second")
+        updated.cloudSystemFields = ICloudTextSyncEngine.encodedSystemFields(for: original)
+
+        let rehydrated = ICloudTextSyncEngine.syncZoneCloudRecord(from: updated)
+
+        XCTAssertEqual(rehydrated.recordID, original.recordID)
+        XCTAssertEqual(rehydrated["text"] as? String, "second")
+    }
+
+    func testNewerFetchedServerRecordReplacesLocalDirtyRowAndPendingSave() async throws {
+        let directory = try Self.temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = Muesli.SharedStore(containerURL: directory)
+        let result = Muesli.DictationResult(
+            requestID: UUID(),
+            text: "older local text",
+            engineIdentifier: "test"
+        )
+        try store.saveResult(result)
+        let local = try XCTUnwrap(try store.textRecordsNeedingSync().first)
+        let remote = Self.cloudRecord(
+            basedOn: local,
+            text: "newer server text",
+            updatedAt: local.updatedAt.addingTimeInterval(60)
+        )
+        let pending = CKSyncEngine.PendingRecordZoneChange.saveRecord(remote.recordID)
+        let state = TestPendingState([pending])
+        let engine = MuesliCKSyncEngine(store: store)
+
+        let appliedCount = try await engine.handleFetchedRecords([remote], state: state)
+        XCTAssertEqual(appliedCount, 1)
+
+        let resolved = try XCTUnwrap(
+            try store.textRecordsForSync(recordNames: [local.id])[local.id]
+        )
+        XCTAssertEqual(resolved.text, "newer server text")
+        XCTAssertFalse(try store.hasTextRecordsNeedingSync())
+        XCTAssertTrue(state.pendingRecordZoneChanges.isEmpty)
+    }
+
+    func testNewerLocalEditKeepsDirtyOutboxAndHydratesFetchedServerMetadata() async throws {
+        let directory = try Self.temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = Muesli.SharedStore(containerURL: directory)
+        let result = Muesli.DictationResult(
+            requestID: UUID(),
+            text: "newer local text",
+            engineIdentifier: "test"
+        )
+        try store.saveResult(result)
+        let local = try XCTUnwrap(try store.textRecordsNeedingSync().first)
+        let remote = Self.cloudRecord(
+            basedOn: local,
+            text: "older server text",
+            updatedAt: local.updatedAt.addingTimeInterval(-60)
+        )
+        let pending = CKSyncEngine.PendingRecordZoneChange.saveRecord(remote.recordID)
+        let state = TestPendingState([pending])
+        let engine = MuesliCKSyncEngine(store: store)
+
+        let appliedCount = try await engine.handleFetchedRecords([remote], state: state)
+        XCTAssertEqual(appliedCount, 0)
+
+        let resolved = try XCTUnwrap(try store.textRecordsNeedingSync().first)
+        XCTAssertEqual(resolved.text, "newer local text")
+        XCTAssertNotNil(resolved.cloudSystemFields)
+        XCTAssertEqual(state.pendingRecordZoneChanges, [pending])
+    }
+
+    func testSavedRecordClearsDurableOutboxAndPendingState() async throws {
+        let directory = try Self.temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = Muesli.SharedStore(containerURL: directory)
+        try store.saveResult(Muesli.DictationResult(
+            requestID: UUID(),
+            text: "uploaded text",
+            engineIdentifier: "test"
+        ))
+        let local = try XCTUnwrap(try store.textRecordsNeedingSync().first)
+        let saved = Self.cloudRecord(
+            basedOn: local,
+            text: local.text,
+            updatedAt: local.updatedAt
+        )
+        let pending = CKSyncEngine.PendingRecordZoneChange.saveRecord(saved.recordID)
+        let state = TestPendingState([pending])
+        let engine = MuesliCKSyncEngine(store: store)
+
+        try await engine.handleSentRecordChanges(
+            savedRecords: [saved],
+            failedRecordSaves: [],
+            state: state
+        )
+
+        XCTAssertFalse(try store.hasTextRecordsNeedingSync())
+        XCTAssertTrue(state.pendingRecordZoneChanges.isEmpty)
+        let stored = try XCTUnwrap(
+            try store.textRecordsForSync(recordNames: [local.id])[local.id]
+        )
+        XCTAssertNotNil(stored.cloudSystemFields)
+    }
+
+    private static func cloudRecord(
+        basedOn record: Muesli.SyncTextRecord,
+        text: String,
+        updatedAt: Date
+    ) -> CKRecord {
+        ICloudTextSyncEngine.syncZoneCloudRecord(from: Muesli.SyncTextRecord(
+            id: record.id,
+            kind: record.kind,
+            title: record.title,
+            text: text,
+            speakerTranscript: record.speakerTranscript,
+            summaryText: record.summaryText,
+            manualNotes: record.manualNotes,
+            source: record.source,
+            localSource: record.localSource,
+            engineIdentifier: record.engineIdentifier,
+            createdAt: record.createdAt,
+            updatedAt: updatedAt,
+            startedAt: record.startedAt,
+            endedAt: record.endedAt,
+            durationSeconds: record.durationSeconds,
+            wordCount: text.split(separator: " ").count,
+            isDeleted: record.isDeleted,
+            cloudChangeTag: record.cloudChangeTag
+        ))
+    }
+
+    private static func temporaryDirectory() throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("muesli-cksyncengine-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        return directory
+    }
+
+    private static func record(id: String, text: String) -> Muesli.SyncTextRecord {
+        Muesli.SyncTextRecord(
+            id: id,
+            kind: Muesli.SyncTextRecordKind.dictation,
+            title: nil,
+            text: text,
+            speakerTranscript: nil,
+            summaryText: nil,
+            manualNotes: nil,
+            source: "ios",
+            engineIdentifier: "test",
+            createdAt: Date(timeIntervalSince1970: 100),
+            updatedAt: Date(timeIntervalSince1970: 200),
+            startedAt: nil,
+            endedAt: nil,
+            durationSeconds: 0,
+            wordCount: text.split(separator: " ").count,
+            isDeleted: false,
+            cloudChangeTag: nil
+        )
+    }
+}
+
+private enum TestFailure: Error {
+    case expected
+}
+
+private final class TestPendingState: MuesliCKSyncPendingState, @unchecked Sendable {
+    private(set) var pendingRecordZoneChanges: [CKSyncEngine.PendingRecordZoneChange]
+
+    init(_ changes: [CKSyncEngine.PendingRecordZoneChange] = []) {
+        pendingRecordZoneChanges = changes
+    }
+
+    func add(pendingRecordZoneChanges changes: [CKSyncEngine.PendingRecordZoneChange]) {
+        for change in changes where !pendingRecordZoneChanges.contains(change) {
+            pendingRecordZoneChanges.append(change)
+        }
+    }
+
+    func remove(pendingRecordZoneChanges changes: [CKSyncEngine.PendingRecordZoneChange]) {
+        pendingRecordZoneChanges.removeAll { changes.contains($0) }
+    }
+}

--- a/Tests/MuesliTests/MuesliCKSyncEngineTests.swift
+++ b/Tests/MuesliTests/MuesliCKSyncEngineTests.swift
@@ -91,6 +91,22 @@ final class MuesliCKSyncEngineTests: XCTestCase {
         XCTAssertTrue(intents.pending.isEmpty)
     }
 
+    func testRemotePresentationPublishesOnceAfterAllFetchPagesComplete() {
+        var publication = MuesliCKSyncRemoteChangePublication()
+
+        publication.beginFetch()
+        publication.recordAppliedChanges(200)
+        publication.recordAppliedChanges(200)
+        publication.recordAppliedChanges(1)
+
+        XCTAssertTrue(publication.completeFetch())
+        XCTAssertFalse(publication.completeFetch())
+
+        publication.beginFetch()
+        publication.recordAppliedChanges(0)
+        XCTAssertFalse(publication.completeFetch())
+    }
+
     func testPreparationGateRunsPreflightOnceUntilInvalidated() async throws {
         let gate = MuesliCKSyncPreparationGate()
         let counter = TestAsyncCounter()

--- a/Tests/MuesliTests/MuesliCKSyncEngineTests.swift
+++ b/Tests/MuesliTests/MuesliCKSyncEngineTests.swift
@@ -347,6 +347,46 @@ final class MuesliCKSyncEngineTests: XCTestCase {
         }
     }
 
+    func testOverlappingCancellationWaitsForEveryEngineCleanup() async throws {
+        let executor = TestRuntimeExecutor()
+        let runtime = MuesliCKSyncRuntime(
+            execute: { intent in try await executor.execute(intent) },
+            cancel: { await executor.waitForCancellationRelease() }
+        )
+        let retired = Task { try await runtime.fetchRemoteChanges() }
+        try await executor.waitForCallCount(1)
+
+        let firstCancellation = Task { await runtime.cancel() }
+        try await executor.waitForCancellationCleanupCount(1)
+        let secondCancellation = Task { await runtime.cancel() }
+        try await executor.waitForCancellationCleanupCount(2)
+        let replacement = Task { try await runtime.sendLocalChanges() }
+
+        // Finish the newer cleanup first. The older cleanup still owns the
+        // execution barrier, so the replacement cannot reach the executor.
+        await executor.releaseCancellationCleanup(at: 1)
+        await secondCancellation.value
+        try await Task.sleep(for: .milliseconds(30))
+        let beforeAllCleanups = await executor.executedIntents()
+        XCTAssertEqual(beforeAllCleanups, [.fetch])
+
+        await executor.failOldOperationForCancellation()
+        await executor.releaseCancellationCleanup(at: 0)
+        await firstCancellation.value
+        try await executor.waitForCallCount(2)
+        let afterAllCleanups = await executor.executedIntents()
+        XCTAssertEqual(afterAllCleanups, [.fetch, .send])
+        await executor.succeedActiveOperation()
+        _ = try await replacement.value
+
+        do {
+            _ = try await retired.value
+            XCTFail("The retired request must be cancelled")
+        } catch is CancellationError {
+            // Expected.
+        }
+    }
+
     func testDeadlineRemovesBlockedBackgroundWaiterButLeavesDurableFetchRunning() async throws {
         let executor = TestRuntimeExecutor()
         let runtime = MuesliCKSyncRuntime(execute: { intent in
@@ -408,13 +448,42 @@ final class MuesliCKSyncEngineTests: XCTestCase {
 
         let refresh = Task { await runtime.refreshBridgeDevice(forceRefresh: true) }
         try await bridge.waitForCallCount(1)
-        await runtime.cancel()
+        let cancellation = Task { await runtime.cancel() }
         await refresh.value
         await bridge.releaseActive()
+        await cancellation.value
         try await bridge.waitForCommitCount(1)
 
         let commitAuthorities = await bridge.commitAuthorities()
         XCTAssertEqual(commitAuthorities, [false])
+    }
+
+    func testCancelledCloudKitSaveCancelsOperationAndIgnoresLateCallback() async {
+        let cancellation = MuesliCancellableCloudKitOperation<Int>()
+        let operation = CKModifyRecordsOperation(recordsToSave: [], recordIDsToDelete: [])
+        let installed = XCTestExpectation(description: "operation installed")
+        let request = Task {
+            try await withCheckedThrowingContinuation { continuation in
+                cancellation.install(operation: operation, continuation: continuation)
+                installed.fulfill()
+            }
+        }
+        await fulfillment(of: [installed], timeout: 1)
+
+        cancellation.cancel()
+        do {
+            _ = try await request.value
+            XCTFail("Cancelled CloudKit write must release its caller")
+        } catch is CancellationError {
+            // Expected.
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+        XCTAssertTrue(operation.isCancelled)
+
+        // CloudKit is allowed to invoke a result block after cancellation.
+        // The completion owner must treat that callback as a no-op.
+        cancellation.succeed(42)
     }
 
     func testBackgroundFetchReportsNewDataOnlyForAppliedRemoteRecords() async {
@@ -959,9 +1028,8 @@ private actor TestAsyncCounter {
 private actor TestRuntimeExecutor {
     private var intents: [MuesliCKSyncIntent] = []
     private var operationContinuations: [CheckedContinuation<ICloudTextSyncResult, Error>] = []
-    private var cancellationContinuation: CheckedContinuation<Void, Never>?
-    private var cancellationStarted = false
-    private var cancellationFinished = false
+    private var cancellationContinuations: [CheckedContinuation<Void, Never>?] = []
+    private var cancellationFinishedCount = 0
 
     func execute(_ intent: MuesliCKSyncIntent) async throws -> ICloudTextSyncResult {
         intents.append(intent)
@@ -995,31 +1063,45 @@ private actor TestRuntimeExecutor {
     }
 
     func waitForCancellationRelease() async {
-        cancellationStarted = true
         await withCheckedContinuation { continuation in
-            cancellationContinuation = continuation
+            cancellationContinuations.append(continuation)
         }
-        cancellationFinished = true
+        cancellationFinishedCount += 1
     }
 
     func releaseCancellationCleanup() {
         if !operationContinuations.isEmpty {
             operationContinuations.removeFirst().resume(throwing: CancellationError())
         }
-        cancellationContinuation?.resume()
-        cancellationContinuation = nil
+        releaseCancellationCleanup(at: 0)
     }
 
     func waitForCancellationCleanupStart() async throws {
+        try await waitForCancellationCleanupCount(1)
+    }
+
+    func waitForCancellationCleanupCount(_ expected: Int) async throws {
         for _ in 0..<200 {
-            if cancellationStarted { return }
+            if cancellationContinuations.count >= expected { return }
             try await Task.sleep(for: .milliseconds(5))
         }
         throw TestFailure.expected
     }
 
+    func releaseCancellationCleanup(at index: Int) {
+        guard cancellationContinuations.indices.contains(index),
+              let continuation = cancellationContinuations[index] else { return }
+        cancellationContinuations[index] = nil
+        continuation.resume()
+    }
+
+    func failOldOperationForCancellation() {
+        guard !operationContinuations.isEmpty else { return }
+        operationContinuations.removeFirst().resume(throwing: CancellationError())
+    }
+
     func cancellationCleanupFinished() -> Bool {
-        cancellationFinished
+        cancellationFinishedCount > 0
     }
 }
 

--- a/Tests/MuesliTests/MuesliCKSyncEngineTests.swift
+++ b/Tests/MuesliTests/MuesliCKSyncEngineTests.swift
@@ -217,6 +217,45 @@ final class MuesliCKSyncEngineTests: XCTestCase {
         XCTAssertNotNil(stored.cloudSystemFields)
     }
 
+    func testAccountChangeClearsOldStateAndRequeuesSyncedLocalText() async throws {
+        let directory = try Self.temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = Muesli.SharedStore(containerURL: directory)
+        try store.saveResult(Muesli.DictationResult(
+            requestID: UUID(),
+            text: "local text survives account change",
+            engineIdentifier: "test"
+        ))
+        let local = try XCTUnwrap(try store.textRecordsNeedingSync().first)
+        let saved = Self.cloudRecord(
+            basedOn: local,
+            text: local.text,
+            updatedAt: local.updatedAt
+        )
+        XCTAssertTrue(try store.markTextRecordSynced(
+            kind: local.kind,
+            recordName: local.id,
+            changeTag: "old-account-tag",
+            systemFields: ICloudTextSyncEngine.encodedSystemFields(for: saved),
+            recordUpdatedAt: local.updatedAt
+        ))
+        XCTAssertFalse(try store.hasTextRecordsNeedingSync())
+        try store.saveCloudSyncStateData(Data([1, 2, 3]), forKey: MuesliCKSyncEngine.stateKey)
+
+        let state = TestPendingState()
+        let engine = MuesliCKSyncEngine(store: store)
+        try await engine.handleAccountChange(requiresMetadataReset: true, state: state)
+
+        XCTAssertNil(try store.cloudSyncStateData(forKey: MuesliCKSyncEngine.stateKey))
+        XCTAssertTrue(try store.hasTextRecordsNeedingSync())
+        let pending = try XCTUnwrap(state.pendingRecordZoneChanges.first)
+        guard case .saveRecord(let pendingRecordID) = pending else {
+            return XCTFail("Expected account change to queue a record save")
+        }
+        XCTAssertEqual(pendingRecordID.recordName, local.id)
+        XCTAssertEqual(pendingRecordID.zoneID, ICloudTextSyncEngine.Schema.syncZoneID)
+    }
+
     private static func cloudRecord(
         basedOn record: Muesli.SyncTextRecord,
         text: String,

--- a/Tests/MuesliTests/SettingsModelCatalogTests.swift
+++ b/Tests/MuesliTests/SettingsModelCatalogTests.swift
@@ -90,6 +90,86 @@ final class SettingsModelCatalogTests: XCTestCase {
         )
     }
 
+    func testEverySelectableModelHasABackgroundDownloadPlan() {
+        XCTAssertTrue(
+            LocalTranscriptionModel.allCases.allSatisfy {
+                ModelBackgroundDownloadService.supportsBackgroundDownload($0)
+            }
+        )
+    }
+
+    func testPreparationPolicyDownloadsBeforeAttemptingWarmup() {
+        XCTAssertEqual(
+            ModelPreparationPolicy.action(isDownloaded: false),
+            .startBackgroundDownload
+        )
+        XCTAssertEqual(
+            ModelPreparationPolicy.action(isDownloaded: true),
+            .warmDownloadedModel
+        )
+    }
+
+    func testFluidAudioDownloadRequiresCompleteModelsAndVocabulary() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("muesli-fluidaudio-integrity-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let modelNames: Set<String> = ["Encoder.mlmodelc", "Decoder.mlmodelc"]
+        let supportingFiles: Set<String> = ["parakeet_vocab.json"]
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        for modelName in modelNames {
+            let modelDirectory = root.appendingPathComponent(modelName, isDirectory: true)
+            try FileManager.default.createDirectory(at: modelDirectory, withIntermediateDirectories: true)
+            try Data("model".utf8).write(to: modelDirectory.appendingPathComponent("coremldata.bin"))
+        }
+
+        XCTAssertFalse(
+            ModelBackgroundDownloadService.containsCompleteFluidAudioArtifacts(
+                at: root,
+                modelNames: modelNames,
+                supportingFiles: supportingFiles
+            ),
+            "Compiled models without their vocabulary must not be treated as transcription-ready."
+        )
+
+        try Data("{}".utf8).write(to: root.appendingPathComponent("parakeet_vocab.json"))
+        XCTAssertTrue(
+            ModelBackgroundDownloadService.containsCompleteFluidAudioArtifacts(
+                at: root,
+                modelNames: modelNames,
+                supportingFiles: supportingFiles
+            )
+        )
+
+        try FileManager.default.removeItem(
+            at: root.appendingPathComponent("Encoder.mlmodelc/coremldata.bin")
+        )
+        XCTAssertFalse(
+            ModelBackgroundDownloadService.containsCompleteFluidAudioArtifacts(
+                at: root,
+                modelNames: modelNames,
+                supportingFiles: supportingFiles
+            ),
+            "A partially downloaded CoreML directory must not enter the inference path."
+        )
+    }
+
+    func testLocalParakeetVocabularySupportsBothShippedFormats() throws {
+        let arrayVocabulary = try FluidAudioTranscriptionEngine.decodeParakeetVocabulary(
+            Data("[\"blank\",\"hello\"]".utf8)
+        )
+        XCTAssertEqual(arrayVocabulary, [0: "blank", 1: "hello"])
+
+        let dictionaryVocabulary = try FluidAudioTranscriptionEngine.decodeParakeetVocabulary(
+            Data("{\"0\":\"blank\",\"42\":\"hello\"}".utf8)
+        )
+        XCTAssertEqual(dictionaryVocabulary, [0: "blank", 42: "hello"])
+
+        XCTAssertThrowsError(
+            try FluidAudioTranscriptionEngine.decodeParakeetVocabulary(Data("[1]".utf8))
+        )
+    }
+
     func testEveryModelHasAnIsolatedStorageDirectory() {
         let directories = LocalTranscriptionModel.allCases.compactMap {
             ModelBackgroundDownloadService.storageDirectory(for: $0)?.standardizedFileURL.path

--- a/Tests/MuesliTests/SharedStoreTests.swift
+++ b/Tests/MuesliTests/SharedStoreTests.swift
@@ -410,6 +410,42 @@ final class SharedStoreTests: XCTestCase {
         XCTAssertEqual(try sqliteInt("SELECT COUNT(*) FROM result_history", in: directory), 205)
     }
 
+    func testHistorySnapshotReadsResultsSessionsAndTranscriptsTogether() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let store = SharedStore(containerURL: directory)
+        let session = RecordingSession(
+            kind: .meeting,
+            createdAt: Date(timeIntervalSince1970: 100),
+            phase: .completed
+        )
+        let transcript = Transcript(
+            sessionID: session.id,
+            text: "Persisted transcript",
+            createdAt: session.createdAt,
+            engineIdentifier: "test"
+        )
+        let result = DictationResult(
+            requestID: UUID(),
+            sessionID: session.id,
+            text: "Persisted voice note",
+            createdAt: session.createdAt,
+            engineIdentifier: "test"
+        )
+        try store.saveSession(session)
+        try store.saveTranscript(transcript)
+        try store.saveResult(result)
+
+        let snapshot = try store.historySnapshot()
+
+        XCTAssertEqual(snapshot.history, [result])
+        XCTAssertEqual(snapshot.sessions.map(\.id), [session.id])
+        XCTAssertEqual(snapshot.sessions.first?.phase, session.phase)
+        XCTAssertEqual(snapshot.sessions.first?.cloudRecordName, session.id.uuidString)
+        XCTAssertEqual(snapshot.transcripts, [transcript])
+    }
+
     func testResultWritesPopulateNormalizedSyncColumns() throws {
         let directory = try makeTemporaryDirectory()
         defer { try? FileManager.default.removeItem(at: directory) }

--- a/Tests/MuesliTests/SharedStoreTests.swift
+++ b/Tests/MuesliTests/SharedStoreTests.swift
@@ -467,6 +467,20 @@ final class SharedStoreTests: XCTestCase {
         XCTAssertNil(try store.cloudSyncStateData(forKey: "private-zone"))
     }
 
+    func testCloudSyncAccountScopeCanBeClaimedButNotReassigned() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = SharedStore(containerURL: directory)
+
+        XCTAssertTrue(try store.claimCloudSyncAccountScope("scope-a", forKey: "account-owner"))
+        XCTAssertTrue(try store.claimCloudSyncAccountScope("scope-a", forKey: "account-owner"))
+        XCTAssertFalse(try store.claimCloudSyncAccountScope("scope-b", forKey: "account-owner"))
+        XCTAssertEqual(
+            try store.cloudSyncStateData(forKey: "account-owner"),
+            Data("scope-a".utf8)
+        )
+    }
+
     func testDictationSyncRecordsIncludeLinkedSessionTiming() throws {
         let directory = try makeTemporaryDirectory()
         defer { try? FileManager.default.removeItem(at: directory) }
@@ -669,13 +683,13 @@ final class SharedStoreTests: XCTestCase {
         XCTAssertEqual(stored.cloudSystemFields, systemFields)
     }
 
-    func testAccountChangeResetPreservesTextAndRequeuesRecords() throws {
+    func testZoneRecreationResetPreservesTextAndRequeuesRecordsWithoutStaleMetadata() throws {
         let directory = try makeTemporaryDirectory()
         defer { try? FileManager.default.removeItem(at: directory) }
         let store = SharedStore(containerURL: directory)
         let result = DictationResult(
             requestID: UUID(),
-            text: "must survive account switch",
+            text: "must survive zone recreation",
             engineIdentifier: "test"
         )
         try store.saveResult(result)
@@ -683,14 +697,14 @@ final class SharedStoreTests: XCTestCase {
         XCTAssertTrue(try store.markTextRecordSynced(
             kind: .dictation,
             recordName: uploaded.id,
-            changeTag: "old-account-tag",
+            changeTag: "deleted-zone-tag",
             systemFields: Data([8]),
             recordUpdatedAt: uploaded.updatedAt
         ))
 
-        try store.resetTextRecordCloudMetadataForAccountChange()
+        try store.resetTextRecordCloudMetadataForZoneRecreation()
 
-        XCTAssertEqual(try store.resultsHistory().first?.text, "must survive account switch")
+        XCTAssertEqual(try store.resultsHistory().first?.text, "must survive zone recreation")
         let requeued = try XCTUnwrap(try store.textRecordsNeedingSync().first)
         XCTAssertNil(requeued.cloudChangeTag)
         XCTAssertNil(requeued.cloudSystemFields)
@@ -1041,6 +1055,61 @@ final class SharedStoreTests: XCTestCase {
 
         let record = try XCTUnwrap(try store.textRecordsNeedingSync().first { $0.kind == .meeting })
         XCTAssertEqual(record.source, "macos")
+    }
+
+    func testMeetingSyncDecodersAgreeAcrossDirtyLookupAndMigrationQueries() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = SharedStore(containerURL: directory)
+        let transcriptID = UUID()
+        let session = RecordingSession(
+            id: UUID(),
+            kind: .meeting,
+            title: "Decoder contract",
+            createdAt: Date(timeIntervalSince1970: 100),
+            startedAt: Date(timeIntervalSince1970: 110),
+            endedAt: Date(timeIntervalSince1970: 170),
+            phase: .completed,
+            transcriptID: transcriptID,
+            engineIdentifier: "test",
+            source: "ios"
+        )
+        try store.saveSession(session)
+        try store.saveTranscript(Transcript(
+            id: transcriptID,
+            sessionID: session.id,
+            text: "shared transcript",
+            createdAt: Date(timeIntervalSince1970: 171),
+            engineIdentifier: "test",
+            speakerTranscript: "Speaker 1: shared transcript",
+            summaryText: "Shared summary"
+        ))
+        try store.updateMeetingManualNotes(
+            sessionID: session.id,
+            manualNotes: "Shared notes"
+        )
+
+        let dirty = try XCTUnwrap(
+            try store.textRecordsNeedingSync().first { $0.kind == .meeting }
+        )
+        let lookup = try XCTUnwrap(
+            try store.textRecordsForSync(recordNames: [dirty.id])[dirty.id]
+        )
+        let migration = try XCTUnwrap(
+            try store.textRecordsForSyncMigration().first { $0.id == dirty.id }
+        )
+
+        for record in [dirty, lookup, migration] {
+            XCTAssertEqual(record.id, session.id.uuidString)
+            XCTAssertEqual(record.title, "Decoder contract")
+            XCTAssertEqual(record.text, "shared transcript")
+            XCTAssertEqual(record.speakerTranscript, "Speaker 1: shared transcript")
+            XCTAssertEqual(record.summaryText, "Shared summary")
+            XCTAssertEqual(record.manualNotes, "Shared notes")
+            XCTAssertEqual(record.startedAt, Date(timeIntervalSince1970: 110))
+            XCTAssertEqual(record.endedAt, Date(timeIntervalSince1970: 170))
+            XCTAssertEqual(record.durationSeconds, 60, accuracy: 0.001)
+        }
     }
 
     func testMeetingManualNotesPersistAndSync() throws {

--- a/Tests/MuesliTests/SharedStoreTests.swift
+++ b/Tests/MuesliTests/SharedStoreTests.swift
@@ -481,6 +481,32 @@ final class SharedStoreTests: XCTestCase {
         )
     }
 
+    func testAccountVerificationNamesExcludeLocalOnlyRowsAndIncludeSyncedRows() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = SharedStore(containerURL: directory)
+        try store.saveResult(DictationResult(
+            requestID: UUID(),
+            text: "private local text",
+            engineIdentifier: "test"
+        ))
+        let local = try XCTUnwrap(try store.textRecordsNeedingSync().first)
+
+        XCTAssertTrue(try store.textRecordNamesRequiringAccountVerification().isEmpty)
+
+        XCTAssertTrue(try store.markTextRecordSynced(
+            kind: local.kind,
+            recordName: local.id,
+            changeTag: "server-change-tag",
+            systemFields: Data([1, 2, 3]),
+            recordUpdatedAt: local.updatedAt
+        ))
+        XCTAssertEqual(
+            try store.textRecordNamesRequiringAccountVerification(),
+            Set([local.id])
+        )
+    }
+
     func testDictationSyncRecordsIncludeLinkedSessionTiming() throws {
         let directory = try makeTemporaryDirectory()
         defer { try? FileManager.default.removeItem(at: directory) }

--- a/Tests/MuesliTests/SharedStoreTests.swift
+++ b/Tests/MuesliTests/SharedStoreTests.swift
@@ -90,14 +90,14 @@ final class SharedStoreTests: XCTestCase {
         XCTAssertFalse(bus.postedEvents.contains(.commandChanged))
     }
 
-    func testFreshSQLiteStoreCreatesV4Schema() throws {
+    func testFreshSQLiteStoreCreatesV5Schema() throws {
         let directory = try makeTemporaryDirectory()
         defer { try? FileManager.default.removeItem(at: directory) }
 
         let store = SharedStore(containerURL: directory)
         XCTAssertEqual(try store.resultsHistory(), [])
 
-        XCTAssertEqual(try sqliteInt("PRAGMA user_version", in: directory), 4)
+        XCTAssertEqual(try sqliteInt("PRAGMA user_version", in: directory), 5)
         XCTAssertTrue(try sqliteColumnNames(table: "result_history", in: directory).isSuperset(of: [
             "session_id",
             "text",
@@ -106,14 +106,17 @@ final class SharedStoreTests: XCTestCase {
             "deleted_at",
             "cloud_record_name",
             "cloud_change_tag",
+            "cloud_system_fields",
             "last_synced_at",
             "sync_dirty"
         ]))
         XCTAssertTrue(try sqliteColumnNames(table: "recording_sessions", in: directory).contains("audio_file_name"))
         XCTAssertTrue(try sqliteColumnNames(table: "recording_sessions", in: directory).contains("manual_notes"))
         XCTAssertTrue(try sqliteColumnNames(table: "recording_sessions", in: directory).contains("manual_notes_updated_at"))
+        XCTAssertTrue(try sqliteColumnNames(table: "recording_sessions", in: directory).contains("cloud_system_fields"))
         XCTAssertTrue(try sqliteColumnNames(table: "transcripts", in: directory).contains("summary_model"))
         XCTAssertTrue(try sqliteColumnNames(table: "custom_words", in: directory).contains("matching_threshold"))
+        XCTAssertEqual(try sqliteInt("SELECT COUNT(*) FROM cloud_sync_state", in: directory), 0)
     }
 
     func testLegacyJSONFilesMigrateIntoSQLiteStore() throws {
@@ -164,7 +167,7 @@ final class SharedStoreTests: XCTestCase {
         XCTAssertEqual(try sqliteString("SELECT text FROM result_history LIMIT 1", in: directory), "migrated dictation")
         XCTAssertEqual(try sqliteString("SELECT engine_identifier FROM result_history LIMIT 1", in: directory), "parakeet-v3")
         XCTAssertEqual(try sqliteString("SELECT replacement FROM custom_words LIMIT 1", in: directory), "Muesli")
-        XCTAssertEqual(try sqliteInt("PRAGMA user_version", in: directory), 4)
+        XCTAssertEqual(try sqliteInt("PRAGMA user_version", in: directory), 5)
     }
 
     func testResultsHistoryPersistsSortedResultsAfterOneOffResultIsCleared() throws {
@@ -449,6 +452,247 @@ final class SharedStoreTests: XCTestCase {
 
         let record = try XCTUnwrap(try store.textRecordsNeedingSync().first { $0.kind == .dictation })
         XCTAssertEqual(record.source, "macos")
+    }
+
+    func testCloudSyncEngineStateRoundTripsAndClears() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = SharedStore(containerURL: directory)
+        let state = Data([0x43, 0x4B, 0x53, 0x45])
+
+        XCTAssertNil(try store.cloudSyncStateData(forKey: "private-zone"))
+        try store.saveCloudSyncStateData(state, forKey: "private-zone")
+        XCTAssertEqual(try store.cloudSyncStateData(forKey: "private-zone"), state)
+        try store.clearCloudSyncStateData(forKey: "private-zone")
+        XCTAssertNil(try store.cloudSyncStateData(forKey: "private-zone"))
+    }
+
+    func testSyncRecordBatchLookupIncludesCloudSystemFields() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = SharedStore(containerURL: directory)
+        let recordID = UUID().uuidString
+        let systemFields = Data([1, 2, 3, 4])
+        let record = SyncTextRecord(
+            id: recordID,
+            kind: .dictation,
+            title: nil,
+            text: "server text",
+            speakerTranscript: nil,
+            summaryText: nil,
+            manualNotes: nil,
+            source: "ios",
+            engineIdentifier: "icloud",
+            createdAt: Date(timeIntervalSince1970: 100),
+            updatedAt: Date(timeIntervalSince1970: 200),
+            startedAt: nil,
+            endedAt: nil,
+            durationSeconds: 0,
+            wordCount: 2,
+            isDeleted: false,
+            cloudChangeTag: "tag-1",
+            cloudSystemFields: systemFields
+        )
+
+        XCTAssertTrue(try store.upsertSyncedTextRecord(record))
+        let fetched = try XCTUnwrap(try store.textRecordsForSync(recordNames: [recordID])[recordID])
+        XCTAssertEqual(fetched.cloudChangeTag, "tag-1")
+        XCTAssertEqual(fetched.cloudSystemFields, systemFields)
+        XCTAssertEqual(fetched.text, "server text")
+    }
+
+    func testUploadAcknowledgementDoesNotClearNewerLocalDictationEdit() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = SharedStore(containerURL: directory)
+        let id = UUID()
+        let requestID = UUID()
+        try store.saveResult(DictationResult(
+            id: id,
+            requestID: requestID,
+            text: "version one",
+            engineIdentifier: "test"
+        ))
+        let uploaded = try XCTUnwrap(try store.textRecordsNeedingSync().first)
+
+        Thread.sleep(forTimeInterval: 0.01)
+        try store.saveResult(DictationResult(
+            id: id,
+            requestID: requestID,
+            text: "version two",
+            engineIdentifier: "test"
+        ))
+
+        XCTAssertFalse(try store.markTextRecordSynced(
+            kind: .dictation,
+            recordName: id.uuidString,
+            changeTag: "stale-upload-tag",
+            systemFields: Data([9]),
+            recordUpdatedAt: uploaded.updatedAt
+        ))
+        XCTAssertTrue(try store.hasTextRecordsNeedingSync())
+        let pending = try XCTUnwrap(try store.textRecordsNeedingSync().first)
+        XCTAssertEqual(pending.text, "version two")
+        XCTAssertNil(pending.cloudSystemFields)
+    }
+
+    func testEqualTimestampFetchedRecordCannotOverwriteDirtyLocalDictation() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = SharedStore(containerURL: directory)
+        try store.saveResult(DictationResult(
+            requestID: UUID(),
+            text: "local value",
+            engineIdentifier: "test"
+        ))
+        let local = try XCTUnwrap(try store.textRecordsNeedingSync().first)
+        var remote = local
+        remote.text = "different server value"
+        remote.cloudSystemFields = Data([1])
+
+        XCTAssertFalse(try store.upsertSyncedTextRecord(remote))
+        XCTAssertEqual(try store.textRecordsNeedingSync().first?.text, "local value")
+    }
+
+    func testUploadAcknowledgementPersistsMetadataAndClearsExactLocalVersion() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = SharedStore(containerURL: directory)
+        let result = DictationResult(
+            requestID: UUID(),
+            text: "ready to acknowledge",
+            engineIdentifier: "test"
+        )
+        try store.saveResult(result)
+        let uploaded = try XCTUnwrap(try store.textRecordsNeedingSync().first)
+        let systemFields = Data([5, 6, 7])
+
+        XCTAssertTrue(try store.markTextRecordSynced(
+            kind: .dictation,
+            recordName: uploaded.id,
+            changeTag: "saved-tag",
+            systemFields: systemFields,
+            recordUpdatedAt: uploaded.updatedAt
+        ))
+        XCTAssertFalse(try store.hasTextRecordsNeedingSync())
+        let stored = try XCTUnwrap(try store.textRecordsForSync(recordNames: [uploaded.id])[uploaded.id])
+        XCTAssertEqual(stored.cloudChangeTag, "saved-tag")
+        XCTAssertEqual(stored.cloudSystemFields, systemFields)
+    }
+
+    func testAccountChangeResetPreservesTextAndRequeuesRecords() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = SharedStore(containerURL: directory)
+        let result = DictationResult(
+            requestID: UUID(),
+            text: "must survive account switch",
+            engineIdentifier: "test"
+        )
+        try store.saveResult(result)
+        let uploaded = try XCTUnwrap(try store.textRecordsNeedingSync().first)
+        XCTAssertTrue(try store.markTextRecordSynced(
+            kind: .dictation,
+            recordName: uploaded.id,
+            changeTag: "old-account-tag",
+            systemFields: Data([8]),
+            recordUpdatedAt: uploaded.updatedAt
+        ))
+
+        try store.resetTextRecordCloudMetadataForAccountChange()
+
+        XCTAssertEqual(try store.resultsHistory().first?.text, "must survive account switch")
+        let requeued = try XCTUnwrap(try store.textRecordsNeedingSync().first)
+        XCTAssertNil(requeued.cloudChangeTag)
+        XCTAssertNil(requeued.cloudSystemFields)
+    }
+
+    func testMeetingUploadAcknowledgementDoesNotClearNewerTranscriptEdit() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = SharedStore(containerURL: directory)
+        let transcriptID = UUID()
+        let session = RecordingSession(
+            id: UUID(),
+            kind: .meeting,
+            title: "Sync race",
+            phase: .completed,
+            transcriptID: transcriptID,
+            engineIdentifier: "test",
+            source: "ios"
+        )
+        try store.saveSession(session)
+        try store.saveTranscript(Transcript(
+            id: transcriptID,
+            sessionID: session.id,
+            text: "first transcript",
+            engineIdentifier: "test"
+        ))
+        let uploaded = try XCTUnwrap(
+            try store.textRecordsNeedingSync().first { $0.kind == .meeting }
+        )
+
+        Thread.sleep(forTimeInterval: 0.01)
+        try store.saveTranscript(Transcript(
+            id: transcriptID,
+            sessionID: session.id,
+            text: "newer transcript",
+            engineIdentifier: "test"
+        ))
+
+        XCTAssertFalse(try store.markTextRecordSynced(
+            kind: .meeting,
+            recordName: uploaded.id,
+            changeTag: "stale-meeting-tag",
+            systemFields: Data([4]),
+            recordUpdatedAt: uploaded.updatedAt
+        ))
+        let pending = try XCTUnwrap(
+            try store.textRecordsNeedingSync().first { $0.kind == .meeting }
+        )
+        XCTAssertEqual(pending.text, "newer transcript")
+        XCTAssertNil(pending.cloudSystemFields)
+    }
+
+    func testFetchedMeetingChecksTranscriptTimestampBeforeOverwriting() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = SharedStore(containerURL: directory)
+        let transcriptID = UUID()
+        let session = RecordingSession(
+            id: UUID(),
+            kind: .meeting,
+            title: "Transcript race",
+            phase: .completed,
+            transcriptID: transcriptID,
+            engineIdentifier: "test",
+            source: "ios"
+        )
+        try store.saveSession(session)
+        try store.saveTranscript(Transcript(
+            id: transcriptID,
+            sessionID: session.id,
+            text: "initial local transcript",
+            engineIdentifier: "test"
+        ))
+        let initial = try XCTUnwrap(
+            try store.textRecordsNeedingSync().first { $0.kind == .meeting }
+        )
+
+        Thread.sleep(forTimeInterval: 0.02)
+        try store.saveTranscript(Transcript(
+            id: transcriptID,
+            sessionID: session.id,
+            text: "newest local transcript",
+            engineIdentifier: "test"
+        ))
+        var remote = initial
+        remote.text = "intermediate server transcript"
+        remote.updatedAt = initial.updatedAt.addingTimeInterval(0.001)
+
+        XCTAssertFalse(try store.upsertSyncedTextRecord(remote))
+        XCTAssertEqual(try store.transcript(for: session.id)?.text, "newest local transcript")
+        XCTAssertTrue(try store.hasTextRecordsNeedingSync())
     }
 
     func testSyncedDictationPreservesLocalSessionLink() throws {
@@ -1354,7 +1598,7 @@ final class SharedStoreTests: XCTestCase {
         XCTAssertEqual(try store.recordingSessions(), [expectedSession])
         XCTAssertEqual(try store.transcript(for: session.id), transcript)
         XCTAssertEqual(try store.customWords(), [customWord])
-        XCTAssertEqual(try sqliteInt("PRAGMA user_version", in: directory), 4)
+        XCTAssertEqual(try sqliteInt("PRAGMA user_version", in: directory), 5)
         XCTAssertEqual(try sqliteString("SELECT text FROM result_history LIMIT 1", in: directory), "legacy sqlite dictation")
         XCTAssertEqual(try sqliteString("SELECT audio_file_name FROM recording_sessions LIMIT 1", in: directory), "legacy.wav")
         XCTAssertEqual(try sqliteString("SELECT summary_text FROM transcripts LIMIT 1", in: directory), "Legacy notes")

--- a/Tests/MuesliTests/SharedStoreTests.swift
+++ b/Tests/MuesliTests/SharedStoreTests.swift
@@ -467,6 +467,95 @@ final class SharedStoreTests: XCTestCase {
         XCTAssertNil(try store.cloudSyncStateData(forKey: "private-zone"))
     }
 
+    func testDictationSyncRecordsIncludeLinkedSessionTiming() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = SharedStore(containerURL: directory)
+        let startedAt = Date(timeIntervalSince1970: 100)
+        let endedAt = Date(timeIntervalSince1970: 145)
+        let session = RecordingSession(
+            kind: .quickDictation,
+            startedAt: startedAt,
+            endedAt: endedAt,
+            phase: .completed,
+            source: "ios"
+        )
+        try store.saveSession(session)
+        let result = DictationResult(
+            requestID: UUID(),
+            sessionID: session.id,
+            text: "timed sync record",
+            engineIdentifier: "test"
+        )
+        try store.saveResult(result)
+
+        let dirty = try XCTUnwrap(try store.textRecordsNeedingSync().first)
+        let current = try XCTUnwrap(
+            try store.textRecordsForSync(recordNames: [dirty.id])[dirty.id]
+        )
+        let migration = try XCTUnwrap(
+            try store.textRecordsForSyncMigration().first { $0.id == dirty.id }
+        )
+
+        for record in [dirty, current, migration] {
+            XCTAssertEqual(record.startedAt, startedAt)
+            XCTAssertEqual(record.endedAt, endedAt)
+            XCTAssertEqual(record.durationSeconds, 45, accuracy: 0.001)
+        }
+    }
+
+    func testDictationTimingRepairRequeuesOnlyRecoverableRowsOnce() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = SharedStore(containerURL: directory)
+        let session = RecordingSession(
+            kind: .quickDictation,
+            startedAt: Date(timeIntervalSince1970: 100),
+            endedAt: Date(timeIntervalSince1970: 130),
+            phase: .completed,
+            source: "ios"
+        )
+        try store.saveSession(session)
+        let timed = DictationResult(
+            requestID: UUID(),
+            sessionID: session.id,
+            text: "recoverable timing",
+            engineIdentifier: "test"
+        )
+        let legacy = DictationResult(
+            requestID: UUID(),
+            text: "no linked timing",
+            engineIdentifier: "test"
+        )
+        try store.saveResult(timed)
+        try store.saveResult(legacy)
+
+        for record in try store.textRecordsNeedingSync() where record.kind == .dictation {
+            XCTAssertTrue(try store.markTextRecordSynced(
+                kind: .dictation,
+                recordName: record.id,
+                changeTag: "saved-tag",
+                systemFields: Data([1]),
+                recordUpdatedAt: record.updatedAt
+            ))
+        }
+        XCTAssertFalse(try store.hasTextRecordsNeedingSync())
+
+        XCTAssertEqual(
+            try store.requeueDictationsWithRecoverableTimingIfNeeded(repairKey: "timing-v1"),
+            1
+        )
+        let requeued = try store.textRecordsNeedingSync()
+        XCTAssertEqual(requeued.map(\.id), [timed.id.uuidString])
+        XCTAssertEqual(try XCTUnwrap(requeued.first).durationSeconds, 30, accuracy: 0.001)
+
+        XCTAssertEqual(
+            try store.requeueDictationsWithRecoverableTimingIfNeeded(repairKey: "timing-v1"),
+            0
+        )
+        XCTAssertEqual(try store.textRecordsNeedingSync().map(\.id), [timed.id.uuidString])
+    }
+
     func testSyncRecordBatchLookupIncludesCloudSystemFields() throws {
         let directory = try makeTemporaryDirectory()
         defer { try? FileManager.default.removeItem(at: directory) }

--- a/Tests/MuesliTests/VoiceNotePresentationPerformanceTests.swift
+++ b/Tests/MuesliTests/VoiceNotePresentationPerformanceTests.swift
@@ -36,8 +36,7 @@ final class VoiceNotePresentationPerformanceTests: XCTestCase {
         XCTAssertEqual(VoiceNoteElapsedClock.publishedSeconds(elapsed: -5), 0)
     }
 
-    @MainActor
-    func testTimelineCacheRebuildsOnlyForExactInputChanges() {
+    func testHistoryPresentationPrecomputesStableFilteredTimelines() {
         let requestID = UUID()
         let sessionID = UUID()
         let result = Muesli.DictationResult(
@@ -56,25 +55,64 @@ final class VoiceNotePresentationPerformanceTests: XCTestCase {
             phase: .completed,
             source: "ios"
         )
-        let input = VoiceNoteTimelineInput(
+        let presentation = VoiceNoteHistoryPresentation(
+            revision: 1,
             history: [result],
-            sessions: [session],
-            sourceFilter: .all
+            sessions: [session]
         )
-        let cache = VoiceNoteTimelineCache()
 
-        XCTAssertEqual(cache.items(for: input).count, 1)
-        XCTAssertEqual(cache.rebuildCount, 1)
-        XCTAssertEqual(cache.items(for: input).count, 1)
-        XCTAssertEqual(cache.rebuildCount, 1)
-
-        let filteredInput = VoiceNoteTimelineInput(
-            history: [result],
-            sessions: [session],
-            sourceFilter: .fromMac
+        XCTAssertEqual(presentation.timeline(for: .all).count, 1)
+        XCTAssertEqual(presentation.timeline(for: .thisIPhone).count, 1)
+        XCTAssertTrue(presentation.timeline(for: .fromMac).isEmpty)
+        XCTAssertTrue(presentation.matches(history: [result], sessions: [session]))
+        XCTAssertEqual(
+            presentation.updated(history: [result], sessions: [session]).revision,
+            presentation.revision
         )
-        XCTAssertTrue(cache.items(for: filteredInput).isEmpty)
-        XCTAssertEqual(cache.rebuildCount, 2)
+    }
+
+    func testLargeHistoryRemoteInsertionPreservesEveryExistingRowIdentity() {
+        let existing = (0..<2_600).map { index in
+            Muesli.DictationResult(
+                requestID: UUID(),
+                text: "Local note \(index)",
+                createdAt: Date(timeIntervalSinceReferenceDate: TimeInterval(index)),
+                engineIdentifier: "parakeet",
+                source: "ios"
+            )
+        }.reversed()
+        let before = VoiceNoteHistoryPresentation(
+            revision: 1,
+            history: Array(existing),
+            sessions: []
+        )
+        let remote = Muesli.DictationResult(
+            requestID: UUID(),
+            text: "New Mac note",
+            createdAt: Date(timeIntervalSinceReferenceDate: 3_000),
+            engineIdentifier: "icloud",
+            source: "macos"
+        )
+        let afterHistory = [remote] + Array(existing)
+        let after = VoiceNoteHistoryPresentation(
+            revision: 2,
+            history: afterHistory,
+            sessions: []
+        )
+
+        let beforeIDs = before.timeline(for: .all).map(\.id)
+        let afterIDs = after.timeline(for: .all).map(\.id)
+        XCTAssertEqual(afterIDs.count, 2_601)
+        XCTAssertEqual(Set(afterIDs).count, 2_601)
+        XCTAssertEqual(afterIDs.first, "result-\(remote.id.uuidString)")
+        XCTAssertEqual(Array(afterIDs.dropFirst()), beforeIDs)
+        XCTAssertEqual(after.timeline(for: .fromMac).map(\.id), [afterIDs[0]])
+        XCTAssertFalse(before.matches(history: afterHistory, sessions: []))
+        XCTAssertTrue(after.matches(history: afterHistory, sessions: []))
+        XCTAssertEqual(
+            before.updated(history: afterHistory, sessions: []).revision,
+            before.revision + 1
+        )
     }
 
     func testTimelineBuilderMergesRecoverableNotesByCreationDate() {


### PR DESCRIPTION
## Summary
- replace the manual iOS CloudKit cursor loop with a persistent, process-wide CKSyncEngine runtime
- standardize routing with macOS: committed local mutations send immediately, APNs/foreground fetch only, and manual sync sends then fetches
- keep SQLite dirty rows as the durable outbox and namespace serialized engine/account state by CloudKit environment
- add merged request intents, bounded background-fetch completion, startup convergence, automatic zone-loss recovery, cancellable CloudKit operations, and lifecycle-safe bridge refresh
- preserve conflict resolution, exact-version upload acknowledgements, size-aware batching, CloudKit system fields, and recoverable dictation timing repair
- fail closed across iCloud account changes: an unscoped legacy library is claimed only when every required stable record ID exists as a text record in the current private zone

## Validation
- focused CKSyncEngine tests passed: 43/43
- full local MuesliTests suite passed: 252/252
- local `build-for-testing` passed using the existing governed DerivedData cache
- GitHub simulator build plus unit/UI tests and coverage upload passed
- CodeRabbit, Socket Security, and Greptile passed
- Greptile confidence improved from 3/5 to **5/5** after the complete-provenance fix and reports no blocking finding
- branch already contains current `origin/main`

## Privacy and account safety
- CloudKit provenance requests use stable record IDs with `desiredKeys: []`; authored fields are never fetched for account proof
- raw CloudKit account/record identifiers and transcript content are never logged
- partial overlap, missing records, wrong record types, and incomplete responses cannot authorize a library
- diagnostics expose only aggregate phase/count/timestamp information and fixed error categories

## Companion change
The matching macOS implementation and historical WPM defense are in Muesli-HQ/muesli#393. Both platforms now share the same directional trigger, durable-outbox, cancellation, recovery, and account-boundary contract.

## Remaining physical soak
The prior Production-entitled two-way MuesliDev round trip passed. The final standardized heads still need one physical picophone/macOS Production-container latency and background-notification soak before release promotion.

## Known external check issue
The Claude Code Review workflow exits after initialization with `is_error:true` and no review findings or permission denials. The app build/tests and the other code-review/security bots are green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reliable iCloud text synchronization with background updates, conflict handling, account safety, and CloudKit recovery.
  * Sync progress, status updates, cancellation, and device refreshes are now better coordinated.
  * Added safer model preparation with validated background downloads and offline loading.
  * Improved dictation timing recovery and protection while models are downloading.

* **Bug Fixes**
  * Prevented stale sync callbacks and incomplete model files from affecting app state.
  * Improved handling of deleted records, account changes, and interrupted CloudKit operations.

* **Tests**
  * Expanded coverage for synchronization, migrations, conflicts, recovery, and model downloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->