### PR TITLE
Prevent repeating animations from replaying status transitions

### DIFF
--- a/Muesli/DictationView.swift
+++ b/Muesli/DictationView.swift
@@ -1236,6 +1236,7 @@ struct ICloudSyncStatusButton: View {
 
 private struct RotatingSyncGlyph: View {
     let isAnimating: Bool
+    @State private var animationStartedAt: Date?
 
     var body: some View {
         // Keep this rotation time-driven: a repeatForever animation transaction
@@ -1243,9 +1244,17 @@ private struct RotatingSyncGlyph: View {
         TimelineView(.animation(paused: !isAnimating)) { context in
             Image(systemName: "arrow.triangle.2.circlepath")
                 .rotationEffect(.degrees(ICloudSyncGlyphRotation.degrees(
-                    elapsed: context.date.timeIntervalSinceReferenceDate,
+                    at: context.date,
+                    startedAt: animationStartedAt,
                     isAnimating: isAnimating
                 )))
+                .animation(.easeOut(duration: 0.15), value: isAnimating)
+        }
+        .onAppear {
+            animationStartedAt = isAnimating ? .now : nil
+        }
+        .onChange(of: isAnimating) { _, isAnimating in
+            animationStartedAt = isAnimating ? .now : nil
         }
     }
 }
@@ -1253,8 +1262,9 @@ private struct RotatingSyncGlyph: View {
 enum ICloudSyncGlyphRotation {
     static let period: TimeInterval = 0.9
 
-    static func degrees(elapsed: TimeInterval, isAnimating: Bool) -> Double {
-        guard isAnimating else { return 0 }
+    static func degrees(at date: Date, startedAt: Date?, isAnimating: Bool) -> Double {
+        guard isAnimating, let startedAt else { return 0 }
+        let elapsed = max(date.timeIntervalSince(startedAt), 0)
         let phase = elapsed.truncatingRemainder(dividingBy: period) / period
         return phase * 360
     }

--- a/Muesli/DictationView.swift
+++ b/Muesli/DictationView.swift
@@ -320,6 +320,10 @@ struct DictationView: View {
                         Text(coordinator.statusText)
                             .font(MuesliTheme.callout())
                             .foregroundStyle(statusColor)
+                            .contentTransition(.identity)
+                            .transaction { transaction in
+                                transaction.animation = nil
+                            }
                     }
 
                     Spacer()
@@ -1232,35 +1236,27 @@ struct ICloudSyncStatusButton: View {
 
 private struct RotatingSyncGlyph: View {
     let isAnimating: Bool
-    @State private var rotationDegrees = 0.0
 
     var body: some View {
-        Image(systemName: "arrow.triangle.2.circlepath")
-            .rotationEffect(.degrees(rotationDegrees))
-            .onAppear {
-                updateRotation(animated: false)
-            }
-            .onChange(of: isAnimating) { _, _ in
-                updateRotation(animated: true)
-            }
+        // Keep this rotation time-driven: a repeatForever animation transaction
+        // can leak into sibling updates and replay the voice-note status transition.
+        TimelineView(.animation(paused: !isAnimating)) { context in
+            Image(systemName: "arrow.triangle.2.circlepath")
+                .rotationEffect(.degrees(ICloudSyncGlyphRotation.degrees(
+                    elapsed: context.date.timeIntervalSinceReferenceDate,
+                    isAnimating: isAnimating
+                )))
+        }
     }
+}
 
-    private func updateRotation(animated: Bool) {
-        guard isAnimating else {
-            if animated {
-                withAnimation(.easeOut(duration: 0.15)) {
-                    rotationDegrees = 0
-                }
-            } else {
-                rotationDegrees = 0
-            }
-            return
-        }
+enum ICloudSyncGlyphRotation {
+    static let period: TimeInterval = 0.9
 
-        rotationDegrees = 0
-        withAnimation(.linear(duration: 0.9).repeatForever(autoreverses: false)) {
-            rotationDegrees = 360
-        }
+    static func degrees(elapsed: TimeInterval, isAnimating: Bool) -> Double {
+        guard isAnimating else { return 0 }
+        let phase = elapsed.truncatingRemainder(dividingBy: period) / period
+        return phase * 360
     }
 }
 

--- a/Muesli/LaunchWarmupView.swift
+++ b/Muesli/LaunchWarmupView.swift
@@ -199,6 +199,7 @@ private extension ModelPreparationPhase {
 
 private struct WarmupPulseLine: View {
     let isAnimating: Bool
+    @State private var animationStartedAt: Date?
 
     var body: some View {
         // Keep the indefinite motion inside this leaf. A parent-owned
@@ -207,7 +208,8 @@ private struct WarmupPulseLine: View {
             GeometryReader { geometry in
                 let width = max(geometry.size.width, 1)
                 let progress = LaunchWarmupPulsePhase.progress(
-                    elapsed: context.date.timeIntervalSinceReferenceDate,
+                    at: context.date,
+                    startedAt: animationStartedAt,
                     isAnimating: isAnimating
                 )
 
@@ -233,15 +235,22 @@ private struct WarmupPulseLine: View {
             }
         }
         .clipShape(Capsule())
+        .onAppear {
+            animationStartedAt = isAnimating ? .now : nil
+        }
+        .onChange(of: isAnimating) { _, isAnimating in
+            animationStartedAt = isAnimating ? .now : nil
+        }
     }
 }
 
 enum LaunchWarmupPulsePhase {
     static let halfCycle: TimeInterval = 1.15
 
-    static func progress(elapsed: TimeInterval, isAnimating: Bool) -> Double {
-        guard isAnimating else { return 0 }
+    static func progress(at date: Date, startedAt: Date?, isAnimating: Bool) -> Double {
+        guard isAnimating, let startedAt else { return 0 }
 
+        let elapsed = max(date.timeIntervalSince(startedAt), 0)
         let cycle = halfCycle * 2
         let position = elapsed.truncatingRemainder(dividingBy: cycle)
         if position <= halfCycle {

--- a/Muesli/LaunchWarmupView.swift
+++ b/Muesli/LaunchWarmupView.swift
@@ -65,8 +65,6 @@ private struct LaunchWarmupView: View {
     let detail: String
     let modelName: String
 
-    @State private var isAnimating = false
-
     var body: some View {
         ZStack {
             background
@@ -90,19 +88,6 @@ private struct LaunchWarmupView: View {
                     .accessibilityHidden(true)
             }
             .ignoresSafeArea(.keyboard)
-        }
-        .task(id: phase) {
-            updateAnimation(for: phase)
-        }
-    }
-
-    private func updateAnimation(for phase: ModelPreparationPhase) {
-        if phase.isLaunchWarmupActive {
-            withAnimation(.linear(duration: 1.15).repeatForever(autoreverses: false)) {
-                isAnimating = true
-            }
-        } else {
-            isAnimating = false
         }
     }
 
@@ -166,7 +151,7 @@ private struct LaunchWarmupView: View {
             }
             .padding(.horizontal, MuesliTheme.spacing20)
 
-            WarmupPulseLine(isAnimating: isAnimating)
+            WarmupPulseLine(isAnimating: phase.isLaunchWarmupActive)
                 .frame(width: 176, height: 3)
                 .accessibilityHidden(true)
 
@@ -216,28 +201,52 @@ private struct WarmupPulseLine: View {
     let isAnimating: Bool
 
     var body: some View {
-        GeometryReader { geometry in
-            let width = max(geometry.size.width, 1)
-            ZStack(alignment: .leading) {
-                Capsule()
-                    .fill(.white.opacity(0.10))
+        // Keep the indefinite motion inside this leaf. A parent-owned
+        // repeatForever transaction can animate changing warmup copy too.
+        TimelineView(.animation(paused: !isAnimating)) { context in
+            GeometryReader { geometry in
+                let width = max(geometry.size.width, 1)
+                let progress = LaunchWarmupPulsePhase.progress(
+                    elapsed: context.date.timeIntervalSinceReferenceDate,
+                    isAnimating: isAnimating
+                )
 
-                Capsule()
-                    .fill(
-                        LinearGradient(
-                            colors: [
-                                MuesliTheme.brandBlue.opacity(0.25),
-                                MuesliTheme.syncGreen,
-                                MuesliTheme.brandBlue.opacity(0.25)
-                            ],
-                            startPoint: .leading,
-                            endPoint: .trailing
+                ZStack(alignment: .leading) {
+                    Capsule()
+                        .fill(.white.opacity(0.10))
+
+                    Capsule()
+                        .fill(
+                            LinearGradient(
+                                colors: [
+                                    MuesliTheme.brandBlue.opacity(0.25),
+                                    MuesliTheme.syncGreen,
+                                    MuesliTheme.brandBlue.opacity(0.25)
+                                ],
+                                startPoint: .leading,
+                                endPoint: .trailing
+                            )
                         )
-                    )
-                    .frame(width: width * 0.36)
-                    .offset(x: isAnimating ? width * 0.64 : 0)
+                        .frame(width: width * 0.36)
+                        .offset(x: width * 0.64 * progress)
+                }
             }
         }
         .clipShape(Capsule())
+    }
+}
+
+enum LaunchWarmupPulsePhase {
+    static let halfCycle: TimeInterval = 1.15
+
+    static func progress(elapsed: TimeInterval, isAnimating: Bool) -> Double {
+        guard isAnimating else { return 0 }
+
+        let cycle = halfCycle * 2
+        let position = elapsed.truncatingRemainder(dividingBy: cycle)
+        if position <= halfCycle {
+            return position / halfCycle
+        }
+        return (cycle - position) / halfCycle
     }
 }

--- a/Tests/MuesliTests/ICloudSyncStatusPresentationTests.swift
+++ b/Tests/MuesliTests/ICloudSyncStatusPresentationTests.swift
@@ -3,23 +3,48 @@ import XCTest
 
 final class ICloudSyncStatusPresentationTests: XCTestCase {
     func testSyncGlyphRotationStopsAtRest() {
+        let startedAt = Date(timeIntervalSinceReferenceDate: 100)
+
         XCTAssertEqual(
-            ICloudSyncGlyphRotation.degrees(elapsed: 123.45, isAnimating: false),
+            ICloudSyncGlyphRotation.degrees(
+                at: startedAt.addingTimeInterval(0.4),
+                startedAt: startedAt,
+                isAnimating: false
+            ),
             0
         )
     }
 
-    func testSyncGlyphRotationUsesAContinuousTimePhase() {
+    func testSyncGlyphRotationStartsAtRest() {
+        let startedAt = Date(timeIntervalSinceReferenceDate: 100)
+
+        XCTAssertEqual(
+            ICloudSyncGlyphRotation.degrees(
+                at: startedAt,
+                startedAt: startedAt,
+                isAnimating: true
+            ),
+            0
+        )
+    }
+
+    func testSyncGlyphRotationUsesTimeSinceActivation() {
+        let startedAt = Date(timeIntervalSinceReferenceDate: 100)
         let quarterTurn = ICloudSyncGlyphRotation.period / 4
 
         XCTAssertEqual(
-            ICloudSyncGlyphRotation.degrees(elapsed: quarterTurn, isAnimating: true),
+            ICloudSyncGlyphRotation.degrees(
+                at: startedAt.addingTimeInterval(quarterTurn),
+                startedAt: startedAt,
+                isAnimating: true
+            ),
             90,
             accuracy: 0.0001
         )
         XCTAssertEqual(
             ICloudSyncGlyphRotation.degrees(
-                elapsed: ICloudSyncGlyphRotation.period + quarterTurn,
+                at: startedAt.addingTimeInterval(ICloudSyncGlyphRotation.period + quarterTurn),
+                startedAt: startedAt,
                 isAnimating: true
             ),
             90,

--- a/Tests/MuesliTests/ICloudSyncStatusPresentationTests.swift
+++ b/Tests/MuesliTests/ICloudSyncStatusPresentationTests.swift
@@ -1,0 +1,29 @@
+import XCTest
+@testable import Muesli
+
+final class ICloudSyncStatusPresentationTests: XCTestCase {
+    func testSyncGlyphRotationStopsAtRest() {
+        XCTAssertEqual(
+            ICloudSyncGlyphRotation.degrees(elapsed: 123.45, isAnimating: false),
+            0
+        )
+    }
+
+    func testSyncGlyphRotationUsesAContinuousTimePhase() {
+        let quarterTurn = ICloudSyncGlyphRotation.period / 4
+
+        XCTAssertEqual(
+            ICloudSyncGlyphRotation.degrees(elapsed: quarterTurn, isAnimating: true),
+            90,
+            accuracy: 0.0001
+        )
+        XCTAssertEqual(
+            ICloudSyncGlyphRotation.degrees(
+                elapsed: ICloudSyncGlyphRotation.period + quarterTurn,
+                isAnimating: true
+            ),
+            90,
+            accuracy: 0.0001
+        )
+    }
+}

--- a/Tests/MuesliTests/LaunchWarmupPresentationTests.swift
+++ b/Tests/MuesliTests/LaunchWarmupPresentationTests.swift
@@ -1,0 +1,36 @@
+import XCTest
+@testable import Muesli
+
+final class LaunchWarmupPresentationTests: XCTestCase {
+    func testPulseStopsAtItsRestingPosition() {
+        XCTAssertEqual(
+            LaunchWarmupPulsePhase.progress(elapsed: 123.45, isAnimating: false),
+            0
+        )
+    }
+
+    func testPulseUsesAContinuousReversingTimePhase() {
+        let halfCycle = LaunchWarmupPulsePhase.halfCycle
+
+        XCTAssertEqual(
+            LaunchWarmupPulsePhase.progress(elapsed: halfCycle / 2, isAnimating: true),
+            0.5,
+            accuracy: 0.0001
+        )
+        XCTAssertEqual(
+            LaunchWarmupPulsePhase.progress(elapsed: halfCycle, isAnimating: true),
+            1,
+            accuracy: 0.0001
+        )
+        XCTAssertEqual(
+            LaunchWarmupPulsePhase.progress(elapsed: halfCycle * 1.5, isAnimating: true),
+            0.5,
+            accuracy: 0.0001
+        )
+        XCTAssertEqual(
+            LaunchWarmupPulsePhase.progress(elapsed: halfCycle * 2, isAnimating: true),
+            0,
+            accuracy: 0.0001
+        )
+    }
+}

--- a/Tests/MuesliTests/LaunchWarmupPresentationTests.swift
+++ b/Tests/MuesliTests/LaunchWarmupPresentationTests.swift
@@ -3,32 +3,68 @@ import XCTest
 
 final class LaunchWarmupPresentationTests: XCTestCase {
     func testPulseStopsAtItsRestingPosition() {
+        let startedAt = Date(timeIntervalSinceReferenceDate: 100)
+
         XCTAssertEqual(
-            LaunchWarmupPulsePhase.progress(elapsed: 123.45, isAnimating: false),
+            LaunchWarmupPulsePhase.progress(
+                at: startedAt.addingTimeInterval(0.4),
+                startedAt: startedAt,
+                isAnimating: false
+            ),
             0
         )
     }
 
-    func testPulseUsesAContinuousReversingTimePhase() {
+    func testPulseStartsAtItsLeadingEdge() {
+        let startedAt = Date(timeIntervalSinceReferenceDate: 100)
+
+        XCTAssertEqual(
+            LaunchWarmupPulsePhase.progress(
+                at: startedAt,
+                startedAt: startedAt,
+                isAnimating: true
+            ),
+            0
+        )
+    }
+
+    func testPulseUsesAReversingPhaseSinceActivation() {
+        let startedAt = Date(timeIntervalSinceReferenceDate: 100)
         let halfCycle = LaunchWarmupPulsePhase.halfCycle
 
         XCTAssertEqual(
-            LaunchWarmupPulsePhase.progress(elapsed: halfCycle / 2, isAnimating: true),
+            LaunchWarmupPulsePhase.progress(
+                at: startedAt.addingTimeInterval(halfCycle / 2),
+                startedAt: startedAt,
+                isAnimating: true
+            ),
             0.5,
             accuracy: 0.0001
         )
         XCTAssertEqual(
-            LaunchWarmupPulsePhase.progress(elapsed: halfCycle, isAnimating: true),
+            LaunchWarmupPulsePhase.progress(
+                at: startedAt.addingTimeInterval(halfCycle),
+                startedAt: startedAt,
+                isAnimating: true
+            ),
             1,
             accuracy: 0.0001
         )
         XCTAssertEqual(
-            LaunchWarmupPulsePhase.progress(elapsed: halfCycle * 1.5, isAnimating: true),
+            LaunchWarmupPulsePhase.progress(
+                at: startedAt.addingTimeInterval(halfCycle * 1.5),
+                startedAt: startedAt,
+                isAnimating: true
+            ),
             0.5,
             accuracy: 0.0001
         )
         XCTAssertEqual(
-            LaunchWarmupPulsePhase.progress(elapsed: halfCycle * 2, isAnimating: true),
+            LaunchWarmupPulsePhase.progress(
+                at: startedAt.addingTimeInterval(halfCycle * 2),
+                startedAt: startedAt,
+                isAnimating: true
+            ),
             0,
             accuracy: 0.0001
         )


### PR DESCRIPTION
## Summary
- replace the iCloud sync glyph's parent-visible `repeatForever` transaction with a time-driven leaf animation
- prevent the voice-note status label from inheriting animation transactions
- make the launch warmup pulse time-driven so changing preparation status/detail copy remains stable
- add deterministic phase tests for both indefinite animations

## Root cause
The captured `Transcription complete` / `Ready` ghosting recurred every 0.9 seconds, exactly matching the sync glyph rotation period. The repeating SwiftUI transaction could be replayed while adjacent observable status text changed. The launch warmup pulse used the same parent-owned pattern around changing copy. Both animations now derive their visual phase from `TimelineView` inside the animated leaf.

## Validation
- focused presentation tests: 4 passed
- complete `MuesliTests` suite: 263 passed, 0 failures
- `git diff --check` clean

No transcription, CloudKit, model-download, app-data, or permissions behavior is changed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli-ios/pr/35"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789494699&installation_model_id=422865&pr_number=35&repository=Muesli-HQ%2Fmuesli-ios&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli-ios%2Fpull%2F35&signature=16e51cb9ae3f3590ac972249c04cce759fcc9a4d21a4dda55075636cac6ff10a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved recorder sync and launch warm-up animations for smoother, more consistent visual updates.
  - Animations now pause reliably when inactive and avoid unintended content transitions.
  - Refined rotation and pulse timing for predictable, continuous motion.

- **Tests**
  - Added coverage for sync indicator rotation, including inactive, quarter-turn, and full-cycle behavior.
  - Added coverage for launch warm-up pulse timing, activation, reversing motion, and resting positions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->