### PR TITLE
Add an isolated iOS MuesliDev build lane

### DIFF
--- a/Muesli/AppTelemetry.swift
+++ b/Muesli/AppTelemetry.swift
@@ -61,6 +61,19 @@ enum AppTelemetryParameterSanitizer {
     }
 }
 
+enum AppTelemetryConfiguration {
+    static func isEnabled(_ configuredValue: Any?) -> Bool {
+        if let enabled = configuredValue as? Bool {
+            return enabled
+        }
+        guard let configured = configuredValue as? String else {
+            return configuredValue == nil
+        }
+        let normalized = configured.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return ["true", "yes", "1"].contains(normalized)
+    }
+}
+
 @MainActor
 enum AppTelemetry {
     private static let appIDInfoKey = "MuesliTelemetryDeckAppID"
@@ -136,13 +149,9 @@ enum AppTelemetry {
     }
 
     private static var telemetryIsEnabled: Bool {
-        if let enabled = Bundle.main.object(forInfoDictionaryKey: telemetryEnabledInfoKey) as? Bool {
-            return enabled
-        }
-        guard let configured = Bundle.main.object(forInfoDictionaryKey: telemetryEnabledInfoKey) as? String else {
-            return true
-        }
-        return !["false", "no", "0"].contains(configured.lowercased())
+        AppTelemetryConfiguration.isEnabled(
+            Bundle.main.object(forInfoDictionaryKey: telemetryEnabledInfoKey)
+        )
     }
 
     private static func runtimeParameters() -> [String: String] {

--- a/Muesli/AppTelemetry.swift
+++ b/Muesli/AppTelemetry.swift
@@ -64,6 +64,7 @@ enum AppTelemetryParameterSanitizer {
 @MainActor
 enum AppTelemetry {
     private static let appIDInfoKey = "MuesliTelemetryDeckAppID"
+    private static let telemetryEnabledInfoKey = "MuesliTelemetryEnabled"
     private static let fallbackAppID = "A851C6BD-4F55-41ED-A6BC-DA43C850B069"
     private static var isInitialized = false
 
@@ -121,6 +122,7 @@ enum AppTelemetry {
     @discardableResult
     private static func initializeIfNeeded() -> Bool {
         if isInitialized { return true }
+        guard telemetryIsEnabled else { return false }
 
         let configuredAppID = Bundle.main.object(forInfoDictionaryKey: appIDInfoKey) as? String
         let trimmedAppID = configuredAppID?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
@@ -131,6 +133,16 @@ enum AppTelemetry {
         TelemetryDeck.initialize(config: .init(appID: appID))
         isInitialized = true
         return true
+    }
+
+    private static var telemetryIsEnabled: Bool {
+        if let enabled = Bundle.main.object(forInfoDictionaryKey: telemetryEnabledInfoKey) as? Bool {
+            return enabled
+        }
+        guard let configured = Bundle.main.object(forInfoDictionaryKey: telemetryEnabledInfoKey) as? String else {
+            return true
+        }
+        return !["false", "no", "0"].contains(configured.lowercased())
     }
 
     private static func runtimeParameters() -> [String: String] {

--- a/Muesli/ChatGPTAuthManager.swift
+++ b/Muesli/ChatGPTAuthManager.swift
@@ -48,7 +48,7 @@ final class ChatGPTAuthManager: NSObject, ASWebAuthenticationPresentationContext
     private static let redirectURI = "http://localhost:1455/auth/callback"
     private static let scopes = "openid profile email offline_access"
     private static let callbackTimeoutSeconds: TimeInterval = 300
-    private static let keychainService = "com.phequals7.muesli.ios.chatgpt-auth"
+    private static let keychainService = "\(MuesliAppConstants.bundleIdentifier).chatgpt-auth"
 
     private let keychain = KeychainStore(service: keychainService)
     private var activeSession: ASWebAuthenticationSession?

--- a/Muesli/Info.plist
+++ b/Muesli/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
-	<string>Muesli</string>
+	<string>$(MUESLI_DISPLAY_NAME)</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
@@ -22,10 +22,10 @@
 	<array>
 		<dict>
 			<key>CFBundleURLName</key>
-			<string>com.phequals7.muesli.ios</string>
+			<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
-				<string>muesli</string>
+				<string>$(MUESLI_URL_SCHEME)</string>
 			</array>
 		</dict>
 	</array>
@@ -39,6 +39,14 @@
 	<true/>
 	<key>MuesliTelemetryDeckAppID</key>
 	<string>$(MUESLI_TELEMETRYDECK_APP_ID)</string>
+	<key>MuesliTelemetryEnabled</key>
+	<string>$(MUESLI_TELEMETRY_ENABLED)</string>
+	<key>MuesliAppGroupIdentifier</key>
+	<string>$(MUESLI_APP_GROUP_IDENTIFIER)</string>
+	<key>MuesliCrossProcessPrefix</key>
+	<string>$(MUESLI_CROSS_PROCESS_PREFIX)</string>
+	<key>MuesliURLScheme</key>
+	<string>$(MUESLI_URL_SCHEME)</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Muesli records your voice so it can transcribe speech into text on device.</string>
 	<key>NSCameraUsageDescription</key>

--- a/Muesli/MeetingSummaryClient.swift
+++ b/Muesli/MeetingSummaryClient.swift
@@ -26,7 +26,7 @@ enum MeetingSummaryClient {
     private static let openRouterURL = URL(string: "https://openrouter.ai/api/v1/chat/completions")!
     private static let whamURL = URL(string: "https://chatgpt.com/backend-api/wham/responses")!
     private static let maxOutputTokens = 2500
-    private static let keychain = KeychainStore(service: "com.phequals7.muesli.ios.summary")
+    private static let keychain = KeychainStore(service: "\(MuesliAppConstants.bundleIdentifier).summary")
 
     private static let baseSummaryInstructions = """
     You are a meeting notes assistant. Given a raw meeting transcript, produce concise, professional markdown notes.

--- a/Muesli/MuesliDev.entitlements
+++ b/Muesli/MuesliDev.entitlements
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.com.phequals7.muesli.dev</string>
+	</array>
+	<key>aps-environment</key>
+	<string>development</string>
+	<key>com.apple.developer.icloud-container-identifiers</key>
+	<array>
+		<string>iCloud.com.mueslihq.muesli</string>
+	</array>
+	<key>com.apple.developer.icloud-container-environment</key>
+	<string>Development</string>
+	<key>com.apple.developer.icloud-services</key>
+	<array>
+		<string>CloudKit</string>
+	</array>
+</dict>
+</plist>

--- a/MuesliKeyboard/Info.plist
+++ b/MuesliKeyboard/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
-	<string>Muesli</string>
+	<string>$(MUESLI_DISPLAY_NAME)</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
@@ -20,6 +20,12 @@
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>MuesliAppGroupIdentifier</key>
+	<string>$(MUESLI_APP_GROUP_IDENTIFIER)</string>
+	<key>MuesliCrossProcessPrefix</key>
+	<string>$(MUESLI_CROSS_PROCESS_PREFIX)</string>
+	<key>MuesliURLScheme</key>
+	<string>$(MUESLI_URL_SCHEME)</string>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/Shared/AppConstants.swift
+++ b/Shared/AppConstants.swift
@@ -1,8 +1,19 @@
 import Foundation
 
 enum MuesliAppConstants {
-    static let appGroupIdentifier = "group.com.phequals7.muesli"
-    static let urlScheme = "muesli"
+    static let bundleIdentifier = Bundle.main.bundleIdentifier ?? "com.phequals7.muesli.ios"
+    static let appGroupIdentifier = configuredValue(
+        forInfoDictionaryKey: "MuesliAppGroupIdentifier",
+        fallback: "group.com.phequals7.muesli"
+    )
+    static let crossProcessPrefix = configuredValue(
+        forInfoDictionaryKey: "MuesliCrossProcessPrefix",
+        fallback: "com.phequals7.muesli"
+    )
+    static let urlScheme = configuredValue(
+        forInfoDictionaryKey: "MuesliURLScheme",
+        fallback: "muesli"
+    )
     static let dictateHost = "dictate"
     static let syncHost = "sync"
     static let settingsHost = "settings"
@@ -23,4 +34,15 @@ enum MuesliAppConstants {
     static let startAction = "start"
     static let stopAction = "stop"
     static let cancelAction = "cancel"
+
+    private static func configuredValue(forInfoDictionaryKey key: String, fallback: String) -> String {
+        guard let value = Bundle.main.object(forInfoDictionaryKey: key) as? String else {
+            return fallback
+        }
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, !trimmed.hasPrefix("$(") else {
+            return fallback
+        }
+        return trimmed
+    }
 }

--- a/Shared/CrossProcessEventBus.swift
+++ b/Shared/CrossProcessEventBus.swift
@@ -10,7 +10,7 @@ enum CrossProcessEvent: String, CaseIterable, Sendable {
     case ownershipChanged = "ownership.changed"
 
     var notificationName: String {
-        "com.phequals7.muesli.\(rawValue).v1"
+        "\(MuesliAppConstants.crossProcessPrefix).\(rawValue).v1"
     }
 
     init?(notificationName: String) {

--- a/Tests/MuesliTests/AppTelemetryTests.swift
+++ b/Tests/MuesliTests/AppTelemetryTests.swift
@@ -2,6 +2,27 @@ import XCTest
 @testable import Muesli
 
 final class AppTelemetryTests: XCTestCase {
+    func testTelemetryDefaultsToEnabledWhenConfigurationIsAbsent() {
+        XCTAssertTrue(AppTelemetryConfiguration.isEnabled(nil))
+    }
+
+    func testTelemetryRecognizesExplicitTruthyValues() {
+        XCTAssertTrue(AppTelemetryConfiguration.isEnabled(true))
+        XCTAssertTrue(AppTelemetryConfiguration.isEnabled("YES"))
+        XCTAssertTrue(AppTelemetryConfiguration.isEnabled(" true "))
+        XCTAssertTrue(AppTelemetryConfiguration.isEnabled("1"))
+    }
+
+    func testTelemetryFailsClosedForFalseAndMalformedValues() {
+        XCTAssertFalse(AppTelemetryConfiguration.isEnabled(false))
+        XCTAssertFalse(AppTelemetryConfiguration.isEnabled("NO"))
+        XCTAssertFalse(AppTelemetryConfiguration.isEnabled("false"))
+        XCTAssertFalse(AppTelemetryConfiguration.isEnabled("0"))
+        XCTAssertFalse(AppTelemetryConfiguration.isEnabled("$(MUESLI_TELEMETRY_ENABLED)"))
+        XCTAssertFalse(AppTelemetryConfiguration.isEnabled("typo"))
+        XCTAssertFalse(AppTelemetryConfiguration.isEnabled(1))
+    }
+
     func testParameterKeysAreLowercasedSanitizedAndTruncated() {
         let rawKey = "Error Type / With Spaces / And Symbols " + String(repeating: "x", count: 80)
 

--- a/project.yml
+++ b/project.yml
@@ -7,6 +7,11 @@ options:
   generateEmptyDirectories: true
   groupSortPosition: top
 
+configs:
+  Debug: debug
+  Release: release
+  MuesliDev: debug
+
 settings:
   base:
     SWIFT_VERSION: "6.0"
@@ -18,6 +23,11 @@ settings:
     MARKETING_VERSION: "0.1.5"
     CURRENT_PROJECT_VERSION: "11"
     ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS: true
+    MUESLI_APP_GROUP_IDENTIFIER: group.com.phequals7.muesli
+    MUESLI_CROSS_PROCESS_PREFIX: com.phequals7.muesli
+    MUESLI_DISPLAY_NAME: Muesli
+    MUESLI_TELEMETRY_ENABLED: YES
+    MUESLI_URL_SCHEME: muesli
 
 packages:
   FluidAudio:
@@ -49,6 +59,39 @@ targets:
     dependencies:
       - target: MuesliKeyboard
       - target: MuesliLiveActivityExtension
+      - package: FluidAudio
+      - package: TelemetryDeck
+      - package: WhisperKit
+      - sdk: libsqlite3.tbd
+
+  # Side-by-side physical-device lane for validating changes against the
+  # Development CloudKit environment without replacing the TestFlight app/data.
+  # Extensions stay out of this target because their separate dev App IDs and
+  # profiles are not required for app/sync validation.
+  MuesliDev:
+    type: application
+    platform: iOS
+    sources:
+      - path: Muesli
+      - path: Shared
+      - path: LiveActivityShared
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.phequals7.muesli.ios.dev
+        PRODUCT_NAME: MuesliDev
+        INFOPLIST_FILE: Muesli/Info.plist
+        CODE_SIGN_ENTITLEMENTS: Muesli/MuesliDev.entitlements
+        CODE_SIGN_IDENTITY: Apple Development
+        CODE_SIGN_STYLE: Manual
+        ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
+        MUESLI_APP_GROUP_IDENTIFIER: group.com.phequals7.muesli.dev
+        MUESLI_CROSS_PROCESS_PREFIX: com.phequals7.muesli.dev
+        MUESLI_DISPLAY_NAME: MuesliDev
+        MUESLI_TELEMETRYDECK_APP_ID: disabled
+        MUESLI_TELEMETRY_ENABLED: NO
+        MUESLI_URL_SCHEME: mueslidev
+        PROVISIONING_PROFILE_SPECIFIER: muesli-ios-mueslidev-cloudkit-push
+    dependencies:
       - package: FluidAudio
       - package: TelemetryDeck
       - package: WhisperKit
@@ -140,6 +183,13 @@ schemes:
         - MuesliUITests
     archive:
       config: Release
+
+  MuesliDev:
+    build:
+      targets:
+        MuesliDev: all
+    run:
+      config: MuesliDev
 
   MuesliKeyboard:
     build:

--- a/scripts/ios-dev-test.sh
+++ b/scripts/ios-dev-test.sh
@@ -13,7 +13,6 @@ set -euo pipefail
 #   ./scripts/ios-dev-test.sh --reset --reset-permissions
 #   ./scripts/ios-dev-test.sh --device-id 00008140-001C6D2C11FA801C --reset
 
-ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SCHEME="${MUESLI_IOS_SCHEME:-Muesli}"
 CONFIGURATION="${MUESLI_IOS_CONFIGURATION:-Debug}"
 BUNDLE_ID="${MUESLI_IOS_BUNDLE_ID:-com.phequals7.muesli.ios}"

--- a/scripts/ios-dev-test.sh
+++ b/scripts/ios-dev-test.sh
@@ -8,13 +8,16 @@ set -euo pipefail
 #
 # Usage:
 #   ./scripts/ios-dev-test.sh
+#   ./scripts/ios-dev-test.sh --dev
 #   ./scripts/ios-dev-test.sh --reset
 #   ./scripts/ios-dev-test.sh --reset --reset-permissions
 #   ./scripts/ios-dev-test.sh --device-id 00008140-001C6D2C11FA801C --reset
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SCHEME="${MUESLI_IOS_SCHEME:-Muesli}"
+CONFIGURATION="${MUESLI_IOS_CONFIGURATION:-Debug}"
 BUNDLE_ID="${MUESLI_IOS_BUNDLE_ID:-com.phequals7.muesli.ios}"
+PRODUCT_NAME="${MUESLI_IOS_PRODUCT_NAME:-Muesli}"
 SIMULATOR_NAME="${MUESLI_IOS_SIMULATOR_NAME:-iPhone 17 Pro}"
 SIMULATOR_OS="${MUESLI_IOS_SIMULATOR_OS:-26.5}"
 DEVICE_ID="${MUESLI_IOS_DEVICE_ID:-}"
@@ -32,6 +35,7 @@ Options:
   --simulator-name NAME   Simulator name. Default: iPhone 17 Pro
   --simulator-os VERSION  Simulator OS. Default: 26.5
   --device-id ID          Install on a connected iPhone instead of simulator.
+  --dev                   Use the isolated, Development-CloudKit MuesliDev app.
   --reset                 Reset onboarding progress via debug launch argument.
   --reset-permissions     Reset simulator privacy permissions. Physical iPhone
                           privacy permissions cannot be reset non-destructively.
@@ -66,6 +70,13 @@ while [[ $# -gt 0 ]]; do
       DEVICE_ID="$2"
       shift 2
       ;;
+    --dev)
+      SCHEME="MuesliDev"
+      CONFIGURATION="MuesliDev"
+      BUNDLE_ID="com.phequals7.muesli.ios.dev"
+      PRODUCT_NAME="MuesliDev"
+      shift
+      ;;
     --reset)
       RESET_ONBOARDING=1
       shift
@@ -93,12 +104,12 @@ command -v xcrun >/dev/null 2>&1 || die "xcrun is required."
 
 if [[ -z "$DEVICE_ID" ]]; then
   DESTINATION="platform=iOS Simulator,name=${SIMULATOR_NAME},OS=${SIMULATOR_OS}"
-  PRODUCT_DIR="$DERIVED_DATA/Build/Products/Debug-iphonesimulator"
-  APP_PATH="$PRODUCT_DIR/Muesli.app"
+  PRODUCT_DIR="$DERIVED_DATA/Build/Products/$CONFIGURATION-iphonesimulator"
+  APP_PATH="$PRODUCT_DIR/$PRODUCT_NAME.app"
 
   if [[ "$SKIP_BUILD" -ne 1 ]]; then
     log "Building $SCHEME for simulator: $SIMULATOR_NAME ($SIMULATOR_OS)"
-    xcodebuild build -scheme "$SCHEME" -destination "$DESTINATION" -derivedDataPath "$DERIVED_DATA"
+    xcodebuild build -scheme "$SCHEME" -configuration "$CONFIGURATION" -destination "$DESTINATION" -derivedDataPath "$DERIVED_DATA"
   fi
 
   [[ -d "$APP_PATH" ]] || die "App product not found at $APP_PATH"
@@ -121,12 +132,12 @@ if [[ -z "$DEVICE_ID" ]]; then
   fi
 else
   DESTINATION="id=${DEVICE_ID}"
-  PRODUCT_DIR="$DERIVED_DATA/Build/Products/Debug-iphoneos"
-  APP_PATH="$PRODUCT_DIR/Muesli.app"
+  PRODUCT_DIR="$DERIVED_DATA/Build/Products/$CONFIGURATION-iphoneos"
+  APP_PATH="$PRODUCT_DIR/$PRODUCT_NAME.app"
 
   if [[ "$SKIP_BUILD" -ne 1 ]]; then
     log "Building $SCHEME for device: $DEVICE_ID"
-    xcodebuild build -scheme "$SCHEME" -destination "$DESTINATION" -derivedDataPath "$DERIVED_DATA"
+    xcodebuild build -scheme "$SCHEME" -configuration "$CONFIGURATION" -destination "$DESTINATION" -derivedDataPath "$DERIVED_DATA"
   fi
 
   [[ -d "$APP_PATH" ]] || die "App product not found at $APP_PATH"


### PR DESCRIPTION
## Summary
- add a side-by-side MuesliDev iOS target and scheme with an isolated bundle ID, app group, URL scheme, cross-process notifications, and keychain services
- keep MuesliDev in the CloudKit Development environment; TestFlight and App Store Muesli remain the only Production CloudKit builds
- extend the existing iOS device/simulator script with an explicit --dev lane while preserving app data by default
- disable telemetry in MuesliDev and leave the official app defaults unchanged

## Scope
MuesliDev intentionally excludes separate keyboard and Live Activity development extensions. This lane is for app and sync validation without replacing the installed TestFlight app or its local data.

## Validation
- xcodegen project generation succeeded
- property-list and entitlement validation succeeded
- official Muesli generic-device build succeeded
- MuesliDev generic-device build succeeded using the existing DerivedData cache
- signed MuesliDev artifact confirms bundle com.phequals7.muesli.ios.dev, app group group.com.phequals7.muesli.dev, and CloudKit environment Development
- git diff checks passed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Muesli-HQ/codesmith/muesli-ios/pr/36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789884324&installation_model_id=422865&pr_number=36&repository=Muesli-HQ%2Fmuesli-ios&return_to=https%3A%2F%2Fgithub.com%2FMuesli-HQ%2Fmuesli-ios%2Fpull%2F36&signature=5162d03f1ad3e4d5024e6f63e9b4db375d3dd32c98fc8d3ccdc9e712368414bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a separate development app variant with dedicated build, signing, iCloud, and push notification settings.
  * Added configurable app branding, URL handling, app-group settings, and cross-process communication.
  * Added an option to disable telemetry through app configuration.

* **Improvements**
  * Updated authentication and meeting-summary integrations to respect the active app configuration.
  * Enhanced iOS development testing with a dedicated development build option.
  * Improved telemetry configuration handling for common Boolean values and invalid settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->